### PR TITLE
entity 4099-various front end fixes

### DIFF
--- a/client/src/components/new-request/analyze-results.vue
+++ b/client/src/components/new-request/analyze-results.vue
@@ -364,7 +364,7 @@ export default class AnalyzeResults extends Vue {
     }
   }
   getBaseNameOps () {
-    let nameWords = this.name.split(' ')
+    let nameWords = this.originalName.split(' ')
     return nameWords.map((word, i) => (
       { insert: (i > 0) ? (' ' + word) : (word) }
     ))
@@ -402,7 +402,9 @@ export default class AnalyzeResults extends Vue {
     newReqModule.startAnalyzeName()
   }
   updateContents (text) {
-    this.quill.setText(text)
+    this.quill.setContents([
+      { insert: text }
+    ])
   }
 }
 

--- a/client/src/components/new-request/grey-box.vue
+++ b/client/src/components/new-request/grey-box.vue
@@ -244,14 +244,19 @@ export default class GreyBox extends Vue {
   get designationIsFixed () {
     if (!this.changesInBaseName) {
       let AllDesignationsList = allDesignationsList
+      // below condition is entity types PAR, FI, PA, and the proprietorships - don't use a designation
       if (allDesignations[this.entityType].words.length === 0) {
         if (this.nameActionWords.length > 0) {
           for (let word of this.nameActionWords) {
+            // in addition to checking the name for the inclusion of designations from the list-data, check for any
+            // designation-like words that the back-end is providing in the name_actions (eg. INC, CORP)
             if (!AllDesignationsList.includes(word)) {
               AllDesignationsList = AllDesignationsList.concat(word)
             }
           }
         }
+        // these entity types do not use designations, so they should not have one in their text
+        // fail the test (return false) if any are found
         for (let designation of AllDesignationsList) {
           if (matchWord(this.name, designation)) {
             return false
@@ -265,7 +270,10 @@ export default class GreyBox extends Vue {
           end = designation
         }
       })
+      // entities which don't use ending designations have either been dealt with above or are not covered by
+      // the name-request app so by this point, any name still being considered by this getter use one
       if (!end) {
+        // so fail the test if there is no ending designation
         return false
       }
       if (this.nameActionWords.length > 0) {
@@ -406,7 +414,7 @@ export default class GreyBox extends Vue {
     return []
   }
   get nameActionWords () {
-    if (Array.isArray(this.nameActions)) {
+    if (Array.isArray(this.nameActions) && this.nameActions.length > 0) {
       return this.nameActions.map(action => action.word.toUpperCase())
     }
     return []

--- a/client/src/components/new-request/submit-request/send-for-examination.vue
+++ b/client/src/components/new-request/submit-request/send-for-examination.vue
@@ -1,30 +1,38 @@
 <template>
-  <v-form v-model="isValid">
-    <v-container fluid class="pa-0 pt-9">
+  <v-form @keydown="validate" id="send-to-examination-form">
+    <v-container fluid class="pa-0 pt-9" id="send-to-examination-container">
       <v-row>
         <v-col cols="2" class="py-0 h5" align-self="start">
           First Choice
         </v-col>
         <v-col :cols="designationAtEnd ? 7 : 10" class="py-0">
-          <v-text-field filled
-                        :error-messages="name1Message"
-                        :readonly="designationAtEnd"
-                        id="choice-1-text-field"
+          <v-text-field :autofocus="autofocusField === 'name1'"
+                        :error-messages="messages.name1"
+                        :hide-details="hide"
+                        :value="nameChoices.name1"
+                        @blur="handleBlur()"
                         @input="editChoices('name1', $event)"
-                        :value="nameChoices.name1" />
+                        filled
+                        id="choice-1-text-field" />
         </v-col>
         <v-col cols="3" class="py-0" v-if="designationAtEnd">
-          <v-select filled
+          <v-select :autofocus="autofocusField === 'des1'"
                     :error-messages="des1Message"
-                    hide-details="auto"
+                    :hide-details="hide"
                     :items="items"
-                    placeholder="Designation"
-                    id="designation-1-select"
+                    :menu-props="props"
+                    :value="nameChoices.designation1"
+                    @blur="handleBlur(); showDesignationErrors.des1 = true"
                     @input="editChoices('designation1', $event)"
-                    :value="nameChoices.designation1" />
+                    filled
+                    id="designation-1-select"
+                    placeholder="Designation" />
         </v-col>
       </v-row>
       <v-row class="grey-text">
+        <v-col cols="10" v-if="entityPhraseRequired" class="mt-n2">
+          A {{ entityType === 'CC' ? 'Community Contribution Company' : 'Cooperative'}} name must
+          include (but not start with) one of the following phrases: <b>{{ entityPhraseText }}</b></v-col>
         <v-col cols="9">You may provide up to two additional names which will be considered at no further cost, in the
                         order provided, only if your First Choice cannot be approved.</v-col>
       </v-row>
@@ -33,22 +41,27 @@
           Second Choice
         </v-col>
         <v-col :cols="designationAtEnd ? 7 : 10" class="py-0">
-          <v-text-field filled
-                        hide-details
-                        id="choice-2-text-field"
-                        placeholder="Second Alternate Name (Optional)"
+          <v-text-field :autofocus="autofocusField === 'name2'"
+                        :error-messages="messages.name2"
+                        :hide-details="hide"
+                        :value="nameChoices.name2"
+                        @blur="handleBlur()"
                         @input="editChoices('name2', $event)"
-                        :value="nameChoices.name2" />
+                        filled
+                        id="choice-2-text-field"
+                        placeholder="Second Alternate Name (Optional)" />
         </v-col>
         <v-col cols="3" class="py-0" v-if="designationAtEnd">
-          <v-select filled
-                    :error-messages="des2Message"
-                    hide-details="auto"
-                    placeholder="Designation"
+          <v-select :error-messages="des2Message"
+                    :hide-details="hide"
                     :items="items"
-                    id="designation-2-select"
+                    :menu-props="props"
+                    :value="nameChoices.designation2"
+                    @blur="handleBlur(); showDesignationErrors.des2 = true"
                     @input="editChoices('designation2', $event)"
-                    :value="nameChoices.designation2" />
+                    filled
+                    id="designation-2-select"
+                    placeholder="Designation" />
         </v-col>
       </v-row>
       <v-row no gutters class="mt-2">
@@ -56,35 +69,37 @@
           Third Choice
         </v-col>
         <v-col :cols="designationAtEnd ? 7 : 10" class="py-0" style="height:60px">
-          <v-text-field filled
-                        :error-messages="name3Message"
-                        hide-details="auto"
-                        id="choice-3-text-field"
-                        placeholder="Third Alternate Name (Optional)"
+          <v-text-field :error-messages="messages.name3"
+                        :hide-details="hide"
+                        :value="nameChoices.name3"
+                        @blur="handleBlur()"
                         @input="editChoices('name3', $event)"
-                        :value="nameChoices.name3" />
+                        filled
+                        id="choice-3-text-field"
+                        placeholder="Third Alternate Name (Optional)" />
         </v-col>
         <v-col cols="3" class="py-0" style="height: 60px" v-if="designationAtEnd">
-          <v-select filled
-                    :error-messages="des3Message"
-                    hide-details="auto"
+          <v-select :error-messages="des3Message"
+                    :hide-details="hide"
                     :items="items"
-                    id="designation-3-select"
-                    placeholder="Designation"
+                    :value="nameChoices.designation3"
+                    @blur="handleBlur(); showDesignationErrors.des3 = true"
                     @input="editChoices('designation3', $event)"
-                    :value="nameChoices.designation3" />
+                    filled
+                    id="designation-3-select"
+                    placeholder="Designation" />
         </v-col>
       </v-row>
       <v-row class="mt-3">
         <v-col cols="12" class="text-right">
           <v-btn x-large
-                 v-if="choice1Valid && choice2Valid && choice3Valid"
+                 v-if="isValid"
                  id="submit-continue-btn"
-                 @click="showNextTab()">Continue</v-btn>
+                 @click="validate(true)">Continue</v-btn>
           <v-btn x-large
                  v-else
                  id="submit-continue-btn-disabled"
-                 @click="validate()">Continue</v-btn>
+                 @click="validateButton">Continue</v-btn>
         </v-col>
       </v-row>
     </v-container>
@@ -95,93 +110,188 @@
 import newReqModule from '@/store/new-request-module'
 import { Component, Vue, Watch } from 'vue-property-decorator'
 import designations from '@/store/list-data/designations'
+import { sanitizeName } from '@/plugins/utilities'
 
 @Component({})
 export default class SendForExamination extends Vue {
-  des1Message = ''
-  des2Message = ''
-  des3Message = ''
-  name1Message = ''
-  name3Message = ''
-  isValid: boolean = false
+  hide: boolean | 'auto' = true
+  messages = {
+    des1: '',
+    des2: '',
+    des3: '',
+    name1: '',
+    name2: '',
+    name3: ''
+  }
+  showDesignationErrors = {
+    des1: false,
+    des2: false,
+    des3: false
+  }
+  props = {
+    disableKeys: false
+  }
 
   mounted () {
+    this.$el.addEventListener('keydown', this.handleKeydown)
     newReqModule.mutateSubmissionType('examination')
     newReqModule.mutateNameChoicesToInitialState()
     this.$nextTick(function () {
       if (this.designationAtEnd) {
         for (let item of this.items) {
-          if (this.name.endsWith(item)) {
-            this.editChoices('designation1', item)
-            let value = this.name.replace(item, '').trim()
-            newReqModule.mutateNameChoices({ key: 'name1', value })
-            return
+          let { name } = this
+          if ([' LTD', ' INC', ' CORP'].some(des => name.endsWith(des))) {
+            name = name + '.'
           }
-          newReqModule.mutateNameChoices({ key: 'name1', value: this.name })
+          if (item) {
+            if (name.endsWith(item)) {
+              this.editChoices('designation1', item)
+              let value = name.replace(item, '').trim()
+              newReqModule.mutateNameChoices({ key: 'name1', value })
+              return
+            }
+          }
         }
       }
+      newReqModule.mutateNameChoices({ key: 'name1', value: this.name })
     })
-    newReqModule.mutateNameChoices({ key: 'name1', value: this.name })
   }
-
-  get choice1Valid () {
-    if (this.designationAtEnd) {
-      if (this.nameChoices.designation1) {
-        return true
-      }
-      return false
-    }
-    if (this.nameChoices.name1) {
-      return true
-    }
-    return false
+  destroyed () {
+    this.$el.removeEventListener('keydown', this.handleKeydown)
   }
-  get choice2Valid () {
-    let choices = this.nameChoices
-    if (!choices.name2) {
-      return true
-    }
+  get autofocusField () {
+    let output = 'name2'
     if (this.designationAtEnd) {
-      if (choices.name2 && choices.designation2) {
-        return true
+      if (!this.messages.name1 && !this.messages.des1) {
+        return output
       }
-      return false
+      if (this.messages.des1) {
+        output = 'des1'
+      }
+      if (this.messages.name1) {
+        output = 'name1'
+      }
+      return output
     }
-    if (!choices.name1) {
-      return false
+    if (this.messages.name1) {
+      output = 'name1'
     }
-    return true
+    return output
   }
-  get choice3Valid () {
-    let choices = this.nameChoices
-    if (!choices.name3) {
-      return true
+  get des1Message () {
+    if (this.showDesignationErrors.des1) {
+      return this.messages.des1
     }
-    if (this.designationAtEnd) {
-      if (choices.name2 && choices.designation3) {
-        return true
-      }
-      return false
+    return ''
+  }
+  get des2Message () {
+    if (this.showDesignationErrors.des2) {
+      return this.messages.des2
     }
-    if (this.nameChoices.name1 && this.nameChoices.name2) {
-      return true
+    return ''
+  }
+  get des3Message () {
+    if (this.showDesignationErrors.des3) {
+      return this.messages.des3
     }
-    return false
+    return ''
+  }
+  get designationAtEnd () {
+    return designations[this.entityType].end
+  }
+  get entityPhraseChoices () {
+    let basePhrases = designations[this.entityType].words
+    // filter the CR type designations from the list since they are not required inner phrases
+    return basePhrases.filter(phrase => !designations['CR'].words.includes(phrase))
+  }
+  get entityPhraseRequired () {
+    return ['CC', 'CP'].includes(this.entityType)
+  }
+  get entityPhraseText () {
+    return this.entityPhraseChoices.join(', ')
   }
   get entityType () {
     return newReqModule.entityType
   }
+  get isValid () {
+    let { nameChoices, messages, designationAtEnd, validatePhrases } = this
+    function name1 () {
+      messages.name1 = ''
+      messages.des1 = ''
+
+      validatePhrases('name1')
+      if (!nameChoices.name1) {
+        messages.name1 = 'Please enter at least one name'
+      }
+      if (designationAtEnd && !nameChoices.designation1) {
+        messages.des1 = 'Please choose a designation'
+      }
+      if (messages.name1 || messages.des1) {
+        return false
+      }
+      return true
+    }
+    function name2 () {
+      messages.name2 = ''
+      messages.des2 = ''
+
+      if (!nameChoices.name2) {
+        return true
+      }
+      validatePhrases('name2')
+      if (nameChoices.name2 === nameChoices.name1) {
+        messages.name2 = 'This is identical to your first name choice.  Please enter a unique name'
+      }
+      if (designationAtEnd && !nameChoices.designation2) {
+        messages.des2 = 'Please choose a designation'
+      }
+      if (messages.name2 || messages.des2) {
+        return false
+      }
+      return true
+    }
+    function name3 () {
+      messages.name3 = ''
+      messages.des3 = ''
+      if (!nameChoices.name3) {
+        return true
+      }
+      if (!nameChoices.name2) {
+        messages.name3 = 'Please choose a second name before entering a third name'
+        return false
+      }
+      validatePhrases('name3')
+      if (nameChoices.name3 === nameChoices.name1) {
+        messages.name3 = 'This is identical to your first name choice.  Please enter a unique name'
+      }
+      if (nameChoices.name3 === nameChoices.name2) {
+        messages.name3 = 'This is identical to your second name choice.  Please enter a unique name'
+      }
+      if (designationAtEnd && !nameChoices.designation3) {
+        messages.des3 = 'Please choose a designation'
+      }
+      if (messages.name3 || messages.des3) {
+        return false
+      }
+      return true
+    }
+
+    let step1 = name1()
+    let step2 = name2()
+    let step3 = name3()
+    return (step1 && step2 && step3
+    )
+  }
+  get items () {
+    let output: string[] = designations[this.entityType].words
+    if (this.entityType === 'CC') {
+      output = designations['CR'].words
+    }
+    output.unshift('')
+    return output
+  }
   get location () {
     return newReqModule.location
-  }
-  get requestAction () {
-    return newReqModule.requestAction
-  }
-  get designationAtEnd () {
-    if (this.location !== 'BC' && this.requestAction !== 'MVE') {
-      return false
-    }
-    return designations[this.entityType].end
   }
   get name () {
     return newReqModule.name
@@ -189,37 +299,67 @@ export default class SendForExamination extends Vue {
   get nameChoices () {
     return newReqModule.nameChoices
   }
-  get items () {
-    return designations[this.entityType].words
+  get requestAction () {
+    return newReqModule.requestAction
   }
 
-  editChoices (key, value) {
-    value = value.toUpperCase()
+  autoCapitalize (key: string) {
+    let value = sanitizeName(this.nameChoices[key])
     newReqModule.mutateNameChoices({ key, value })
-    let messages = ['des1Message', 'des2Message', 'des3Message', 'name1Message', 'name3Message']
-    messages.forEach(messsage => {
-      this[messsage] = ''
-    })
+  }
+  editChoices (key, value) {
+    this.hide = true
+    for (let key in this.messages) {
+      this.messages[key] = ''
+    }
+    newReqModule.mutateNameChoices({ key, value })
+  }
+  handleBlur () {
+    for (let key in this.nameChoices) {
+      let value = this.nameChoices[key] ? sanitizeName(this.nameChoices[key]) : ''
+      this.editChoices(key, value)
+    }
+    this.validate()
+  }
+  handleKeydown (event) {
+    if (event.key === 'Enter') {
+      this.props.disableKeys = true
+      this.validateButton()
+    }
   }
   showNextTab () {
     newReqModule.mutateSubmissionTabComponent('ApplicantInfo1')
   }
-  validate () {
-    if (!this.choice1Valid) {
-      this.des1Message = 'Required Field'
+  validate (next = false) {
+    if (!this.isValid) {
+      this.hide = 'auto'
+      this.props.disableKeys = false
+      return
     }
-    if (!this.choice2Valid) {
-      this.des2Message = 'Required Field'
+    this.hide = true
+    if (next) {
+      this.showNextTab()
     }
-    if (!this.choice3Valid) {
-      if (this.nameChoices.name3 && !this.nameChoices.name2) {
-        this.name3Message = 'Please enter a second choice before entering your third choice'
-      } else {
-        this.des3Message = 'Required Field'
+  }
+  validateButton () {
+    for (let key in this.showDesignationErrors) {
+      this.showDesignationErrors[key] = true
+    }
+    this.validate(true)
+  }
+  validatePhrases (choice: string) {
+    let name = this.nameChoices[choice]
+    if (this.entityPhraseRequired) {
+      let name = this.nameChoices[choice].toUpperCase()
+      if (this.entityPhraseChoices.every(phrase => {
+        phrase = phrase.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
+        return (name.search(new RegExp('(\\s)' + phrase + '(\\s|$)')) === -1)
+      })) {
+        this.messages[choice] = 'Your name must contain one of the required phrases'
       }
-    }
-    if (!this.designationAtEnd && !this.nameChoices.name1) {
-      this.name1Message = 'Please enter a first choice'
+      if (this.entityPhraseChoices.some(phrase => name.startsWith(phrase))) {
+        this.messages[choice] = 'Your name must not begin with one of the required phrases'
+      }
     }
   }
 }

--- a/client/src/plugins/utilities.ts
+++ b/client/src/plugins/utilities.ts
@@ -1,29 +1,107 @@
 import removeAccents from 'remove-accents'
 
 export function removeExcessSpaces (name: string): string {
+  // trims any spaces padding <name> and any internal spaces between words in excess of a single space per two words.
   name = name.replace(/\s\s+/g, ' ')
   return name.trim()
 }
 
 export function sanitizeName (name: string): string {
+  // replaces most characters from the extended-latin character set, such as those modified with diacritics, and most
+  // ligatures, with their closest ASCII equivalents (eg. é => e, ø => o, æ => ae); removes any symbols outside of
+  // the limited set supported by Namex; capitalizes; and trims any spaces padding <name> and any internal spaces
+  // between words in excess of a single space per two words.
   name = removeAccents(name)
-  name = removeExcessSpaces(name)
-  name = name.replace(/[^\sa-zA-Z0-9*/+&().,="'#@!?;:-]/g, '')
-  return name.toUpperCase()
+  name = name.replace(/[^\sa-zA-Z0-9^\[\]*/+&().,="'#@!?;:-]/g, '')
+  return removeExcessSpaces(name.toUpperCase())
 }
 
-export function matchWord (name: string, word: string) {
+export function matchWord (name: string, word: string): string[] | string {
+  // matches all occurrences of a word or phrase <word> in a longer string <name> where <word> appears in one of the
+  // following three ways: "word ", " word ", or " word" [ RegExp: /(\\s|^)word(\\s|$)/ ] with awareness to the special
+  // cases of designations where a short designation may comprise part of a longer designation and then only returning
+  // one match for the longer designation in such cases.  Return value is an array of <word> of length equal to the
+  // number of matches or null if there were none.
   name = name.toUpperCase()
-  word = word.toUpperCase().replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
-  return name.match(new RegExp('(?<=(^|\\s))' + word + '(?=(\\s|$))', 'g'))
-}
-
-export function replaceWord (name: string, word: string, substitution: string | null = null) {
-  name = name.toUpperCase()
-  word = word.toUpperCase().replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
-  if (substitution) {
-    substitution = substitution.toUpperCase()
-    return removeExcessSpaces(name.replace(new RegExp('(?<=(^|\\s))' + word + '(?=(\\s|$))'), substitution))
+  word = word.toUpperCase()
+  function escWrd () {
+    return word.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
   }
-  return removeExcessSpaces(name.replace(new RegExp('(?<=(^|\\s))' + word + '(?=(\\s|$))', 'g'), ''))
+  function matchWrd () {
+    return name.match(new RegExp('(\\s|^)' + escWrd() + '(\\s|$)'))
+  }
+  if (containsLongAndShortDesignation(name, word)) {
+    return null
+  }
+  let { length } = word
+  let output = []
+  while (matchWrd()) {
+    let match = matchWrd()
+    output.push(match[0].trim())
+    let newStartIndex = match.index + length - 1
+    name = name.substring(newStartIndex)
+  }
+  if (output.length > 0) {
+    return output
+  }
+  return null
+}
+
+export function replaceWord (name: string, word: string, substitution: string | null = null): string {
+  // when called with 2 arguments (<name> and <word>), finds all matches of <word> within <name> according to the same
+  // rules as matchWord above, replaces them with nothing (ie. removes them), and returns <name>.  When called with 3
+  // arguments, it finds the first match for <word> in <name>, replaces it with <substitution>, and returns <name>.  In
+  // either case, if there are no matches, <name> is returned without modification (aside from capitalization)
+  name = name.toUpperCase()
+  word = word.toUpperCase()
+
+  if (containsLongAndShortDesignation(name, word)) {
+    return name
+  }
+  function escWrd (w) {
+    return w.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
+  }
+  function replWrd (n) {
+    return n.replace(new RegExp('(\\s|^)' + escWrd(word) + '(\\s|$)'), ' ')
+  }
+  if (substitution) {
+    substitution = ' ' + substitution.toUpperCase() + ' '
+    name = name.replace(new RegExp('(\\s|^)' + escWrd(word) + '(\\s|$)'), substitution)
+  } else {
+    while (name !== replWrd(name)) {
+      name = replWrd(name)
+    }
+  }
+  return removeExcessSpaces(name)
+}
+
+export function containsLongAndShortDesignation (name: string, word: string): boolean {
+  word = word.toUpperCase()
+  name = name.toUpperCase()
+
+  if (word === 'LIMITED') {
+    let designationsContainingWord = [
+      ' LIMITED LIABILITY CO.',
+      ' LIMITED LIABILITY COMPANY',
+      ' LIMITED LIABILITY PARTNERSHIP',
+      ' LIMITED PARTNERSHIP'
+    ]
+    for (let designation of designationsContainingWord) {
+      if (name.includes(designation)) {
+        return true
+      }
+    }
+  }
+  if (word === 'LIMITEE') {
+    let designationsContainingWord = [
+      ' SOCIETE A RESPONSABILITE LIMITEE',
+      ' SOCIETE EN NOM COLLECTIF A RESPONSABILITE LIMITEE'
+    ]
+    for (let designation of designationsContainingWord) {
+      if (name.includes(designation)) {
+        return true
+      }
+    }
+  }
+  return false
 }

--- a/client/src/store/list-data/designations.js
+++ b/client/src/store/list-data/designations.js
@@ -4,10 +4,10 @@ const corporateDesignations = {
     'CORPORATION',
     'INC.',
     'INCORPORATED',
-    'INCORPOREE',
     'LIMITED',
-    'LIMITEE',
     'LTD.',
+    'INCORPOREE',
+    'LIMITEE',
     'LTEE'
   ],
   end: true
@@ -24,30 +24,7 @@ const cooperativeDesignations = {
 }
 
 const designations = {
-  CR: corporateDesignations,
-  XCR: corporateDesignations,
-  RLC: {
-    words: [
-      'L.L.C.',
-      'LIMITED LIABILITY CO.',
-      'LIMITED LIABILITY COMPANY',
-      'LLC'
-    ],
-    end: true
-  },
-  LL: {
-    words: [
-      'LLP',
-      'LIMITED LIABILITY PARTNERSHIP',
-      'SOCIETE A RESPONSABILITE LIMITEE',
-      'SOCIETE EN NOM COLLECTIF A RESPONSABILITE LIMITEE',
-      'SLR',
-      'SENCRL'
-    ],
-    end: true
-  },
-  CP: cooperativeDesignations,
-  XCP: cooperativeDesignations,
+  BC: corporateDesignations,
   CC: {
     words: [
       'CCC',
@@ -56,23 +33,13 @@ const designations = {
     ],
     end: true
   },
-  UL: {
-    words: [
-      'ULC',
-      'UNLIMITED LIABILITY COMPANY'
-    ],
-    end: true
-  },
-  BC: corporateDesignations,
-  PA: {
+  CP: cooperativeDesignations,
+  CR: corporateDesignations,
+  DBA: {
     words: [],
     end: false
   },
   FI: {
-    words: [],
-    end: false
-  },
-  PAR: {
     words: [],
     end: false
   },
@@ -84,10 +51,47 @@ const designations = {
     words: [],
     end: false
   },
-  DBA: {
+  LL: {
+    words: [
+      'LIMITED LIABILITY PARTNERSHIP',
+      'LLP',
+      'SENCRL',
+      'SLR',
+      'SOCIETE A RESPONSABILITE LIMITEE',
+      'SOCIETE EN NOM COLLECTIF A RESPONSABILITE LIMITEE'
+    ],
+    end: true
+  },
+  LP: {
+    words: ['LIMITED PARTNERSHIP'],
+    end: true
+  },
+  PA: {
     words: [],
     end: false
-  }
+  },
+  PAR: {
+    words: [],
+    end: false
+  },
+  RLC: {
+    words: [
+      'L.L.C.',
+      'LIMITED LIABILITY CO.',
+      'LIMITED LIABILITY COMPANY',
+      'LLC'
+    ],
+    end: true
+  },
+  UL: {
+    words: [
+      'ULC',
+      'UNLIMITED LIABILITY COMPANY'
+    ],
+    end: true
+  },
+  XCP: cooperativeDesignations,
+  XCR: corporateDesignations
 }
 
 function getAllDesignations () {

--- a/client/tests/unit/analyze-pending.spec.ts
+++ b/client/tests/unit/analyze-pending.spec.ts
@@ -13,9 +13,9 @@ describe('analyze-pending.vue', () => {
     vuetify
   })
   it('renders a spinner', () => {
-    expect(wrapper.contains('#analyze-pending-spinner')).toBe(true)
+    expect(wrapper.find('#analyze-pending-spinner').element).toBeTruthy()
   })
   it('renders a stop button', () => {
-    expect(wrapper.contains('#analyze-pending-stop-button')).toBe(true)
+    expect(wrapper.find('#analyze-pending-stop-button').element).toBeTruthy()
   })
 })

--- a/client/tests/unit/applicant-info-1.spec.ts
+++ b/client/tests/unit/applicant-info-1.spec.ts
@@ -21,11 +21,11 @@ describe('applicant-info-1.vue', () => {
     done()
   })
   it('renders the form', () => {
-    expect(wrapper.contains('#applicant-info-1-form')).toBe(true)
+    expect(wrapper.find('#applicant-info-1-form').element).toBeTruthy()
   })
   it('Initially renders the disabled continue button', () => {
-    expect(wrapper.contains('#submit-continue-btn-disabled')).toBe(true)
-    expect(wrapper.contains('#submit-continue-btn')).toBe(false)
+    expect(wrapper.find('#submit-continue-btn-disabled').element).toBeTruthy()
+    expect(wrapper.find('#submit-continue-btn').element).toBeFalsy()
   })
   it('calls validate when Continue button is pressed', async () => {
     wrapper.vm.validate = jest.fn()

--- a/client/tests/unit/applicant-info-2.spec.ts
+++ b/client/tests/unit/applicant-info-2.spec.ts
@@ -21,11 +21,11 @@ describe('It initially renders correctly', () => {
   })
 
   it('renders the form', () => {
-    expect(wrapper.contains('#applicant-info-2-form')).toBe(true)
+    expect(wrapper.find('#applicant-info-2-form').element).toBeTruthy()
   })
   it('Initially renders the disabled continue button', () => {
-    expect(wrapper.contains('#submit-continue-btn-disabled')).toBe(true)
-    expect(wrapper.contains('#submit-continue-btn')).toBe(false)
+    expect(wrapper.find('#submit-continue-btn-disabled').element).toBeTruthy()
+    expect(wrapper.find('#submit-continue-btn').element).toBeFalsy()
   })
   it('calls validate when Continue button is pressed', async () => {
     wrapper.vm.validate = jest.fn()

--- a/client/tests/unit/landing.spec.ts
+++ b/client/tests/unit/landing.spec.ts
@@ -33,9 +33,9 @@ describe('landing.vue', () => {
   })
 
   it('Landing initially displays only the New Request Tabs component', () => {
-    expect(wrapper.contains('#tabs-landing-comp')).toBe(true)
-    expect(wrapper.contains('#analyze-pending-container')).toBe(false)
-    expect(wrapper.contains('#analyze-results-container')).toBe(false)
+    expect(wrapper.find('#tabs-landing-comp').element).toBeTruthy()
+    expect(wrapper.find('#analyze-pending-container').element).toBeFalsy()
+    expect(wrapper.find('#analyze-results-container').element).toBeFalsy()
   })
 })
 
@@ -54,9 +54,9 @@ describe('landing.vue', () => {
   })
 
   it('When the state.searchShowStage key is set to "analysing", it shows only the pending container', () => {
-    expect(wrapper.contains('#new-req-existing-req-container')).toBe(false)
-    expect(wrapper.contains('#analyze-pending-container')).toBe(true)
-    expect(wrapper.contains('#analyze-results-container')).toBe(false)
+    expect(wrapper.find('#new-req-existing-req-container').element).toBeFalsy()
+    expect(wrapper.find('#analyze-pending-container').element).toBeTruthy()
+    expect(wrapper.find('#analyze-results-container').element).toBeFalsy()
   })
 })
 
@@ -75,8 +75,8 @@ describe('landing.vue', () => {
 
   it('When state.displayedComponent === "AnalyzeResults", it shows only the results container', async () => {
     await wrapper.vm.$nextTick()
-    expect(wrapper.contains('#new-req-existing-req-container')).toBe(false)
-    expect(wrapper.contains('#nanalyze-pending-container')).toBe(false)
-    expect(wrapper.contains('#analyze-results-container')).toBe(true)
+    expect(wrapper.find('#new-req-existing-req-container').element).toBeFalsy()
+    expect(wrapper.find('#nanalyze-pending-container').element).toBeFalsy()
+    expect(wrapper.find('#analyze-results-container').element).toBeTruthy()
   })
 })

--- a/client/tests/unit/name-input.spec.ts
+++ b/client/tests/unit/name-input.spec.ts
@@ -27,8 +27,8 @@ describe('name-input.vue', () => {
   })
 
   it('Displays the required ui elements', () => {
-    expect(wrapper.contains('#name-input-text-field')).toBe(true)
-    expect(wrapper.contains('#name-input-icon')).toBe(true)
+    expect(wrapper.find('#name-input-text-field').element).toBeTruthy()
+    expect(wrapper.find('#name-input-icon').element).toBeTruthy()
   })
   it('Resists submitting when the entity type is set to "INFO" and detects the correct error type', async () => {
     newReqModule.mutateEntityType('INFO')

--- a/client/tests/unit/new-request.spec.ts
+++ b/client/tests/unit/new-request.spec.ts
@@ -21,14 +21,14 @@ describe('search.vue', () => {
   })
 
   it('Displays the necessary UI components', () => {
-    expect(wrapper.contains('#search-type-options-select')).toBe(true)
-    expect(wrapper.contains('#location-options-select')).toBe(true)
-    expect(wrapper.contains('#entity-type-options-select')).toBe(true)
-    expect(wrapper.contains('#name-input-component')).toBe(true)
+    expect(wrapper.find('#search-type-options-select').element).toBeTruthy()
+    expect(wrapper.find('#location-options-select').element).toBeTruthy()
+    expect(wrapper.find('#entity-type-options-select').element).toBeTruthy()
+    expect(wrapper.find('#name-input-component').element).toBeTruthy()
   })
   it('Displays the two modal activators', () => {
-    expect(wrapper.contains('#help-me-choose-activator')).toBe(true)
-    expect(wrapper.contains('#nr-required-activator')).toBe(true)
+    expect(wrapper.find('#help-me-choose-activator').element).toBeTruthy()
+    expect(wrapper.find('#nr-required-activator').element).toBeTruthy()
   })
   it('Initially sets the state for controlling both info modals visibility to false', () => {
     expect(newReqModule.nrRequiredModalVisible).toBe(false)

--- a/client/tests/unit/nr-required-modal.spec.ts
+++ b/client/tests/unit/nr-required-modal.spec.ts
@@ -19,7 +19,7 @@ describe('nr-not-required.vue', () => {
   it('Shows the modal when the state is set and it displays the required info', async () => {
     wrapper.vm.showModal = true
     await wrapper.vm.$nextTick()
-    expect(wrapper.contains('#nr-required-close-btn')).toBe(true)
+    expect(wrapper.find('#nr-required-close-btn').element).toBeTruthy()
     expect(wrapper.text().includes('You want a numbered company. The business does not need a name.')).toBe(true)
   })
   it('Closes the modal when the close button is pressed', async () => {

--- a/client/tests/unit/pick-request-type-modal.spec.ts
+++ b/client/tests/unit/pick-request-type-modal.spec.ts
@@ -24,13 +24,13 @@ describe('pick-request-type.vue', (): void => {
   })
 
   it('and it does not show the modal', () => {
-    expect(wrapper.contains('#pick-request-type-modal-card')).toBe(false)
+    expect(wrapper.find('#pick-request-type-modal-card').element).toBeFalsy()
   })
 
   it('When the modal visibility state key is set to true, expect the opposite', async () => {
     newReqModule.store.state.newRequestModule.pickRequestTypeModalVisible = true
     await wrapper.vm.$nextTick()
-    expect(wrapper.contains('#pick-request-type-modal-card')).toBe(true)
+    expect(wrapper.find('#pick-request-type-modal-card').element).toBeTruthy()
     expect(wrapper.vm.showModal).toBe(true)
   })
   it('clicking an entity sets the entityType and closes the modal', async () => {

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -4,10 +4,10 @@ module.exports = {
   configureWebpack: {
     devtool: 'eval-source-map',
     devServer: {
-      hot: false
+      hot: true
     },
     resolve: {
-      extensions: ['.ts', '.tsx', '.js', '.json', '.vue', '.jsx']
+      extensions: ['.ts', '.js', '.json', '.vue']
     }
   },
   pluginOptions: {


### PR DESCRIPTION
- fixed handling of limited partnership and limited liability partnership
- refactored designation matching utility function to properly handle "limited" and "limitee" designations which make up part of several longer designations and were previously being matched inappropriately.
- removed CCC from designations list
- updated the formatting / text of send-for-examination.vue to handle CCCs
- enhanced the name validation in send-for-examination.vue to handle and validate
the required phrases in CCCs / Co-ops
- refactored and fixed the error message display logic for the above comp

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
