### PR TITLE
added env variables for AP_URL

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,5 +1,5 @@
-VUE_APP_PATH_PROD = namerequest
+VUE_APP_API_URL = https://namex-dev.pathfinder.gov.bc.ca
+VUE_APP_API_URL_MOCK = http://localhost:3000
 VUE_APP_PATH_DEV = /
-VUE_API_URL_MOCK = http://localhost:3000
-VUE_API_URL = https://namex-dev.pathfinder.gov.bc.ca
+VUE_APP_PATH_PROD = namerequest
 

--- a/client/.env.production
+++ b/client/.env.production
@@ -1,2 +1,2 @@
-VUE_APP_PATH = namerequest
-VUE_API_URL = https://namex-dev.pathfinder.gov.bc.ca
+VUE_APP_API_URL = https://namex-dev.pathfinder.gov.bc.ca
+VUE_APP_PATH_PROD = namerequest

--- a/client/src/plugins/axios.ts
+++ b/client/src/plugins/axios.ts
@@ -5,13 +5,12 @@ let baseURL = function () {
     if (process.env.VUE_APP_MOCK_API === 'yes') {
       return process.env.VUE_APP_API_URL_MOCK
     }
-    return process.env.VUE_APP_API_URL
   }
   return process.env.VUE_APP_API_URL
 }
 
 const Axios: any = axios.create({
-  baseURL: baseURL + '/api/v1'
+  baseURL: baseURL() + '/api/v1'
 })
 
 export const cancelToken: any = axios.CancelToken.source().token


### PR DESCRIPTION
Storred the API URL in the .env file.  added variables VUE_APP_API_UR…L and VUE_APP_API_URL_MOCK and put logic in place to determine which varianle to use for the API_URL.
This is both an improvement on functionality of the front end and fix for the last PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
