### PR TITLE
Entity 3277 - Handle more than one designation in name

### DIFF
--- a/client/src/components/new-request/grey-box.vue
+++ b/client/src/components/new-request/grey-box.vue
@@ -17,15 +17,15 @@
         <!-- Header, Line 1 and Line 2-->
 
         <v-col class="small-copy pale-blue-text pt-0"
-               v-if="designationIsFixed && designationTypes"
+               v-if="designationIsFixed && isDesignationIssueType && i === 0"
                cols="12">
           No additional issues were identified with your name.  You may proceed.
         </v-col>
         <v-col class="small-copy pale-blue-text pt-0"
-               v-else-if="changesInBaseName && i === 0"
+               v-else-if="changesInBaseName && isDesignationIssueType && i === 0"
                cols="12">
-          You have altered the text of your name.  You must either change it back or click the magnifying glass
-          to initiate analysis on the new name.
+          You have altered the base text of your name.  You must
+          either change it back or click the magnifying glass to run a new search for your edited name.
         </v-col>
         <v-col class="small-copy pale-blue-text pt-0"
                v-else
@@ -35,18 +35,18 @@
         </v-col>
 
         <!-- NAME/DESIGNATION-MANIPULATING OPTION BOXES -->
-        <template v-if="designationTypes">
+        <template v-if="isDesignationIssueType">
           <transition name="fade"
                       mode="out-in">
             <v-col v-if="!designationIsFixed && !changesInBaseName && i === 0"
                    class="text-center"
                    key="designation-error-col">
-              <template v-if="option.type !== 'change designation at the end'">
+              <template v-if="Array.isArray(designations) && designations.length > 0">
                 <div class="designation-buttons">
                   <button tag="div"
                           :key="'designation-'+d"
                           :id="'designation-'+d"
-                          @click="changeDesignation(des)"
+                          @click.once.prevent="changeDesignation(des)"
                           class="small-link ma-0 pa-0 px-1"
                           v-for="(des, d) in designations">
                     {{ des }}{{ (d !== issue.designations.length - 1) ? ',' : '' }}
@@ -57,7 +57,8 @@
                 <v-btn @click="moveDesignation">Move Designation</v-btn>
               </template>
             </v-col>
-            <v-col v-if="designationIsFixed && i === 0" key="designation-fixed-col" class="text-center">
+            <v-col v-if="designationIsFixed && i === 0 && issueIndex + 1 === issueLength"
+                   key="designation-fixed-col" class="text-center">
               <ReserveSubmit id="reserve-submit-button"
                              style="display: inline"
                              :setup="reserveSubmitConfig" />
@@ -99,11 +100,12 @@
 </template>
 
 <script lang="ts">
-import allDesignations from '@/store/list-data/designations'
+import allDesignations, { allDesignationsList } from '@/store/list-data/designations'
 import newReqModule from '@/store/new-request-module'
+import ReserveSubmit from '@/components/new-request/submit-request/reserve-submit.vue'
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
 import { IssueI, OptionI } from '@/models'
-import ReserveSubmit from '@/components/new-request/submit-request/reserve-submit.vue'
+import { matchWord, removeExcessSpaces, replaceWord } from '@/plugins/utilities'
 
 @Component({
   components: { ReserveSubmit }
@@ -113,14 +115,9 @@ export default class GreyBox extends Vue {
   @Prop(Number) issueIndex: number
   @Prop(Object) option: OptionI
   @Prop(String) originalName: string
-
-  showError: boolean = false
-  clickedDesignation: string = ''
-  types = ['send_to_examiner', 'obtain_consent', 'conflict_self_consent']
-  showLastStepButtons = {
-    conflict_self_consent: false,
-    obtain_consent: false,
-    send_to_examiner: false
+  @Watch('designationIsFixed')
+  updateStore (newVal) {
+    newReqModule.mutateDesignationIsFixed(newVal)
   }
 
   mounted () {
@@ -129,53 +126,135 @@ export default class GreyBox extends Vue {
         this.showLastStepButtons[key] = false
       })
     })
+    let { originalName } = this
+    if (this.issueType === 'designation_mismatch' || this.issueType === 'designation_misplaced') {
+      this.originalNameBase = this.removeMismatchedDesignations(originalName)
+      return
+    }
+    if (this.issueType === 'end_designation_more_than_once') {
+      for (let word of this.nameActionWords) {
+        originalName = replaceWord(originalName, word)
+      }
+      this.originalNameBase = originalName
+      return
+    }
+    for (let word of allDesignationsList) {
+      originalName = replaceWord(originalName, word)
+    }
+    this.originalNameBase = originalName
   }
 
+  clickedDesignation: string = ''
+  nameObj = {
+    0: '',
+    1: '',
+    2: ''
+  }
+  originalNameBase: string = ''
+  showError: boolean = false
+  showLastStepButtons = {
+    conflict_self_consent: false,
+    obtain_consent: false,
+    send_to_examiner: false
+  }
+  types = ['send_to_examiner', 'obtain_consent', 'conflict_self_consent']
+
+  get allDesignationsStripped () {
+    return this.stripAllDesignations(this.originalName)
+  }
   get boxIsChecked () {
     let { type } = this.option
     return this.requestExaminationOrProvideConsent[this.issueIndex][type]
+  }
+  set boxIsChecked (value) {
+    for (let type of this.types) {
+      newReqModule.mutateRequestExaminationOrProvideConsent({
+        value: false,
+        type,
+        index: this.issueIndex
+      })
+    }
+    if (this.issueIndex === this.issueLength - 1) {
+      for (let type of this.types) {
+        this.showLastStepButtons[type] = false
+      }
+      this.showLastStepButtons[this.option.type] = true
+    }
+    newReqModule.mutateRequestExaminationOrProvideConsent({
+      value,
+      type: this.option.type,
+      index: this.issueIndex
+    })
   }
   get changesInBaseName () {
     if (this.name === this.originalName) {
       return false
     }
-    let { end, words } = allDesignations[this.entityType]
-
-    if (!end) {
-      let chunkedName: string
-      if (this.issueType === 'designation_non_existent') {
-        chunkedName = this.name.split(' ')
-      } else if (this.issueType === 'designation_mismatch') {
-        let original = this.extractInnerDesignation(this.name, this.word)
-        chunkedName = original.split(' ')
-      } else {
-        let original = this.extractInnerDesignation(this.name)
-        chunkedName = original.split(' ')
-      }
-      for (let chunk of chunkedName) {
-        if (!this.originalName.includes(chunk)) {
+    switch (this.issueType) {
+      case 'designation_non_existent': {
+        if (this.name.length === this.originalName.length) {
+          if (this.name.includes(this.originalName)) {
+            return false
+          }
           return true
         }
-      }
-      return false
-    }
-    if (this.issueType === 'designation_non_existent') {
-      if (!this.name.startsWith(this.originalName)) {
+        if (this.name.startsWith(this.originalName + ' ')) {
+          return false
+        }
         return true
       }
-      return false
-    } else if (this.issueType === 'designation_mismatch') {
-      let original = this.extractInnerDesignation(this.originalName, this.word)
-      if (!this.name.startsWith(original)) {
+      case 'designation_mismatch': {
+        let { allDesignationsStripped } = this
+        if (this.nameActionWords.length > 0) {
+          for (let word of this.nameActionWords) {
+            allDesignationsStripped = replaceWord(allDesignationsStripped, word)
+          }
+        }
+        if (this.name.includes(allDesignationsStripped + ' ')) {
+          return false
+        }
         return true
       }
-      return false
+      case 'end_designation_more_than_once':
+      case 'designation_misplaced': {
+        let chunkedOriginalNameBase = this.originalNameBase.split(' ')
+        let chunkedName = removeExcessSpaces(this.name).split(' ')
+        let checkBaseName = () => {
+          // check that every word in the original base name is still exactly in the name
+          return chunkedOriginalNameBase.every(word => {
+            return chunkedName.some(chunk => chunk === word)
+          })
+        }
+        let outcome = !checkBaseName()
+        // if all the words are exactly in the nane, we know the words have not been modified and none are missing
+        // check length to ensure none are added
+        if (this.clickedDesignation) {
+          let max: number
+          if (Array.isArray(this.designations) && this.designations.length > 0) {
+            this.designations.forEach(des => {
+              let l = des.split(' ').length
+              if (!max || l > max) {
+                max = l
+              }
+            })
+          }
+          if (chunkedOriginalNameBase && chunkedName) {
+            let newMaxLength = chunkedOriginalNameBase.length + max
+            if (chunkedName.length < chunkedOriginalNameBase.length || chunkedName.length > newMaxLength) {
+              outcome = true
+            }
+          }
+        }
+        return outcome
+      }
+      case '':
+      default: {
+        if (this.name === this.originalName) {
+          return false
+        }
+        return true
+      }
     }
-    let original = this.extractInnerDesignation(this.originalName)
-    if (!this.name.startsWith(original)) {
-      return true
-    }
-    return false
   }
   get checkBoxLabel () {
     switch (this.option.type) {
@@ -189,19 +268,62 @@ export default class GreyBox extends Vue {
         return ''
     }
   }
-  get designations () {
-    if (newReqModule.analysisJSON && Array.isArray(newReqModule.analysisJSON.issues)) {
-      let designationIssue = newReqModule.analysisJSON.issues.find(issue => issue.designations)
-      if (designationIssue) {
-        return designationIssue.designations.map(des => des.toUpperCase())
-      }
-    }
-    return null
-  }
   get designationIsFixed () {
     if (!this.changesInBaseName) {
+      if (this.issueType === 'end_designation_more_than_once') {
+        let designations = this.designations.map(des => des.toUpperCase())
+        let chosenDesignation = designations.find(des => this.name.includes(' ' + des))
+        if (!chosenDesignation) {
+          return false
+        }
+        let otherDesignations = designations.filter(des => des !== chosenDesignation)
+        if (otherDesignations.every(des => !this.name.includes(' ' + des))) {
+          return true
+        }
+        return false
+      }
+      if (this.issueType === 'designation_misplaced') {
+        if (this.name.endsWith(' ' + this.word)) {
+          return true
+        }
+        return false
+      }
+      if (this.issueType === 'designation_mismatch') {
+        let end: string
+        for (let des of this.designations) {
+          if (this.name.endsWith(' ' + des)) {
+            end = des
+          }
+        }
+        if (!end) {
+          return false
+        }
+        let { allDesignationsStripped } = this
+        if (this.nameActionWords.length > 0) {
+          for (let word of this.nameActionWords) {
+            allDesignationsStripped = replaceWord(allDesignationsStripped, word)
+          }
+        }
+        if (this.name === allDesignationsStripped + ' ' + end) {
+          return true
+        }
+        return false
+      }
+      if (this.word && !this.clickedDesignation) {
+        if (this.name.includes(' ' + this.word)) {
+          return true
+        }
+        return false
+      }
+      if (this.issueType === 'designation_non_existent') {
+        let designation = this.designations.find(des => this.name.endsWith(des.toUpperCase()))
+        if (!designation) {
+          return false
+        }
+        return (this.name === this.originalName + ' ' + designation.toUpperCase())
+      }
       let designations
-      if (this.designations && Array.isArray(this.designations) && this.designations.length > 0) {
+      if (Array.isArray(this.designations) && this.designations.length > 0) {
         designations = this.designations
       } else {
         designations = allDesignations[this.entityType].words
@@ -209,30 +331,25 @@ export default class GreyBox extends Vue {
       designations = designations.map(des => des.toUpperCase())
       if (allDesignations[this.entityType].end) {
         for (let designation of designations) {
-          if (this.name.endsWith(designation)) {
+          if (this.name.endsWith(' ' + designation)) {
             return true
           }
         }
         return false
       }
       for (let designation of designations) {
-        if (this.name.includes(designation)) {
+        if (this.name.includes(' ' + designation)) {
           return true
         }
       }
     }
     return false
   }
-  get designationTypes () {
-    let designationIssueTypes = [
-      'designation_non_existent',
-      'designation_mismatch',
-      'designation_misplaced'
-    ]
-    if (designationIssueTypes.includes(this.issueType)) {
-      return true
+  get designations () {
+    if (this.issue && this.issue.designations) {
+      return this.issue.designations
     }
-    return false
+    return null
   }
   get entityType () {
     return newReqModule.entityType
@@ -244,6 +361,26 @@ export default class GreyBox extends Vue {
           return true
         }
       }
+    }
+    return false
+  }
+  get isDesignationIssueType () {
+    let designationIssueTypes = [
+      'designation_non_existent',
+      'designation_mismatch',
+      'designation_misplaced',
+      'end_designation_more_than_once'
+    ]
+    if (designationIssueTypes.includes(this.issueType)) {
+      return true
+    }
+    return false
+  }
+  get isMismatchFollowingMisplaced () {
+    if (this.issueIndex > 0 &&
+        this.issueType === 'designation_mismatch' &&
+        newReqModule.analysisJSON.issues[this.issueIndex - 1].issue_type === 'designation_misplaced') {
+      return true
     }
     return false
   }
@@ -262,8 +399,34 @@ export default class GreyBox extends Vue {
     }
     return ''
   }
+  get multipleMismatchedDesignations () {
+    if (this.issueType === 'designation_mismatch') {
+      if (Array.isArray(this.nameActions) && this.nameActions.length > 1) {
+        return this.nameActions.map(action => (
+          { word: action.word.toUpperCase(), index: action.index }
+        ))
+      }
+    }
+    return false
+  }
   get name () {
     return newReqModule.name
+  }
+  set name (name) {
+    newReqModule.mutateName(name)
+    this.$root.$emit('updatecontents', name)
+  }
+  get nameActions () {
+    if (this.issue && Array.isArray(this.issue.name_actions)) {
+      return this.issue.name_actions
+    }
+    return []
+  }
+  get nameActionWords () {
+    if (Array.isArray(this.nameActions)) {
+      return this.nameActions.map(action => action.word.toUpperCase())
+    }
+    return []
   }
   get requestExaminationOrProvideConsent () {
     return newReqModule.requestExaminationOrProvideConsent
@@ -325,92 +488,59 @@ export default class GreyBox extends Vue {
     }
     return ''
   }
-  set boxIsChecked (value) {
-    for (let type of this.types) {
-      newReqModule.mutateRequestExaminationOrProvideConsent({
-        value: false,
-        type,
-        index: this.issueIndex
-      })
-    }
-    if (this.issueIndex === this.issueLength - 1) {
-      for (let type of this.types) {
-        this.showLastStepButtons[type] = false
-      }
-      this.showLastStepButtons[this.option.type] = true
-    }
-    newReqModule.mutateRequestExaminationOrProvideConsent({
-      value,
-      type: this.option.type,
-      index: this.issueIndex
-    })
-  }
-  set name (name) {
-    newReqModule.mutateName(name)
-  }
 
+  cancelAnalyzeName () {
+    newReqModule.cancelAnalyzeName()
+  }
   changeDesignation (designation) {
-    this.clickedDesignation = designation
     newReqModule.mutateShowActualInput(true)
     designation = designation.toUpperCase()
+    this.clickedDesignation = designation
+    if (this.issueType === 'designation_mismatch') {
+      let { allDesignationsStripped } = this
+      if (this.nameActionWords.length > 0) {
+        for (let word of this.nameActionWords) {
+          allDesignationsStripped = replaceWord(allDesignationsStripped, word)
+        }
+      }
+      this.name = allDesignationsStripped + ' ' + designation
+      return
+    }
+    if (this.issueType === 'end_designation_more_than_once') {
+      this.name = this.originalNameBase + ' ' + designation
+      return
+    }
     if (this.issueType === 'designation_non_existent') {
       this.name = this.originalName + ' ' + designation
       return
     }
-    this.name = this.originalName.replace(this.word, designation)
-    if (allDesignations[this.entityType].end) {
-      if (!this.name.endsWith(designation)) {
-        let chunked = this.name.split(' ')
-        chunked.splice(chunked.indexOf(designation), 1)
-        this.name = chunked.join(' ') + ' ' + designation
-      }
+    if (this.multipleMismatchedDesignations) {
+      this.name = this.removeMismatchedDesignations(this.originalName) + ' ' + designation
+      return
     }
   }
-
   extractInnerDesignation (name, designation = null) {
     let { words } = allDesignations[this.entityType]
     let index, length
     if (!designation) {
       for (let word of words) {
-        let pattern
-        if (word.includes('.')) {
-          word = word.replace('.', '\\.')
-          pattern = '(^|\\s)' + word
-        } else {
-          pattern = '(^|\\s)' + word + '(\\b)'
-        }
-        let match = name.match(new RegExp(pattern))
-        if (match) {
-          index = match.index
-          length = match[0].length
-          break
-        }
+        name = replaceWord(name, word)
       }
     } else if (designation) {
-      let pattern
-      if (designation.includes('.')) {
-        designation = designation.replace('.', '\\.')
-        pattern = '(^|\\s)' + designation
-      } else {
-        pattern = '(^|\\s)' + designation + '(\\b)'
-      }
-      let match = name.match(new RegExp(pattern))
-      if (match) {
-        index = match.index
-        length = match[0].length
-      }
+      name = replaceWord(name, designation)
     }
-    if (!index) {
-      return null
-    }
-    return name.substring(0, index) + name.substring(index + length, name.length)
+    return name
   }
   moveDesignation () {
     newReqModule.mutateShowActualInput(true)
-    let baseName = this.extractInnerDesignation(this.originalName, this.word)
+    let baseName: string
+    if (this.originalNameBase) {
+      baseName = this.originalNameBase
+    } else {
+      baseName = this.extractInnerDesignation(this.originalName, this.word)
+    }
     this.name = baseName + ' ' + this.word
   }
-
   optionClasses (i) {
     if (this.issue && Array.isArray(this.issue.setup)) {
       switch (this.issue.setup.length) {
@@ -432,9 +562,30 @@ export default class GreyBox extends Vue {
     }
     return ''
   }
+  removeMismatchedDesignations (name, designation = null) {
+    if (designation) {
+      return replaceWord(name, designation)
+    }
+    if (this.nameActionWords.length > 0) {
+      for (let word of this.nameActionWords) {
+        name = replaceWord(name, word)
+      }
+      return name
+    }
+    if (Array.isArray(this.designations)) {
+      let index = this.designations.findIndex(des => name.endsWith(' ' + des))
+      if (index >= 0) {
+        let designation = this.designations[index]
+        name = replaceWord(name, designation)
+      }
+    }
+    return name
+  }
+  stripAllDesignations (name) {
+    for (let word of allDesignationsList) {
+      name = replaceWord(name, word)
+    }
+    return name
+  }
 }
 </script>
-
-<style scoped lang="sass">
-
-</style>

--- a/client/src/components/new-request/submit-request/applicant-info-1.vue
+++ b/client/src/components/new-request/submit-request/applicant-info-1.vue
@@ -64,7 +64,8 @@
                   <v-text-field :messages="messages['Line1']"
                                 :rules="requiredRules"
                                 :value="applicant.addrLine1"
-                                @blur="messages = {}"
+                                @blur="blurAddress1"
+                                @focus="focusAddress1"
                                 @input="updateApplicant('addrLine1', $event)"
                                 class="pa-0"
                                 dense
@@ -303,7 +304,6 @@ export default class ApplicantInfo1 extends Vue {
   mounted () {
     this.updateApplicant('stateProvinceCd', 'BC')
     this.updateApplicant('countryTypeCd', 'CA')
-    document.addEventListener('keydown', this.handleKeydown)
     debounced = null
   }
   beforeDestoy () {
@@ -357,7 +357,13 @@ export default class ApplicantInfo1 extends Vue {
   get submissionType () {
     return newReqModule.submissionType
   }
-
+  blurAddress1 () {
+    this.messages = {}
+    document.removeEventListener('keydown', this.handleKeydown)
+  }
+  focusAddress1 () {
+    document.addEventListener('keydown', this.handleKeydown)
+  }
   clearValidation () {
     if (this.$refs.step1 as any) {
       (this.$refs.step1 as any).resetValidation()
@@ -390,6 +396,9 @@ export default class ApplicantInfo1 extends Vue {
     }
   }
   handleKeydown (event) {
+    if (!this.showAddressMenu) {
+      return event
+    }
     if (this.addressSuggestions && this.showAddressMenu) {
       if (event.key === 'Tab') {
         event.preventDefault()

--- a/client/src/components/new-request/submit-request/reserve-submit.vue
+++ b/client/src/components/new-request/submit-request/reserve-submit.vue
@@ -13,6 +13,9 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 export default class ReserveSubmitButton extends Vue {
   @Prop(String) setup: string
   get text () {
+    if (this.location !== 'BC') {
+      return 'Send For Examination'
+    }
     switch (this.setup) {
       case 'consent':
         return 'Conditionally Reserve'
@@ -22,10 +25,13 @@ export default class ReserveSubmitButton extends Vue {
         return 'Reserve and Continue'
     }
   }
+  get location () {
+    return newReqModule.location
+  }
 
   showNextStep () {
     newReqModule.mutateDisplayedComponent('SubmissionTabs')
-    if (this.setup === 'examine') {
+    if (this.setup === 'examine' || this.location !== 'BC') {
       newReqModule.mutateSubmissionTabComponent('SendForExamination')
       newReqModule.mutateSubmissionType('examination')
       return

--- a/client/src/components/new-request/submit-request/send-for-examination.vue
+++ b/client/src/components/new-request/submit-request/send-for-examination.vue
@@ -108,14 +108,16 @@ export default class SendForExamination extends Vue {
   mounted () {
     newReqModule.mutateSubmissionType('examination')
     this.$nextTick(function () {
+      newReqModule.mutateNameChoicesToInitialState()
       if (this.designationAtEnd) {
         for (let item of this.items) {
-          if (this.name.endsWith(item.text)) {
-            this.editChoices('designation1', item.text)
-            let value = this.name.replace(item.text, '').trim()
+          if (this.name.endsWith(item)) {
+            this.editChoices('designation1', item)
+            let value = this.name.replace(item, '').trim()
             newReqModule.mutateNameChoices({ key: 'name1', value })
             return
           }
+          newReqModule.mutateNameChoices({ key: 'name1', value: this.name })
         }
       }
     })
@@ -179,7 +181,7 @@ export default class SendForExamination extends Vue {
     return newReqModule.nameChoices
   }
   get items () {
-    return newReqModule.designationItems
+    return designations[this.entityType].words
   }
 
   editChoices (key, value) {

--- a/client/src/models.ts
+++ b/client/src/models.ts
@@ -2,16 +2,8 @@ export type DisplayedComponentT = 'Tabs' | 'AnalyzePending' | 'AnalyzeResults' |
 export type LocationT = 'BC' | 'CA' | 'IN' | 'INFO'
 export type NrDataResponseT = RequestDataI | null
 export type NrDataT = string | null
-export type SearchComponentT = 'search' | 'analyzing' | 'results'
 export type SubmissionTypeT = 'examination' | 'consent' | 'normal'
 
-export interface QuillI {
-  setContents(ops: QuillOpsI[]): void
-  getRangeAt(index: number): Range
-  setText(text: string): void
-  getText(): string
-
-}
 export interface SelectionI {
   index?: number
   length?: number
@@ -70,7 +62,7 @@ export interface IssueI {
   ]
   setup: SetupI[]
   show_examination_button: boolean
-  show_resere_button: boolean
+  show_reservxe_button: boolean
 }
 export interface NameDesignationI {
   name: string

--- a/client/src/plugins/utilities.ts
+++ b/client/src/plugins/utilities.ts
@@ -1,12 +1,29 @@
 import removeAccents from 'remove-accents'
 
-export function removeExcessSpaces (name) {
-  return name.replace(/\s\s+/g, ' ')
+export function removeExcessSpaces (name: string): string {
+  name = name.replace(/\s\s+/g, ' ')
+  return name.trim()
 }
 
-export function sanitizeName (name) {
+export function sanitizeName (name: string): string {
   name = removeAccents(name)
   name = removeExcessSpaces(name)
   name = name.replace(/[^\sa-zA-Z0-9*/+&().,="'#@!?;:-]/g, '')
   return name.toUpperCase()
+}
+
+export function replaceWord (name: string, word: string, substitution: string = ' ') {
+  name = name.toUpperCase()
+  word = word.toUpperCase().replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
+  if (substitution !== ' ') {
+    substitution = substitution.toUpperCase()
+    substitution = ` ${substitution} `
+  }
+  return removeExcessSpaces(name.replace(new RegExp('(^|\\s)' + word + '(\\W(\\s|$)|($|\\s))'), substitution))
+}
+
+export function matchWord (name: string, word: string) {
+  name = name.toUpperCase()
+  word = word.toUpperCase().replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
+  return name.match(new RegExp('(^|\\s)' + word + '(($|\\s))'))
 }

--- a/client/src/store/list-data/designations.js
+++ b/client/src/store/list-data/designations.js
@@ -1,6 +1,6 @@
 const corporateDesignations = {
   words: [
-    'CORP',
+    'CORP.',
     'CORPORATION',
     'INC.',
     'INCORPORATED',
@@ -40,7 +40,7 @@ const designations = {
       'LLP',
       'LIMITED LIABILITY PARTNERSHIP',
       'SOCIETE A RESPONSABILITE LIMITEE',
-      'OCIETE EN NOM COLLECTIF A RESPONSABILITE LIMITEE',
+      'SOCIETE EN NOM COLLECTIF A RESPONSABILITE LIMITEE',
       'SLR',
       'SENCRL'
     ],
@@ -54,7 +54,7 @@ const designations = {
       'COMMUNITY CONTRIBUTION COMPANY',
       ...corporateDesignations.words
     ],
-    end: false
+    end: true
   },
   UL: {
     words: [
@@ -65,15 +65,30 @@ const designations = {
   },
   BC: corporateDesignations,
   PA: {
+    words: [],
     end: false
   },
   FI: {
+    words: [],
     end: false
   },
   PAR: {
+    words: [],
     end: false
   }
-
 }
 
+function getAllDesignations () {
+  let output = []
+  for (let entity in designations) {
+    for (let word of designations[entity].words) {
+      if (!output.includes(word)) {
+        output.push(word)
+      }
+    }
+  }
+  return output
+}
+
+export const allDesignationsList = getAllDesignations()
 export default designations

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -23,6 +23,7 @@ import {
 import canadaPostAPIKey from './config'
 import { Action, config, getModule, Module, Mutation, VuexModule } from 'vuex-module-decorators'
 import { removeExcessSpaces, sanitizeName } from '@/plugins/utilities'
+import Vue from 'vue'
 // config.rawError = true
 
 const qs: any = querystring
@@ -59,6 +60,7 @@ export class NewRequestModule extends VuexModule {
     tradeMark: '',
     xproJurisdiction: ''
   }
+  designationIsFixed: boolean = false
   disableSuggestions: boolean = false
   displayedComponent: DisplayedComponentT = 'Tabs'
   doNotAnalyzeEntities: string[] = ['PAR', 'CC', 'BC', 'CP', 'PA', 'FI', 'XCP']
@@ -397,6 +399,17 @@ export class NewRequestModule extends VuexModule {
   tabNumber: number = 0
   waitingAddressSearch: ApplicantI | null = null
 
+  get allDesignationWords () {
+    let output = []
+    for (let des in designations) {
+      designations[des].words.forEach(word => {
+        if (!output.includes(word)) {
+          output.push(word)
+        }
+      })
+    }
+    return output
+  }
   get consentConflicts (): ConsentConflictI {
     let output = {
       name: ''
@@ -425,7 +438,7 @@ export class NewRequestModule extends VuexModule {
     return []
   }
   get designationObject () {
-    if (designations[this.entityType]) {
+    if (this.entityType && designations[this.entityType]) {
       return designations[this.entityType]
     }
     return ''
@@ -675,8 +688,6 @@ export class NewRequestModule extends VuexModule {
       this.mutateDisplayedComponent('AnalyzeResults')
     } catch (error) {
       this.mutateDisplayedComponent('Tabs')
-      // eslint-disable-next-line
-      console.log(error)
       return
     }
   }
@@ -817,6 +828,7 @@ export class NewRequestModule extends VuexModule {
       source.cancel()
       source = null
     }
+    this.mutateName('')
     this.mutateAnalysisJSON(null)
     this.mutateDisplayedComponent('Tabs')
     this.mutateShowActualInput(false)
@@ -926,6 +938,10 @@ export class NewRequestModule extends VuexModule {
     this.applicant[appKV.key] = appKV.value
   }
   @Mutation
+  mutateDesignationIsFixed (value) {
+    this.designationIsFixed = value
+  }
+  @Mutation
   mutateDisableSuggestions (value) {
     this.disableSuggestions = value
   }
@@ -983,6 +999,17 @@ export class NewRequestModule extends VuexModule {
   @Mutation
   mutateName (name: string) {
     this.name = name
+  }
+  @Mutation
+  mutateNameChoicesToInitialState () {
+    Vue.set(this, 'nameChoices', {
+      name1: '',
+      designation1: '',
+      name2: '',
+      designation2: '',
+      name3: '',
+      designation3: ''
+    })
   }
   @Mutation
   mutateNameChoices (choiceObj) {

--- a/client/tests/unit/analyze-results.spec.ts
+++ b/client/tests/unit/analyze-results.spec.ts
@@ -67,7 +67,7 @@ describe('analyze-results.vue', () => {
     })
     it('renders the nameActions properly', async () => {
       await wrapper.vm.$nextTick()
-      expect(wrapper.vm.nameEdit.includes(wrapper.vm.name)).toBe(true)
+      expect(wrapper.vm.contents.includes(wrapper.vm.name)).toBe(true)
     })
   })
 })


### PR DESCRIPTION
- Fixed issues with name search field--now working correctly

- Adjusted front-end to handle the following scenarios:
   1. Two matching (correct) designations, both misplaced
   2. Two matching (correct) designations, one misplaced, the other correctly placed
   3. Two matching (correct) designations, both correctly placed at end of name
   4. Two mismatched (inncorect) designations, both misplaced. 
   5. Two mismatched (inncorect) designations, one misplaced, the other correctly placed. 
   6. Two mismatched (inncorect) designations, both correctly placed at end of name
   7. One mismatched, one matched designations, matched one correctly placed, mismatched one incorrectly placed 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
