### PR TITLE
Fix previous name-resolution pr build issue

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,6 @@
     "babel-plugin-transform-decorators": "^6.24.1",
     "core-js": "^3.3.2",
     "cross-env": "^6.0.3",
-    "fibers": "^4.0.2",
     "material-design-icons-iconfont": "^5.0.1",
     "node-sass": "^4.13.1",
     "style-resources-loader": "^1.3.2",


### PR DESCRIPTION
Removed unneeded package 'fibers' as it was preventing builds in openshift.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
