### PR TITLE
Fixed issue with publicPath

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,4 +1,4 @@
+VUE_APP_PATH = namerequest
 VUE_APP_API_URL = https://namex-dev.pathfinder.gov.bc.ca
 VUE_APP_API_URL_MOCK = http://localhost:3000
-VUE_APP_PATH = namerequest
 

--- a/client/.env.production
+++ b/client/.env.production
@@ -1,2 +1,2 @@
-VUE_APP_API_URL = https://namex-dev.pathfinder.gov.bc.ca
 VUE_APP_PATH = namerequest
+VUE_APP_API_URL = https://namex-dev.pathfinder.gov.bc.ca

--- a/client/public/config/configuration.json
+++ b/client/public/config/configuration.json
@@ -1,0 +1,5 @@
+[
+  {
+    "URL":"https://namex-dev.pathfinder.gov.bc.ca"
+  }
+]

--- a/client/src/plugins/axios.ts
+++ b/client/src/plugins/axios.ts
@@ -2,9 +2,7 @@ import axios from 'axios'
 
 let baseURL = function () {
   if (process.env.NODE_ENV === 'development') {
-    if (process.env.VUE_APP_MOCK_API === 'yes') {
-      return process.env.VUE_APP_API_URL_MOCK
-    }
+    return process.env.VUE_APP_API_URL_MOCK
   }
   return process.env.VUE_APP_API_URL
 }

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -2,17 +2,19 @@ const path = require("path")
 
 module.exports = {
   configureWebpack: {
-    devtool: 'eval-source-map',
+    devtool: 'eval-source-map'
   },
   pluginOptions: {
     'style-resources-loader': {
       preProcessor: 'sass',
-      patterns: './src/sass/theme.sass'
+      patterns: [
+        path.resolve(__dirname, './src/sass/theme.sass')
+      ]
     }
   },
   transpileDependencies: [
     'vuetify',
     'vuex-module-decorators'
   ],
-  publicPath: ''
+  publicPath: process.env.VUE_APP_PATH
 }


### PR DESCRIPTION
Fixed issue with sass import that prevented app from working when running not off of the server root and reconfigured the .env files to hold the API_URLs.  Re-committed public/config/configuration.json and set the app's public path to /namerequest in all environments

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
