### PR TITLE
entity-3677, 3911 and 3912

### DIFF
--- a/client/src/components/new-request/grey-box.vue
+++ b/client/src/components/new-request/grey-box.vue
@@ -73,7 +73,26 @@
             <v-btn @click="cancelAnalyzeName()">Restart and Change Type</v-btn>
           </v-col>
         </template>
-
+        <!-- ASSUMED NAME OPTION BOX -->
+        <template v-else-if="option.type === 'assumed name'">
+          <v-col :id="option.type + '-button-checkbox-col'"
+                 v-if="i !== 0"
+                 class="pa-0 grey-box-checkbox-button text-center">
+            <transition name="fade" mode="out-in" >
+              <v-checkbox :key="option.type+'-checkbox'"
+                          label="I acknowledge I cannot use my company's original name and I will adopt an assumed name"
+                          class="ma-0 pa-0"
+                          id="assumed-name-checkbox"
+                          v-if="!isLastIndex && !assumedName"
+                          v-model="assumedName" />
+              <ReserveSubmit :key="option.type+'-reserve-submit'"
+                             :setup="reserveSubmitConfig"
+                             id="reserve-submit-button"
+                             style="display: inline"
+                             v-if="showCheckBoxOrButton === 'button'" />
+            </transition>
+          </v-col>
+        </template>
         <!-- ALL OTHER TYPES OF OPTION BOXES -->
         <template v-else>
           <v-col :id="option.type + '-button-checkbox-col'"
@@ -160,6 +179,12 @@ export default class GreyBox extends Vue {
   }
   types = ['send_to_examiner', 'obtain_consent', 'conflict_self_consent']
 
+  get assumedName () {
+    return newReqModule.assumedName
+  }
+  set assumedName (value) {
+    newReqModule.mutateAssumedName(value)
+  }
   get allDesignationsStripped () {
     return this.stripAllDesignations(this.originalName)
   }

--- a/client/src/components/new-request/submit-request/entity-cannot-be-auto-analyzed.vue
+++ b/client/src/components/new-request/submit-request/entity-cannot-be-auto-analyzed.vue
@@ -55,6 +55,28 @@ export default class EntityCannotBeAutoAnalyzed extends Vue {
     }
   }
   get boxes () {
+    let entityExplanation = {
+      title: 'Option 2',
+      class: 'square-card-x2',
+      button: 'restart',
+      text: 'You can choose a different entity type and search again.  Please consult with a lawyer' +
+      '/accounting professional if you are unsure about the most appropriate structure for your situation.'
+    }
+    let nameExplanation = {
+      title: 'Helpful Hint',
+      class: 'helpful-hint',
+      button: 'examine',
+      text: 'Click the button below to submit your request.  Please check the wait times listed at the top of' +
+      ' the screen.  Rush services are also available.'
+    }
+    let requestActionExplanation = {
+      title: 'Option 1',
+      class: 'helpful-hint',
+      button: 'examine',
+      text: `Currently only requests for New Names, New Tradenames and Name Changes are handled automatically.
+        Click the button below to submit your request to examination.  Please check the wait times listed at the top of
+        the screen.  Rush services are also available.`
+    }
     let slashEditExplanation = {
       title: 'Option 1',
       class: 'square-card-x2',
@@ -68,19 +90,8 @@ export default class EntityCannotBeAutoAnalyzed extends Vue {
       button: 'examine',
       text: 'You can choose to submit this name to examination. Please check wait times at the top of the screen.'
     }
-    let nameExplanation = {
-      title: 'Helpful Hint',
-      class: 'helpful-hint',
-      button: 'examine',
-      text: 'Click the button below to submit your request.  Please check the wait times listed at the top of' +
-      ' the screen.  Rush services are also available.'
-    }
-    let entityExplanation = {
-      title: 'Option 2',
-      class: 'square-card-x2',
-      button: 'restart',
-      text: 'You can choose a different entity type and search again.  Please consult with a lawyer' +
-      '/accounting professional if you are unsure about the most appropriate structure for your situation.'
+    if (this.requestActionNotSupported) {
+      return [requestActionExplanation]
     }
     if (this.entityTypeNotAnalyzed) {
       let edits = { title: 'Option 1', class: 'square-card-x2' }
@@ -109,9 +120,6 @@ export default class EntityCannotBeAutoAnalyzed extends Vue {
     }
     return false
   }
-  get nameIsSlashed () {
-    return newReqModule.nameIsSlashed
-  }
   get isPersonsName () {
     return newReqModule.isPersonsName
   }
@@ -124,9 +132,22 @@ export default class EntityCannotBeAutoAnalyzed extends Vue {
   get nameIsEnglish () {
     return newReqModule.nameIsEnglish
   }
+  get nameIsSlashed () {
+    return newReqModule.nameIsSlashed
+  }
+  get requestActionNotSupported () {
+    return !(['NEW', 'DBA', 'CHG'].includes(newReqModule.requestAction))
+  }
+  get requestActionText () {
+    return newReqModule.requestTextFromValue
+  }
   get title () {
+    if (this.requestActionNotSupported) {
+      return `Name requests to <b>${this.requestActionText}</b> cannot be auto-analyzed and must be sent<br> to
+      examination for review`
+    }
     if (this.entityTypeNotAnalyzed) {
-      return ` Name Requests for the <b>${this.entityText}</b> entity type cannot be reserved immediately.`
+      return `Name Requests for the <b>${this.entityText}</b> entity type cannot be reserved immediately.`
     }
     if (this.nameIsSlashed) {
       return 'The slash "/" followed by a number of words implies the name is an English name followed by a French' +

--- a/client/src/components/new-request/submit-request/send-for-examination.vue
+++ b/client/src/components/new-request/submit-request/send-for-examination.vue
@@ -107,8 +107,8 @@ export default class SendForExamination extends Vue {
 
   mounted () {
     newReqModule.mutateSubmissionType('examination')
+    newReqModule.mutateNameChoicesToInitialState()
     this.$nextTick(function () {
-      newReqModule.mutateNameChoicesToInitialState()
       if (this.designationAtEnd) {
         for (let item of this.items) {
           if (this.name.endsWith(item)) {
@@ -171,7 +171,16 @@ export default class SendForExamination extends Vue {
   get entityType () {
     return newReqModule.entityType
   }
+  get location () {
+    return newReqModule.location
+  }
+  get requestAction () {
+    return newReqModule.requestAction
+  }
   get designationAtEnd () {
+    if (this.location !== 'BC' && this.requestAction !== 'MVE') {
+      return false
+    }
     return designations[this.entityType].end
   }
   get name () {

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -51,6 +51,7 @@ export class NewRequestModule extends VuexModule {
     postalCd: '',
     stateProvinceCd: ''
   }
+  assumedName: boolean = false
   nrData = {
     additionalInfo: '',
     corpNum: '',
@@ -63,7 +64,7 @@ export class NewRequestModule extends VuexModule {
   designationIsFixed: boolean = false
   disableSuggestions: boolean = false
   displayedComponent: DisplayedComponentT = 'Tabs'
-  doNotAnalyzeEntities: string[] = ['PAR', 'CC', 'BC', 'CP', 'PA', 'FI', 'XCP']
+  doNotAnalyzeEntities: string[] = ['PAR', 'CC', 'CP', 'PA', 'FI', 'XCP']
   entityType: string = 'CR'
   entityTypesBC: EntityI[] = [
     {
@@ -533,6 +534,12 @@ export class NewRequestModule extends VuexModule {
     )
     return output
   }
+  get requestTextFromValue () {
+    if (this.requestAction) {
+      return this.requestTypeOptions.find(req => req.value === this.requestAction).text
+    }
+    return null
+  }
   get requestTypeOptions () {
     let option = this.requestTypes.find(type => type.value === 'NEW')
     option.rank = 1
@@ -872,12 +879,18 @@ export class NewRequestModule extends VuexModule {
       return
     }
     this.mutateName(name)
-    if (this.doNotAnalyzeEntities.includes(this.entityType) || !this.nameIsEnglish || this.isPersonsName) {
+    if (this.location === 'BC') {
+      if (this.nameIsEnglish && !this.isPersonsName && !this.doNotAnalyzeEntities.includes(this.entityType)) {
+        if (['NEW', 'DBA', 'CHG'].includes(this.requestAction)) {
+          this.getNameRequest()
+          return
+        }
+      }
       this.mutateSubmissionTabComponent('EntityNotAutoAnalyzed')
       this.mutateDisplayedComponent('SubmissionTabs')
       return
     }
-    if (this.location === 'BC') {
+    if (this.requestAction === 'MVE') {
       this.getNameRequest()
       return
     }
@@ -936,6 +949,10 @@ export class NewRequestModule extends VuexModule {
       appKV.value = appKV.value.toUpperCase()
     }
     this.applicant[appKV.key] = appKV.value
+  }
+  @Mutation
+  mutateAssumedName (value) {
+    this.assumedName = value
   }
   @Mutation
   mutateDesignationIsFixed (value) {


### PR DESCRIPTION
##### entity 3677
- changed logic so that all requests with location !== 'BC' go to the XPRO name analysis end point and for BC only requestActions of 'NEW', 'DBA' or 'CHG' go to analysis.
created new text and title logic for requestTypeNotSupported in the name-examination introductory component.
##### entity 3911
- removed benefit company from list of entities not analyzed
##### entity 3912
- fixed issue handling for proprietorship entity types and propagation of the name through to the send for examination component for non-analyzed entities

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
