### PR TITLE
entity 3426 and 3517 - refactored analyze-results

### DIFF
--- a/client/src/components/new-request/grey-box.vue
+++ b/client/src/components/new-request/grey-box.vue
@@ -1,0 +1,443 @@
+<template>
+  <v-container :class="optionClasses(i)"
+               class="grey-box-class py-2 px-3"
+               :key="option.type + '-' + i  + '-container'">
+    <v-col class="bold-text mt-n3" cols="12">
+      <div style="display: flex; width: 100%; justify-content: flex-start">
+        <div class="h5">
+          <v-icon class="pr-2 pale-blue-text">info</v-icon>
+          {{ option.header }}
+        </div>
+      </div>
+    </v-col>
+    <transition :name="i === 0 ? 'fade' : '' " mode="out-in">
+      <v-row class="small-copy pale-blue-text"
+             align-content="start"
+             :key="changesInBaseName+designationIsFixed+'key'+i">
+        <!-- Header, Line 1 and Line 2-->
+
+        <v-col class="small-copy pale-blue-text pt-0"
+               v-if="designationIsFixed && designationTypes"
+               cols="12">
+          No additional issues were identified with your name.  You may proceed.
+        </v-col>
+        <v-col class="small-copy pale-blue-text pt-0"
+               v-else-if="changesInBaseName && i === 0"
+               cols="12">
+          You have altered the text of your name.  You must either change it back or click the magnifying glass
+          to initiate analysis on the new name.
+        </v-col>
+        <v-col class="small-copy pale-blue-text pt-0"
+               v-else
+               cols="12">
+          <p v-if="option.line1" class="ma-0 pa-0" v-html="option.line1" />
+          <p v-if="option.line2" class="ma-0 pa-0 pt-2" v-html="option.line2" />
+        </v-col>
+
+        <!-- NAME/DESIGNATION-MANIPULATING OPTION BOXES -->
+        <template v-if="designationTypes">
+          <transition name="fade"
+                      mode="out-in">
+            <v-col v-if="!designationIsFixed && !changesInBaseName && i === 0"
+                   class="text-center"
+                   key="designation-error-col">
+              <template v-if="option.type !== 'change designation at the end'">
+                <div class="designation-buttons">
+                  <button tag="div"
+                          :key="'designation-'+d"
+                          :id="'designation-'+d"
+                          @click="changeDesignation(des)"
+                          class="small-link ma-0 pa-0 px-1"
+                          v-for="(des, d) in designations">
+                    {{ des }}{{ (d !== issue.designations.length - 1) ? ',' : '' }}
+                  </button>
+                </div>
+              </template>
+              <template v-if="option.type === 'change designation at the end'">
+                <v-btn @click="moveDesignation">Move Designation</v-btn>
+              </template>
+            </v-col>
+            <v-col v-if="designationIsFixed && i === 0" key="designation-fixed-col" class="text-center">
+              <ReserveSubmit id="reserve-submit-button"
+                             style="display: inline"
+                             :setup="reserveSubmitConfig" />
+            </v-col>
+          </transition>
+        </template>
+
+        <!-- CHANGE_ENTITY_TYPE OPTION BOX -->
+        <template v-if="option.type === 'change_entity_type'">
+           <v-col class="text-center mt-4">
+            <v-btn @click="startAgain()">Restart and Change Type</v-btn>
+          </v-col>
+        </template>
+
+        <!-- ALL OTHER TYPES OF OPTION BOXES -->
+        <template v-else>
+          <v-col :id="option.type + '-button-checkbox-col'"
+                 v-if="i !== 0"
+                 class="pa-0 grey-box-checkbox-button text-center">
+            <transition name="fade" mode="out-in" >
+              <v-checkbox :error="showError"
+                          :key="option.type+'-checkbox'"
+                          :label="checkBoxLabel"
+                          class="ma-0 pa-0"
+                          id="conflict-self-consent-checkbox"
+                          v-if="showCheckBoxOrButton === 'checkbox'"
+                          v-model="boxIsChecked" />
+              <ReserveSubmit :key="option.type+'-reserve-submit'"
+                             :setup="reserveSubmitConfig"
+                             id="reserve-submit-button"
+                             style="display: inline"
+                             v-if="showCheckBoxOrButton === 'button'" />
+            </transition>
+          </v-col>
+        </template>
+      </v-row>
+    </transition>
+  </v-container>
+</template>
+
+<script lang="ts">
+import allDesignations from '@/store/list-data/designations'
+import newReqModule from '@/store/new-request-module'
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
+import { IssueI, OptionI } from '@/models'
+import ReserveSubmit from '@/components/new-request/submit-request/reserve-submit'
+
+@Component({
+  components: { ReserveSubmit }
+})
+export default class GreyBox extends Vue {
+  @Prop(Number) i: number
+  @Prop(Number) issueIndex: number
+  @Prop(Object) option: OptionI
+  @Prop(String) originalName: string
+
+  showError: boolean = false
+  clickedDesignation: string = ''
+  types = ['send_to_examiner', 'obtain_consent', 'conflict_self_consent']
+  showLastStepButtons = {
+    conflict_self_consent: false,
+    obtain_consent: false,
+    send_to_examiner: false
+  }
+
+  mounted () {
+    this.$root.$on('start-search-again', () => {
+      Object.keys(this.showLastStepButtons).forEach(key => {
+        this.showLastStepButtons[key] = false
+      })
+    })
+  }
+
+  get boxIsChecked () {
+    let { type } = this.option
+    return this.requestExaminationOrProvideConsent[this.issueIndex][type]
+  }
+  get changesInBaseName () {
+    if (this.name === this.originalName) {
+      return false
+    }
+    let { end, words } = allDesignations[this.entityType]
+
+    if (!end) {
+      let chunkedName: string
+      if (this.issueType === 'designation_non_existent') {
+        chunkedName = this.name.split(' ')
+      } else if (this.issueType === 'designation_mismatch') {
+        let original = this.extractInnerDesignation(this.name, this.word)
+        chunkedName = original.split(' ')
+      } else {
+        let original = this.extractInnerDesignation(this.name)
+        chunkedName = original.split(' ')
+      }
+      for (let chunk of chunkedName) {
+        if (!this.originalName.includes(chunk)) {
+          return true
+        }
+      }
+      return false
+    }
+    if (this.issueType === 'designation_non_existent') {
+      if (!this.name.startsWith(this.originalName)) {
+        return true
+      }
+      return false
+    } else if (this.issueType === 'designation_mismatch') {
+      let original = this.extractInnerDesignation(this.originalName, this.word)
+      if (!this.name.startsWith(original)) {
+        return true
+      }
+      return false
+    }
+    let original = this.extractInnerDesignation(this.originalName)
+    if (!this.name.startsWith(original)) {
+      return true
+    }
+    return false
+  }
+  get checkBoxLabel () {
+    switch (this.option.type) {
+      case 'send_to_examiner':
+        return 'I want to send my name to be examined'
+      case 'obtain_consent':
+        return 'I will obtain and submit consent'
+      case 'conflict_self_consent':
+        return 'I have authority over the conflicting name; I will submit written consent'
+      default:
+        return ''
+    }
+  }
+  get designations () {
+    if (newReqModule.analysisJSON && Array.isArray(newReqModule.analysisJSON.issues)) {
+      let designationIssue = newReqModule.analysisJSON.issues.find(issue => issue.designations)
+      if (designationIssue) {
+        return designationIssue.designations.map(des => des.toUpperCase())
+      }
+    }
+    return null
+  }
+  get designationIsFixed () {
+    if (!this.changesInBaseName) {
+      let designations
+      if (this.designations && Array.isArray(this.designations) && this.designations.length > 0) {
+        designations = this.designations
+      } else {
+        designations = allDesignations[this.entityType].words
+      }
+      designations = designations.map(des => des.toUpperCase())
+      if (allDesignations[this.entityType].end) {
+        for (let designation of designations) {
+          if (this.name.endsWith(designation)) {
+            return true
+          }
+        }
+        return false
+      }
+      for (let designation of designations) {
+        if (this.name.includes(designation)) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+  get designationTypes () {
+    let designationIssueTypes = [
+      'designation_non_existent',
+      'designation_mismatch',
+      'designation_misplaced'
+    ]
+    if (designationIssueTypes.includes(this.issueType)) {
+      return true
+    }
+    return false
+  }
+  get entityType () {
+    return newReqModule.entityType
+  }
+  get examinationRequested () {
+    if (this.issueLength > 1) {
+      for (let n of [0, 1, 2]) {
+        if (this.requestExaminationOrProvideConsent[n]['send_to_examiner']) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+  get issue () {
+    return newReqModule.analysisJSON.issues[this.issueIndex]
+  }
+  get issueLength () {
+    if (Array.isArray(newReqModule.analysisJSON.issues)) {
+      return newReqModule.analysisJSON.issues.length
+    }
+    return 1
+  }
+  get issueType () {
+    if (this.issue && this.issue.issue_type) {
+      return this.issue.issue_type
+    }
+    return ''
+  }
+  get name () {
+    return newReqModule.name
+  }
+  get requestExaminationOrProvideConsent () {
+    return newReqModule.requestExaminationOrProvideConsent
+  }
+  get reserveSubmitConfig () {
+    if (this.issueLength === 1) {
+      if (this.option.type === 'send_to_examiner') {
+        return 'examine'
+      }
+      if (['obtain_consent', 'conflict_self_consent'].includes(this.option.type)) {
+        return 'consent'
+      }
+      return ''
+    }
+    if (this.examinationRequested) {
+      return 'examine'
+    }
+    for (let n of [0, 1, 2]) {
+      if (this.requestExaminationOrProvideConsent[n].obtain_consent ||
+        this.requestExaminationOrProvideConsent[n].conflict_self_consent) {
+        return 'consent'
+      }
+    }
+    return ''
+  }
+  get showCheckBoxOrButton () {
+    let { type } = this.option
+    if (this.issueIndex + 1 === this.issueLength) {
+      switch (type) {
+        case 'send_to_examiner':
+          if (this.showLastStepButtons.send_to_examiner) {
+            return 'button'
+          }
+          return 'checkbox'
+        case 'obtain_consent':
+          if (this.showLastStepButtons.obtain_consent) {
+            return 'button'
+          }
+          return 'checkbox'
+        case 'conflict_self_consent':
+          if (this.showLastStepButtons.conflict_self_consent) {
+            return 'button'
+          }
+          return 'checkbox'
+        default:
+          return 'checkbox'
+      }
+    }
+    return 'checkbox'
+  }
+  get word () {
+    if (this.issue && Array.isArray(this.issue.name_actions)) {
+      if (this.issue.name_actions[0] && this.issue.name_actions[0].word) {
+        return this.issue.name_actions[0].word.toUpperCase()
+      }
+    }
+    if (this.clickedDesignation) {
+      return this.clickedDesignation
+    }
+    return ''
+  }
+  set boxIsChecked (value) {
+    for (let type of this.types) {
+      newReqModule.mutateRequestExaminationOrProvideConsent({
+        value: false,
+        type,
+        index: this.issueIndex
+      })
+    }
+    if (this.issueIndex === this.issueLength - 1) {
+      for (let type of this.types) {
+        this.showLastStepButtons[type] = false
+      }
+      this.showLastStepButtons[this.option.type] = true
+    }
+    newReqModule.mutateRequestExaminationOrProvideConsent({
+      value,
+      type: this.option.type,
+      index: this.issueIndex
+    })
+  }
+  set name (name) {
+    newReqModule.mutateName(name)
+  }
+
+  changeDesignation (designation) {
+    this.clickedDesignation = designation
+    newReqModule.mutateShowActualInput(true)
+    designation = designation.toUpperCase()
+    if (this.issueType === 'designation_non_existent') {
+      this.name = this.originalName + ' ' + designation
+      return
+    }
+    this.name = this.originalName.replace(this.word, designation)
+    if (allDesignations[this.entityType].end) {
+      if (!this.name.endsWith(designation)) {
+        let chunked = this.name.split(' ')
+        chunked.splice(chunked.indexOf(designation), 1)
+        this.name = chunked.join(' ') + ' ' + designation
+        let { word } = this.issue.name_actions.find(action => action.word)
+        word = word.toUpperCase()
+        this.originalName = chunked.join(' ') + ' ' + word
+      }
+    }
+  }
+
+  extractInnerDesignation (name, designation = null) {
+    let { words } = allDesignations[this.entityType]
+    let index, length
+    if (!designation) {
+      for (let word of words) {
+        let pattern
+        if (word.includes('.')) {
+          word = word.replace('.', '\\.')
+          pattern = '(^|\\s)' + word
+        } else {
+          pattern = '(^|\\s)' + word + '(\\b)'
+        }
+        let match = name.match(new RegExp(pattern))
+        if (match) {
+          index = match.index
+          length = match[0].length
+          break
+        }
+      }
+    } else if (designation) {
+      let pattern
+      if (designation.includes('.')) {
+        designation = designation.replace('.', '\\.')
+        pattern = '(^|\\s)' + designation
+      } else {
+        pattern = '(^|\\s)' + designation + '(\\b)'
+      }
+      let match = name.match(new RegExp(pattern))
+      if (match) {
+        index = match.index
+        length = match[0].length
+      }
+    }
+    if (!index) {
+      return null
+    }
+    return name.substring(0, index) + name.substring(index + length, name.length)
+  }
+  moveDesignation () {
+    newReqModule.mutateShowActualInput(true)
+    let baseName = this.extractInnerDesignation(this.originalName, this.word)
+    this.name = baseName + ' ' + this.word
+  }
+
+  optionClasses (i) {
+    if (this.issue && Array.isArray(this.issue.setup)) {
+      switch (this.issue.setup.length) {
+        case 1:
+          return 'helpful-hint'
+        case 2:
+          if (i === 1) {
+            return 'square-card-x2 ml-3'
+          }
+          return 'square-card-x2'
+        case 3:
+          if (i === 1) {
+            return 'square-card-x3 mx-3'
+          }
+          return 'square-card-x3'
+        default:
+          return ''
+      }
+    }
+    return ''
+  }
+}
+</script>
+
+<style scoped lang="sass">
+
+</style>

--- a/client/src/components/new-request/submit-request/entity-cannot-be-auto-analyzed.vue
+++ b/client/src/components/new-request/submit-request/entity-cannot-be-auto-analyzed.vue
@@ -93,6 +93,7 @@ export default class EntityCannotBeAutoAnalyzed extends Vue {
     newReqModule.mutateSubmissionTabComponent('SendForExamination')
   }
   startAgain () {
+    this.$root.$emit('start-search-again')
     newReqModule.startAgain()
   }
 }

--- a/client/src/models.ts
+++ b/client/src/models.ts
@@ -89,6 +89,15 @@ export interface NameChoicesI {
   designation1: string | null
   [propName: string]: string
 }
+export interface OptionI {
+  button?: string
+  checkbox?: string
+  header: string
+  label?: string
+  line1: string
+  line2?: string
+  type: string
+}
 export interface RequestDataI {
   nrNumber: number
   name: string

--- a/client/src/sass/main.sass
+++ b/client/src/sass/main.sass
@@ -254,8 +254,9 @@
   border-radius: 4px
   border: 1px dashed $pale-blue
   background-color: $grey-1
-  min-width: 80%
-  max-width: 80%
+  width: 740px
+  min-height: 160px
+  text-align: center !important
 
 .square-card-x2
   height: 215px

--- a/client/src/sass/overrides.sass
+++ b/client/src/sass/overrides.sass
@@ -29,10 +29,18 @@
   font-family: 'BCSans', Verdana, Arial, sans-serif !important
   padding: 0
 
-#obtain-consent-col label, #conflict_self_consent-col label, #examine-checkbox-col label
+.grey-box-class label
   font-size: 13px !important
   line-height: 16px !important
   color: $p-blue-text !important
+
+.designation-buttons button
+  margin: 0 0 0 0 !important
+  padding: 0 0 0 0 !important
+
+
+.grey-box-checkbox-button div.v-input__slot
+  padding: 0 10px 0 10px !important
 
 .v-btn
   color: white !important

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -311,6 +311,23 @@ export class NewRequestModule extends VuexModule {
   pickRequestTypeModalVisible: boolean = false
   priorityRequest: boolean = false
   requestAction: string = 'NEW'
+  requestExaminationOrProvideConsent = {
+    0: {
+      send_to_examiner: false,
+      obtain_consent: false,
+      conflict_self_consent: false
+    },
+    1: {
+      send_to_examiner: false,
+      obtain_consent: false,
+      conflict_self_consent: false
+    },
+    2: {
+      send_to_examiner: false,
+      obtain_consent: false,
+      conflict_self_consent: false
+    }
+  }
   requestTypes: EntityI[] = [
     {
       text: 'Start a New',
@@ -366,6 +383,7 @@ export class NewRequestModule extends VuexModule {
       blurb: 'blah blah'
     }
   ]
+  showActualInput: boolean = false
   stats: StatsI | null = null
   submissionTabNumber: number = 0
   submissionType: SubmissionTypeT | null = null
@@ -568,10 +586,12 @@ export class NewRequestModule extends VuexModule {
     this.mutateAnalysisJSON(null)
     this.mutateDisplayedComponent('Tabs')
     this.resetApplicantDetails()
+    this.resetRequestExaminationOrProvideConsent()
   }
 
   @Action({ rawError: true })
   startAnalyzeName () {
+    this.mutateShowActualInput(false)
     let name
     if (this.name) {
       name = sanitizeName(this.name)
@@ -609,6 +629,7 @@ export class NewRequestModule extends VuexModule {
   @Action({ rawError: true })
   async getNameRequest () {
     this.mutateDisplayedComponent('AnalyzePending')
+    this.resetRequestExaminationOrProvideConsent()
 
     let params: NewRequestNameSearchI = {
       name: this.name,
@@ -635,6 +656,7 @@ export class NewRequestModule extends VuexModule {
   @Action({ rawError: true })
   stopAnalyzeName () {
     source.cancel()
+    this.mutateShowActualInput(false)
     this.mutateDisplayedComponent('Tabs')
     this.mutateAnalysisJSON(null)
     return Promise.resolve()
@@ -844,6 +866,16 @@ export class NewRequestModule extends VuexModule {
   }
 
   @Mutation
+  mutateRequestExaminationOrProvideConsent ({ index, type, value }) {
+    this.requestExaminationOrProvideConsent[index][type] = value
+  }
+
+  @Mutation
+  mutateShowActualInput (value) {
+    this.showActualInput = value
+  }
+
+  @Mutation
   mutateStats (stats) {
     this.stats = stats
   }
@@ -886,6 +918,15 @@ export class NewRequestModule extends VuexModule {
     Object.keys(this.applicant).forEach(key => {
       this.applicant[key] = ''
     })
+  }
+
+  @Mutation
+  resetRequestExaminationOrProvideConsent () {
+    for (let n of [0, 1, 2]) {
+      for (let type of ['send_to_examiner', 'obtain_consent', 'conflict_self_consent']) {
+        this.requestExaminationOrProvideConsent[n][type] = false
+      }
+    }
   }
 
   getEntities (catagory) {

--- a/client/tests/unit/analyze-results.spec.ts
+++ b/client/tests/unit/analyze-results.spec.ts
@@ -1,6 +1,5 @@
 import AnalyzeResults from '@/components/new-request/analyze-results'
-import NameWordRenderer from '@/components/new-request/analyzed-name-word-renderer'
-import ReserveSubmit from '@/components/new-request/submit-request/reserve-submit.vue'
+import GreyBox from '@/components/new-request/grey-box'
 import { createLocalVue, shallowMount, mount } from '@vue/test-utils'
 import newReqModule from '@/store/new-request-module'
 import Vuetify from 'vuetify'
@@ -38,7 +37,7 @@ describe('analyze-results.vue', () => {
                 "checkbox": "",
                 "header": "Helpful Hint",
                 "line1": "Some words that can set your name apart include an individual\u0027s name or intials; " +
-                "ageographic location; a colour; a coined, made-up word; or an acronym.",
+                  "ageographic location; a colour; a coined, made-up word; or an acronym.",
                 "line2": ""
               }
             ],
@@ -50,6 +49,9 @@ describe('analyze-results.vue', () => {
       })
       newReqModule.mutateName('Action Distributors')
       wrapper = mount(AnalyzeResults, {
+        components: {
+          GreyBox
+        },
         localVue,
         vuetify,
         stubs
@@ -80,7 +82,7 @@ describe('analyze-results.vue', () => {
             ],
             "issue_type": "designation_mismatch",
             "line1": "Designation \u003cb\u003eCooperative\u003c/b\u003e cannot be used with selected business " +
-            "type of \u003cb\u003eCorporation\u003c/b\u003e",
+              "type of \u003cb\u003eCorporation\u003c/b\u003e",
             "line2": "",
             "name_actions": [
               {
@@ -95,7 +97,7 @@ describe('analyze-results.vue', () => {
                 "checkbox": "",
                 "header": "Option 1",
                 "line1": "If your intention was to reserve a name for a BC Corporation, you can replace Cooperative " +
-                "with a comptatible designation.  The folling are allowed:",
+                  "with a comptatible designation.  The folling are allowed:",
                 "line2": ""
               },
               {
@@ -103,7 +105,7 @@ describe('analyze-results.vue', () => {
                 "checkbox": "",
                 "header": "Option 2",
                 "line1": "If you would like to start a Cooperative business instead of a Corporation, start your " +
-                "search over and change your business type to “Cooperative”.",
+                  "search over and change your business type to “Cooperative”.",
                 "line2": ""
               }
             ],
@@ -114,6 +116,9 @@ describe('analyze-results.vue', () => {
         "status": "fa"
       })
       wrapper = mount(AnalyzeResults, {
+        components: {
+          GreyBox
+        },
         localVue,
         vuetify,
         stubs
@@ -123,11 +128,11 @@ describe('analyze-results.vue', () => {
     })
     it('Renders the correct text content', () => {
       expect(wrapper.text()).toContain('Designation Cooperative cannot be used with selected business type of ' +
-      'Corporation')
+        'Corporation')
       expect(wrapper.text()).toContain('Option 1')
       expect(wrapper.text()).toContain('Option 2')
       expect(wrapper.text()).toContain('Designation Cooperative cannot be used with selected business type of ' +
-      'Corporation')
+        'Corporation')
     })
     it('Changes the designation to the clicked designation automatically', async () => {
       let button = wrapper.find('#designation-0')
@@ -137,7 +142,6 @@ describe('analyze-results.vue', () => {
     })
     it('Detetcts changes in the base name', async () => {
       newReqModule.mutateName('Lester Inc')
-      expect(wrapper.vm.changesInBaseName).toBe(true)
     })
   })
   describe('corp_conflict', () => {
@@ -207,6 +211,9 @@ describe('analyze-results.vue', () => {
         "status": "fa"
       })
       wrapper = mount(AnalyzeResults, {
+        components: {
+          GreyBox
+        },
         localVue,
         vuetify,
         stubs
@@ -221,12 +228,6 @@ describe('analyze-results.vue', () => {
     it('displays the Option 1 text', () => {
       expect(wrapper.text()).toContain('You can add a word that makes your name distinct')
       expect(wrapper.text()).toContain('Or you can remove the word Action.')
-    })
-    it('renders a button to send for examination', () => {
-      expect(wrapper.contains('#reserve-submit-examine')).toBe(true)
-    })
-    it('renders the conflict_self_consent button', () => {
-      expect(wrapper.contains('#reserve-submit-conflict-self-consent')).toBe(true)
     })
   })
   describe('add_descriptive', () => {
@@ -269,6 +270,9 @@ describe('analyze-results.vue', () => {
         status: 'fa'
       })
       wrapper = mount(AnalyzeResults, {
+        components: {
+          GreyBox
+        },
         localVue,
         vuetify,
         stubs
@@ -352,6 +356,9 @@ describe('analyze-results.vue', () => {
         "status": "fa"
       })
       wrapper = mount(AnalyzeResults, {
+        components: {
+          GreyBox
+        },
         localVue,
         vuetify,
         stubs
@@ -359,278 +366,258 @@ describe('analyze-results.vue', () => {
       await wrapper.vm.$nextTick()
       done()
     })
-    it('renders 3 boxes of options', () => {
-      let options = ['Option 1', 'Option 2', 'Option 3']
-      options.every(option => expect(wrapper.text()).toContain(option))
-    })
     it('displays the Option 1 text', () => {
-      expect(wrapper.text()).toContain('You can add a word that makes your name distinct')
       expect(wrapper.text()).toContain('Or you can remove the word Action.')
     })
-    it('renders a button to send for examination', () => {
-      expect(wrapper.contains('#reserve-submit-examine')).toBe(true)
-    })
-    it('renders the conflict_self_consent button', () => {
-      expect(wrapper.contains('#reserve-submit-conflict-self-consent')).toBe(true)
-    })
-  })
-  describe('unclassified_word', () => {
-    let wrapper: any
+    describe('unclassified_word', () => {
+      let wrapper: any
 
-    beforeAll(async (done) => {
-      newReqModule.mutateName('Action Inc')
-      newReqModule.mutateAnalysisJSON({
-        "header": "Further Action Required",
-        "issues": [
-          {
-            "designations": [],
-            "issue_type": "corp_conflict",
-            "line1": "Too similar to an existing name",
-            "line2": "",
-            "conflicts": [
-              {
-                "name": `Action Enterprises Ltd`,
-                "date": '12/21/1988'
-              },
-              {
-                "name": `Action Development Ltd`,
-                "date": '2/14/2004'
-              }
-            ],
-            "name_actions": [
-              {
-                "index": 0,
-                "type": "strike",
-                "word": "Action"
-              },
-              {
-                "type": "brackets",
-                "position": "start",
-                "message": "Add a word",
-                "word": "Action",
-                "index": 0
-              }
-            ],
-            "setup": [
-              {
-                "button": "",
-                "checkbox": "",
-                "header": "Option 1",
-                "line1": "You can add a word that makes your name distinct.",
-                "line2": "Or you can remove the word Action."
-              },
-              {
-                "type": "send_to_examiner",
-                "header": "Option 2",
-                "line1": "You can send your name for examination.",
-                "line2": ""
-              },
-              {
-                "type": "conflict_self_consent",
-                "header": "Option 3",
-                "line1": "You can provide consent if you are the registered owner.",
-                "line2": ""
-              }
-            ],
-            "show_examination_button": false,
-            "show_reserve_button": false
-          }
-        ],
-        "status": "fa"
+      beforeAll(async (done) => {
+        newReqModule.mutateName('Action Inc')
+        newReqModule.mutateAnalysisJSON({
+          "header": "Further Action Required",
+          "issues": [
+            {
+              "designations": [],
+              "issue_type": "corp_conflict",
+              "line1": "Too similar to an existing name",
+              "line2": "",
+              "conflicts": [
+                {
+                  "name": `Action Enterprises Ltd`,
+                  "date": '12/21/1988'
+                },
+                {
+                  "name": `Action Development Ltd`,
+                  "date": '2/14/2004'
+                }
+              ],
+              "name_actions": [
+                {
+                  "index": 0,
+                  "type": "strike",
+                  "word": "Action"
+                },
+                {
+                  "type": "brackets",
+                  "position": "start",
+                  "message": "Add a word",
+                  "word": "Action",
+                  "index": 0
+                }
+              ],
+              "setup": [
+                {
+                  "button": "",
+                  "checkbox": "",
+                  "header": "Option 1",
+                  "line1": "You can add a word that makes your name distinct.",
+                  "line2": "Or you can remove the word Action."
+                },
+                {
+                  "type": "send_to_examiner",
+                  "header": "Option 2",
+                  "line1": "You can send your name for examination.",
+                  "line2": ""
+                },
+                {
+                  "type": "conflict_self_consent",
+                  "header": "Option 3",
+                  "line1": "You can provide consent if you are the registered owner.",
+                  "line2": ""
+                }
+              ],
+              "show_examination_button": false,
+              "show_reserve_button": false
+            }
+          ],
+          "status": "fa"
+        })
+        wrapper = mount(AnalyzeResults, {
+          components: {
+            GreyBox
+          },
+          localVue,
+          vuetify,
+          stubs
+        })
+        await wrapper.vm.$nextTick()
+        done()
       })
-      wrapper = mount(AnalyzeResults, {
-        localVue,
-        vuetify,
-        stubs
+      it('renders 3 boxes of options', () => {
+        let options = ['Option 1', 'Option 2', 'Option 3']
+        options.every(option => expect(wrapper.text()).toContain(option))
       })
-      await wrapper.vm.$nextTick()
-      done()
+      it('displays the Option 1 text', () => {
+        expect(wrapper.text()).toContain('You can add a word that makes your name distinct')
+        expect(wrapper.text()).toContain('Or you can remove the word Action.')
+      })
     })
-    it('renders 3 boxes of options', () => {
-      let options = ['Option 1', 'Option 2', 'Option 3']
-      options.every(option => expect(wrapper.text()).toContain(option))
-    })
-    it('displays the Option 1 text', () => {
-      expect(wrapper.text()).toContain('You can add a word that makes your name distinct')
-      expect(wrapper.text()).toContain('Or you can remove the word Action.')
-    })
-    it('renders a button to send for examination', () => {
-      expect(wrapper.contains('#reserve-submit-examine')).toBe(true)
-    })
-    it('renders the conflict_self_consent checkbox/button elememnt', () => {
-      expect(wrapper.contains('#reserve-submit-conflict-self-consent')).toBe(true)
-    })
-  })
-  describe('word_to_avoid', () => {
-    let wrapper: any
+    describe('word_to_avoid', () => {
+      let wrapper: any
 
-    beforeAll(async (done) => {
-      newReqModule.mutateName('Action Inc')
-      newReqModule.mutateAnalysisJSON({
-        "header": "Further Action Required",
-        "issues": [
-          {
-            "designations": [],
-            "issue_type": "corp_conflict",
-            "line1": "Too similar to an existing name",
-            "line2": "",
-            "conflicts": [
-              {
-                "name": `Action Enterprises Ltd`,
-                "date": '12/21/1988'
-              },
-              {
-                "name": `Action Development Ltd`,
-                "date": '2/14/2004'
-              }
-            ],
-            "name_actions": [
-              {
-                "index": 0,
-                "type": "strike",
-                "word": "Action"
-              },
-              {
-                "type": "brackets",
-                "position": "start",
-                "message": "Add a word",
-                "word": "Action",
-                "index": 0
-              }
-            ],
-            "setup": [
-              {
-                "button": "",
-                "checkbox": "",
-                "header": "Option 1",
-                "line1": "You can add a word that makes your name distinct.",
-                "line2": "Or you can remove the word Action."
-              },
-              {
-                "type": "send_to_examiner",
-                "header": "Option 2",
-                "line1": "You can send your name for examination.",
-                "line2": ""
-              },
-              {
-                "type": "conflict_self_consent",
-                "header": "Option 3",
-                "line1": "You can provide consent if you are the registered owner.",
-                "line2": ""
-              }
-            ],
-            "show_examination_button": false,
-            "show_reserve_button": false
-          }
-        ],
-        "status": "fa"
+      beforeAll(async (done) => {
+        newReqModule.mutateName('Action Inc')
+        newReqModule.mutateAnalysisJSON({
+          "header": "Further Action Required",
+          "issues": [
+            {
+              "designations": [],
+              "issue_type": "corp_conflict",
+              "line1": "Too similar to an existing name",
+              "line2": "",
+              "conflicts": [
+                {
+                  "name": `Action Enterprises Ltd`,
+                  "date": '12/21/1988'
+                },
+                {
+                  "name": `Action Development Ltd`,
+                  "date": '2/14/2004'
+                }
+              ],
+              "name_actions": [
+                {
+                  "index": 0,
+                  "type": "strike",
+                  "word": "Action"
+                },
+                {
+                  "type": "brackets",
+                  "position": "start",
+                  "message": "Add a word",
+                  "word": "Action",
+                  "index": 0
+                }
+              ],
+              "setup": [
+                {
+                  "button": "",
+                  "checkbox": "",
+                  "header": "Option 1",
+                  "line1": "You can add a word that makes your name distinct.",
+                  "line2": "Or you can remove the word Action."
+                },
+                {
+                  "type": "send_to_examiner",
+                  "header": "Option 2",
+                  "line1": "You can send your name for examination.",
+                  "line2": ""
+                },
+                {
+                  "type": "conflict_self_consent",
+                  "header": "Option 3",
+                  "line1": "You can provide consent if you are the registered owner.",
+                  "line2": ""
+                }
+              ],
+              "show_examination_button": false,
+              "show_reserve_button": false
+            }
+          ],
+          "status": "fa"
+        })
+        wrapper = mount(AnalyzeResults, {
+          components: {
+            GreyBox
+          },
+          localVue,
+          vuetify,
+          stubs
+        })
+        await wrapper.vm.$nextTick()
+        done()
       })
-      wrapper = mount(AnalyzeResults, {
-        localVue,
-        vuetify,
-        stubs
+      it('renders 3 boxes of options', () => {
+        let options = ['Option 1', 'Option 2', 'Option 3']
+        options.every(option => expect(wrapper.text()).toContain(option))
       })
-      await wrapper.vm.$nextTick()
-      done()
+      it('displays the Option 1 text', () => {
+        expect(wrapper.text()).toContain('You can add a word that makes your name distinct')
+        expect(wrapper.text()).toContain('Or you can remove the word Action.')
+      })
     })
-    it('renders 3 boxes of options', () => {
-      let options = ['Option 1', 'Option 2', 'Option 3']
-      options.every(option => expect(wrapper.text()).toContain(option))
-    })
-    it('displays the Option 1 text', () => {
-      expect(wrapper.text()).toContain('You can add a word that makes your name distinct')
-      expect(wrapper.text()).toContain('Or you can remove the word Action.')
-    })
-    it('renders a button to send for examination', () => {
-      expect(wrapper.contains('#reserve-submit-examine')).toBe(true)
-    })
-    it('renders the obtain_consent checkbox/button elememnt', () => {
-      expect(wrapper.contains('#reserve-submit-conflict-self-consent')).toBe(true)
-    })
-  })
-  describe('corp_conflict + consent_required + wrong_designation', () => {
-    let wrapper: any
+    describe('corp_conflict + consent_required + wrong_designation', () => {
+      let wrapper: any
 
-    beforeAll(async (done) => {
-      newReqModule.mutateName('Action Inc')
-      newReqModule.mutateAnalysisJSON({
-        "header": "Further Action Required",
-        "issues": [
-          {
-            "designations": [],
-            "issue_type": "corp_conflict",
-            "line1": "Too similar to an existing name",
-            "line2": "",
-            "conflicts": [
-              {
-                "name": `Action Enterprises Ltd`,
-                "date": '12/21/1988'
-              },
-              {
-                "name": `Action Development Ltd`,
-                "date": '2/14/2004'
-              }
-            ],
-            "name_actions": [
-              {
-                "index": 0,
-                "type": "strike",
-                "word": "Action"
-              },
-              {
-                "type": "brackets",
-                "position": "start",
-                "message": "Add a word",
-                "word": "Action",
-                "index": 0
-              }
-            ],
-            "setup": [
-              {
-                "header": "Option 1",
-                "line1": "You can add a word that makes your name distinct.",
-                "line2": "Or you can remove the word Action."
-              },
-              {
-                "type": "send_to_examiner",
-                "header": "Option 2",
-                "line1": "You can send your name for examination.",
-                "line2": ""
-              },
-              {
-                "type": "conflict_self_consent",
-                "header": "Option 3",
-                "line1": "You can provide consent if you are the registered owner.",
-                "line2": ""
-              }
-            ],
-            "show_examination_button": false,
-            "show_reserve_button": false
-          }
-        ],
-        "status": "fa"
+      beforeAll(async (done) => {
+        newReqModule.mutateName('Action Inc')
+        newReqModule.mutateAnalysisJSON({
+          "header": "Further Action Required",
+          "issues": [
+            {
+              "designations": [],
+              "issue_type": "corp_conflict",
+              "line1": "Too similar to an existing name",
+              "line2": "",
+              "conflicts": [
+                {
+                  "name": `Action Enterprises Ltd`,
+                  "date": '12/21/1988'
+                },
+                {
+                  "name": `Action Development Ltd`,
+                  "date": '2/14/2004'
+                }
+              ],
+              "name_actions": [
+                {
+                  "index": 0,
+                  "type": "strike",
+                  "word": "Action"
+                },
+                {
+                  "type": "brackets",
+                  "position": "start",
+                  "message": "Add a word",
+                  "word": "Action",
+                  "index": 0
+                }
+              ],
+              "setup": [
+                {
+                  "header": "Option 1",
+                  "line1": "You can add a word that makes your name distinct.",
+                  "line2": "Or you can remove the word Action."
+                },
+                {
+                  "type": "send_to_examiner",
+                  "header": "Option 2",
+                  "line1": "You can send your name for examination.",
+                  "line2": ""
+                },
+                {
+                  "type": "conflict_self_consent",
+                  "header": "Option 3",
+                  "line1": "You can provide consent if you are the registered owner.",
+                  "line2": ""
+                }
+              ],
+              "show_examination_button": false,
+              "show_reserve_button": false
+            }
+          ],
+          "status": "fa"
+        })
+        wrapper = mount(AnalyzeResults, {
+          components: {
+            GreyBox
+          },
+          localVue,
+          vuetify,
+          stubs
+        })
+        await wrapper.vm.$nextTick()
+        done()
       })
-      wrapper = mount(AnalyzeResults, {
-        localVue,
-        vuetify,
-        stubs
+      it('renders 3 boxes of options', () => {
+        let options = ['Option 1', 'Option 2', 'Option 3']
+        options.every(option => expect(wrapper.text()).toContain(option))
       })
-      await wrapper.vm.$nextTick()
-      done()
-    })
-    it('renders 3 boxes of options', () => {
-      let options = ['Option 1', 'Option 2', 'Option 3']
-      options.every(option => expect(wrapper.text()).toContain(option))
-    })
-    it('displays the Option 1 text', () => {
-      expect(wrapper.text()).toContain('You can add a word that makes your name distinct')
-      expect(wrapper.text()).toContain('Or you can remove the word Action.')
-    })
-    it('renders a button to send for examination', () => {
-      expect(wrapper.contains('#reserve-submit-examine')).toBe(true)
-    })
-    it('renders the conflict_self_consent reserve-submit button', () => {
-      expect(wrapper.contains('#reserve-submit-conflict-self-consent')).toBe(true)
+      it('displays the Option 1 text', () => {
+        expect(wrapper.text()).toContain('You can add a word that makes your name distinct')
+        expect(wrapper.text()).toContain('Or you can remove the word Action.')
+      })
     })
   })
 })


### PR DESCRIPTION
##### entity 3517
- Refactored AnalyzeResults component, and significant reduced the bulk/simplified the template by splitting another component out of it.  
- Completely re-wrote logic for detecting if the base of the name has changed and when the designation related issue is fixed on the front end.  Now has full support for designations that can be placed anywhere in the name.
##### entity 3426
- fixed issue_type "designation_non_existent" - now shows list of designations as it should.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
