### PR TITLE
Fixed app path for deployment to dev

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,2 +1,5 @@
-VUE_APP_PATH = namerequest
+VUE_APP_PATH_PROD = namerequest
+VUE_APP_PATH_DEV = /
+VUE_API_URL_MOCK = http://localhost:3000
+VUE_API_URL = https://namex-dev.pathfinder.gov.bc.ca
 

--- a/client/.env.production
+++ b/client/.env.production
@@ -1,2 +1,2 @@
 VUE_APP_PATH = namerequest
-
+VUE_API_URL = https://namex-dev.pathfinder.gov.bc.ca

--- a/client/package.json
+++ b/client/package.json
@@ -4,9 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "serve-dev": "cross-env VUE_APP_API_URL=https://namex-dev.pathfinder.gov.bc.ca npm run serve",
-    "serve-test": "cross-env VUE_APP_API_URL=https://namex-test.pathfinder.gov.bc.ca npm run serve",
-    "serve-mock": "cross-env VUE_APP_API_URL=http://localhost:3000 npm run serve",
+    "serve-mock": "cross-env VUE_APP_MOCK_API=yes npm run serve",
     "build": "vue-cli-service build",
     "test": "vue-cli-service test:unit  --verbose"
   },

--- a/client/src/plugins/axios.ts
+++ b/client/src/plugins/axios.ts
@@ -1,6 +1,14 @@
 import axios from 'axios'
 
-let baseURL = process.env.VUE_APP_API_URL
+let baseURL = function () {
+  if (process.env.NODE_ENV === 'development') {
+    if (process.env.VUE_APP_MOCK_API === 'yes') {
+      return process.env.VUE_APP_API_URL_MOCK
+    }
+    return process.env.VUE_APP_API_URL
+  }
+  return process.env.VUE_APP_API_URL
+}
 
 const Axios: any = axios.create({
   baseURL: baseURL + '/api/v1'

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -20,5 +20,6 @@ module.exports = {
   transpileDependencies: [
     'vuetify',
     'vuex-module-decorators'
-  ]
+  ],
+  publicPath: './'
 }


### PR DESCRIPTION
changed package.json to set an env variable flag when running in local mode with moock API (VUE_APP_MOCK_ENV === 'yes').  WHen it is set to yes, the publicPath is '/' and the API url is set to localhost.  Otherwise, the VUE_APP_PATH and VUE_APP_API_URL are used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
