### PR TITLE
Entity 3095 - Names that contain slash must be examined

### DIFF
--- a/client/src/components/new-request/search.vue
+++ b/client/src/components/new-request/search.vue
@@ -36,46 +36,36 @@
       <NameInput :class="inputCompClass"
                  id="name-input-component"
                  class="mb-n7"/>
-      <v-row no-gutters class="mt-n3 px-3" align="center">
-        <v-col @mouseenter="handleMouseEnter('name', $event)"
-               @mouseleave="handleMouseLeave"
-               cols="*"
-               id="name-checkbox-col">
-          <v-checkbox v-model="isPersonsName"
-                      id="name-checkbox"
-                      class="small-copy px-0 mx-0"
-                      label="The name is a person's name" />
-        </v-col>
-        <v-col cols="3" @mouseenter="handleMouseEnter('language', $event)" @mouseleave="handleMouseLeave">
-          <v-checkbox v-model="nameIsEnglish"
-                      id="name-checkbox"
-                      class="small-copy ml-n6"
-                      label="The name is English" />
-        </v-col>
-        <v-col cols="5">
-        <span id="nr-required-activator"
-              class="normal-link"
-              style="margin-left: auto"
-              @click="activateNRRModal()">Check to see if you need to file a a name request</span>
-        </v-col>
-      </v-row>
     </v-row>
-    <v-tooltip v-model="showToolTip"
-               absolute
-               bottom
-               :nudge-bottom="nudgeY"
-               max-width="525"
-               :position-x="toolTipX"
-               :position-y="toolTipY">
-      <template v-if="toolTipActivator === 'name'">
+    <v-row no-gutters class="ma-0 pa-0 mt-n3" align="center">
+      <v-col cols="4">
+      <v-tooltip bottom open-delay="300">
+        <template v-slot:activator="{on}">
+            <v-checkbox v-model="isPersonsName"
+                        v-on="on"
+                        id="name-checkbox"
+                        class="small-copy px-0 mx-0"
+                        label="The name is a person's name" />
+        </template>
         <p class="py-0 my-0">Check this box if you are...</p>
-        <ul>
-          <li>Incorporating under your own name (eg. DR. JOE SMITH INC.)</li>
-          <li>The name contains one or more names. (eg. BLAKE, CHAN & DOUGLAS INC.)</li>
-          <li>The name contains one or more names. (eg. FRANKLIN INC.)</li>
-        </ul>
-      </template>
-      <template v-else>
+          <ul>
+            <li>Incorporating under your own name (eg. DR. JOE SMITH INC.)</li>
+            <li>The name contains one or more names. (eg. BLAKE, CHAN & DOUGLAS INC.)</li>
+            <li>The name contains one or more names. (eg. FRANKLIN INC.)</li>
+          </ul>
+      </v-tooltip>
+      </v-col>
+      <v-col cols="3">
+      <v-tooltip bottom open-delay="300">
+        <template v-slot:activator="{on}">
+
+            <v-checkbox v-model="nameIsEnglish"
+                        v-on="on"
+                        id="name-checkbox"
+                        class="small-copy ml-n6"
+                        label="The name is English" />
+
+        </template>
         <p class="py-0 my-0">This refers to the language of the words in your name.</p>
         <ul>
           <li>Leave this box checked if your name contains <b>only</b> English <b>or a mix</b> of English and
@@ -85,8 +75,15 @@
             any English
           </li>
         </ul>
-      </template>
-    </v-tooltip>
+      </v-tooltip>
+      </v-col>
+      <v-col cols="5">
+        <span id="nr-required-activator"
+              class="normal-link"
+              style="margin-left: auto"
+              @click="activateNRRModal()">Check to see if you need to file a a name request</span>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 
@@ -95,8 +92,6 @@ import NameInput from './name-input'
 import newReqModule from '../../store/new-request-module'
 import { Component, Vue, Watch } from 'vue-property-decorator'
 import { LocationT } from '@/models'
-
-let timer: any
 
 @Component({
   components: { NameInput }
@@ -118,13 +113,6 @@ export default class Search extends Vue {
         this.location = oldVal
         this.entityType = type
       })
-    }
-  }
-
-  @Watch('entityType')
-  uncheckBox (newVal) {
-    if (newVal !== 'CR') {
-      this.isPersonsName = false
     }
   }
 
@@ -166,18 +154,12 @@ export default class Search extends Vue {
     return newReqModule.isPersonsName
   }
   set isPersonsName (value) {
-    if (this.nameIsEnglish) {
-      this.nameIsEnglish = false
-    }
     newReqModule.mutateisPersonsName(value)
   }
   get nameIsEnglish () {
     return newReqModule.nameIsEnglish
   }
   set nameIsEnglish (value) {
-    if (this.isPersonsName) {
-      this.isPersonsName = false
-    }
     newReqModule.mutateNameIsEnglish(value)
   }
   get requestAction () {
@@ -211,39 +193,6 @@ export default class Search extends Vue {
   handleSubmit (event: Event) {
     event.preventDefault()
     newReqModule.startAnalyzeName()
-  }
-  handleMouseLeave () {
-    this.hoveringNow = false
-    this.showToolTip = false
-    if (timer && timer.clearTimeout) {
-      timer.clearTimeout()
-      timer = null
-    }
-  }
-  handleMouseEnter (activator, event) {
-    if (timer && timer.clearTimeout) {
-      timer.clearTimeout()
-      timer = null
-    }
-    this.hoveringNow = true
-    let showToolTip = (activator) => {
-      this.toolTipActivator = activator
-      if (this.hoveringNow) {
-        // eslint-disable-next-line
-        console.log(event)
-        let { pageX, pageY } = event
-        // eslint-disable-next-line
-        console.log(window.scrollY)
-
-        this.toolTipX = pageX
-        this.toolTipY = pageY + 25
-        this.nudgeY = window.scrollY
-        this.$nextTick(function () {
-          this.showToolTip = true
-        })
-      }
-    }
-    timer = setTimeout(showToolTip, 350, activator)
   }
 }
 

--- a/client/src/components/new-request/submit-request/entity-cannot-be-auto-analyzed.vue
+++ b/client/src/components/new-request/submit-request/entity-cannot-be-auto-analyzed.vue
@@ -1,32 +1,21 @@
 <template>
-    <v-container fluid class="paz-0 ma-0">
+    <v-container fluid class="pa-0 ma-0">
+      <v-row v-if="nameIsSlashed">
+        <NameInput class="mt-n4" />
+      </v-row>
       <v-row class="text-center">
         <v-col cols="12" class="h5 text-center mt-n6">
           Further Information
         </v-col>
         <v-col cols="12"
                class="text-center mt-n4"
-               v-if="entityTypeNotAnalyzed">
-          Name Requests for the <b>{{ entityText }}</b> entity type cannot be reserved immediately.
-        </v-col>
-        <v-col cols="12"
-               class="text-center mt-n4"
-               v-else-if="isPersonsName">
-          Name Requests that are personal name(s) cannot be reserved immediately.
-        </v-col>
-        <v-col cols="12"
-               class="text-center mt-n4"
-               v-else-if="!nameIsEnglish">
-          Name Requests that contain words that are not English cannot be reserved immediately.
-        </v-col>
+               v-html="title" />
         <v-col v-for="(box, i) in boxes" :key="'box-'+i">
           <v-container class="small-copy text-left" :class="box.class">
             <v-row align-content="space-between" style="height: 100%">
               <v-col class="h5 py-0"><v-icon class="pr-2 pale-blue-text">info</v-icon>
                 {{ box.title }}</v-col>
-              <v-col cols="12">
-                {{ box.text }}
-              </v-col>
+              <v-col cols="12" v-html="box.text" />
                <v-col class="text-center">
                 <v-btn x-large
                        id="submit-continue-btn"
@@ -36,6 +25,10 @@
                        id="submit-continue-btn"
                        v-if="box.button === 'restart'"
                        @click="startAgain()">Start Search Over</v-btn>
+                 <v-btn x-large
+                        id="submit-continue-btn"
+                        v-if="box.button === 'english'"
+                        @click="newSearch()">Search Again</v-btn>
               </v-col>
               </v-row>
           </v-container>
@@ -48,32 +41,33 @@
 import designations from '@/store/list-data/designations'
 import newReqModule from '@/store/new-request-module'
 import { Component, Vue, Watch } from 'vue-property-decorator'
+import NameInput from '@/components/new-request/name-input.vue'
 
-@Component({})
+@Component({
+  components: { NameInput }
+})
 export default class EntityCannotBeAutoAnalyzed extends Vue {
-  get doNotAnalyzeEntities () {
-    return newReqModule.doNotAnalyzeEntities
-  }
-  get entityText () {
-    return newReqModule.entityTextFromValue
-  }
-  get entityType () {
-    return newReqModule.entityType
-  }
-  get nameIsEnglish () {
-    return newReqModule.nameIsEnglish
-  }
-  get isPersonsName () {
-    return newReqModule.isPersonsName
-  }
-  get entityTypeNotAnalyzed () {
-    if (this.doNotAnalyzeEntities.includes(this.entityType)) {
-      return true
+  englishOnlyName: string = ''
+
+  mounted () {
+    if (this.nameIsSlashed) {
+      this.englishOnlyName = this.name.split('/')[0]
     }
-    return false
   }
   get boxes () {
-    let output = []
+    let slashEditExplanation = {
+      title: 'Option 1',
+      class: 'square-card-x2',
+      button: 'english',
+      text: 'You can remove the slash "/" and all words that come after it and try your search again. To' +
+        ` automatically initiate a search for <b>${this.englishOnlyName}</b>, click the button below.`
+    }
+    let slashExamineExplanation = {
+      title: 'Option 2',
+      class: 'square-card-x2',
+      button: 'examine',
+      text: 'You can choose to submit this name to examination. Please check wait times at the top of the screen.'
+    }
     let nameExplanation = {
       title: 'Helpful Hint',
       class: 'helpful-hint',
@@ -88,14 +82,69 @@ export default class EntityCannotBeAutoAnalyzed extends Vue {
       text: 'You can choose a different entity type and search again.  Please consult with a lawyer' +
       '/accounting professional if you are unsure about the most appropriate structure for your situation.'
     }
-    if (this.isPersonsName || !this.nameIsEnglish) {
-      output.push(nameExplanation)
-    }
     if (this.entityTypeNotAnalyzed) {
       let edits = { title: 'Option 1', class: 'square-card-x2' }
-      output.push({ ...nameExplanation, ...edits }, entityExplanation)
+      return [ { ...nameExplanation, ...edits }, entityExplanation ]
+    }
+    if (this.nameIsSlashed) {
+      return [ slashEditExplanation, slashExamineExplanation ]
+    }
+    if (this.isPersonsName || !this.nameIsEnglish) {
+      return [ nameExplanation ]
+    }
+    return []
+  }
+  get doNotAnalyzeEntities () {
+    return newReqModule.doNotAnalyzeEntities
+  }
+  get entityText () {
+    return newReqModule.entityTextFromValue
+  }
+  get entityType () {
+    return newReqModule.entityType
+  }
+  get entityTypeNotAnalyzed () {
+    if (this.doNotAnalyzeEntities.includes(this.entityType)) {
+      return true
+    }
+    return false
+  }
+  get nameIsSlashed () {
+    return newReqModule.nameIsSlashed
+  }
+  get isPersonsName () {
+    return newReqModule.isPersonsName
+  }
+  get name () {
+    return newReqModule.name
+  }
+  set name (value) {
+    newReqModule.mutateName(value)
+  }
+  get nameIsEnglish () {
+    return newReqModule.nameIsEnglish
+  }
+  get title () {
+    if (this.entityTypeNotAnalyzed) {
+      return ` Name Requests for the <b>${this.entityText}</b> entity type cannot be reserved immediately.`
+    }
+    if (this.nameIsSlashed) {
+      return 'The slash "/" followed by a number of words implies the name is an English name followed by a French' +
+        ' (or other language) name.  Names of this type must be sent to examination.'
+    }
+    let output = ''
+    if (this.isPersonsName) {
+      output = '<p class="ma-0 pa-0">Name Requests that are personal name(s) cannot be reserved immediately.</p>'
+    }
+    if (!this.nameIsEnglish) {
+      output = output +
+        '<p>Name Requests that contain words that are not English cannot be reserved immediately.<p>'
     }
     return output
+  }
+  newSearch () {
+    this.name = this.englishOnlyName
+    newReqModule.startAnalyzeName()
   }
   showNextTab () {
     newReqModule.mutateSubmissionTabComponent('SendForExamination')

--- a/client/src/plugins/utilities.ts
+++ b/client/src/plugins/utilities.ts
@@ -1,26 +1,12 @@
 import removeAccents from 'remove-accents'
 
-export function normalizeWordCase (name: string) {
-  name = name.replace(/\s\s+/g, ' ')
-  name = name.toLowerCase()
-  let nameArray = name.split(' ')
-  if (nameArray.length <= 1) {
-    let first = name[0].toUpperCase()
-    let length = name.length
-    let rest = name.slice(1, length)
-    return first + rest
-  }
-  for (let n = 0; n < nameArray.length; n++) {
-    if (nameArray[n] && nameArray[n][0]) {
-      nameArray[n] = nameArray[n][0].toUpperCase() + nameArray[n].slice(1)
-    }
-  }
-  return nameArray.join(' ')
+export function removeExcessSpaces (name) {
+  return name.replace(/\s\s+/g, ' ')
 }
 
 export function sanitizeName (name) {
   name = removeAccents(name)
+  name = removeExcessSpaces(name)
   name = name.replace(/[^\sa-zA-Z0-9*/+&().,="'#@!?;:-]/g, '')
-  name = name.replace(/\s\s+/g, ' ')
   return name.toUpperCase()
 }


### PR DESCRIPTION
Added logic to... 
- Detect names containing / character
- Remove spaces around said / character (if present)
- Intercept such names and show users Options (ie. remove the other langauge part or send examination)
- Also fixed issue with checkbox in search.vue-both name and language checkboxes are independent now

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
