### PR TITLE
entity 4521

### DIFF
--- a/client/src/components/common/applicant-info-2.vue
+++ b/client/src/components/common/applicant-info-2.vue
@@ -93,11 +93,10 @@
         </v-col>
       </v-row>
       <v-row>
-        <v-col cols="12" class="text-right">
+        <v-col cols="12" class="text-right" :class="showAllFields ? 'mt-3' : ''">
           <v-btn x-large
                  id="submit-back-btn"
                  class="mr-3"
-                 v-if="showAllFields"
                  @click="showPreviousTab()">{{ editMode ? 'Previous' : 'Back' }}</v-btn>
           <v-btn x-large
                  v-if="!isValid"

--- a/client/src/components/common/applicant-info-3.vue
+++ b/client/src/components/common/applicant-info-3.vue
@@ -137,7 +137,6 @@
           <v-btn x-large
                  id="submit-back-btn"
                  class="mr-3"
-                 v-if="showAllFields"
                  @click="showPreviousTab()">{{ editMode ? 'Previous' : 'Back' }}</v-btn>
           <v-btn x-large
                  v-if="!isValid"

--- a/client/src/components/existing-request/existing-request-display.vue
+++ b/client/src/components/existing-request/existing-request-display.vue
@@ -40,8 +40,8 @@
                 <v-col cols="12">
                   <span class="bold-text">Submit Count: </span>{{ nr.submitCount }}
                 </v-col>
-                <v-col cols="12" v-if="nr.conditions">
-                  <span class="bold-text">Condition/Consent: </span>
+                <v-col cols="12" v-if="nr.consentFlag && nr.consentFlag !== 'N'">
+                  <span class="bold-text">Consent Rec'd: </span> {{ consentDate }}
                 </v-col>
                 <v-col cols="12">
                   <span class="bold-text">Submitting Party: </span> {{ nr.applicants.lastName }},
@@ -101,6 +101,19 @@ export default class ExistingRequestDisplay extends Vue {
   get cityProvPostal () {
     let { applicants } = this.nr
     return applicants.city + ', ' + applicants.stateProvinceCd + ', ' + applicants.postalCd
+  }
+  get condition () {
+    if (this.nr.names.some(name => name.state === 'CONDITION' && name.decision_text)) {
+      let found = this.nr.names.find(name => name.state === 'CONDITION' && name.decision_text)
+      return found.decision_text
+    }
+    return ''
+  }
+  get consentDate () {
+    if (this.nr.consent_dt) {
+      return Moment(this.nr.consent_dt).utc().format('MMM Do[,] YYYY')
+    }
+    return 'Not Yet Received'
   }
   get expiryDate () {
     if (this.nr.expirationDate) {

--- a/client/src/components/existing-request/existing-request-search.vue
+++ b/client/src/components/existing-request/existing-request-search.vue
@@ -70,7 +70,7 @@ import { NameRequestI, SearchDataI, NrDataResponseT, NrDataT } from '@/models'
 })
 export default class ExistingRequstSearch extends Vue {
   emailRules = [ v => v === '' || /.+@.+\..+/.test(v) || 'Please be sure to enter a valid email' ]
-  nrRules = [ v => v.length === 7 || 'Please enter a valid NR number' ]
+  nrRules = [ v => /^[a-zA-Z]{2}((\d{7})|((\s)(\d{7})))$/.test(v) || 'Please enter a valid NR number' ]
   errorMessage: string = ''
   phoneRules = [ v => v === '' || /^[\d ()\+-]+$/.test(v) || 'Please enter a numeric value' ]
   isValid: boolean = false
@@ -99,7 +99,20 @@ export default class ExistingRequstSearch extends Vue {
     let data = this.existingRequestSearch
     return (data.nrNum && (data.emailAddress || data.phoneNumber))
   }
+  reformatNR () {
+    this.$nextTick(function () {
+      if (this.existingRequestSearch.nrNum) {
+        let number = this.existingRequestSearch.nrNum.replace(
+          /(?:\s+|\s|)(\D|\D+|)(?:\s+|\s|)(\d+)(?:\s+|\s|)/, 'NR ' + '$2'
+        )
+        if (number) {
+          this.setExistingRequestSearch('nrNum', number)
+        }
+      }
+    })
+  }
   handleSubmit () {
+    this.reformatNR()
     newReqModule.getNameRequests()
   }
   setExistingRequestSearch (key, value) {

--- a/client/src/components/modals/pick-entity.vue
+++ b/client/src/components/modals/pick-entity.vue
@@ -132,22 +132,19 @@ export default class PickEntity extends Vue {
     this.showModal = false
   }
 }
-
 </script>
-th
-  border-bottom: 1px solid grey
 
 <style lang="sass" scoped>
+th
+  border-bottom: 1px solid grey
 .no-bullet
   list-style-type: none
   margin-bottom: 8px
   line-height: 18px
-
 .yes-bullet
   list-style-position: inside
   margin-left: 30px
   line-height: 18px
-
 .clickable-cell:hover
   background-color: $grey-2
   cursor: pointer

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -947,7 +947,7 @@ export class NewRequestModule extends VuexModule {
   @Action
   async getNameRequests () {
     this.mutateDisplayedComponent('AnalyzePending')
-
+    this.mutateSubmissionType('normal')
     let params = {
       nrNum: this.existingRequestSearch.nrNum,
       phoneNumber: this.existingRequestSearch.phoneNumber,


### PR DESCRIPTION
- fixed validation on the existing request searh form so that it accepts NR numbers of various formats

- added consent flag and date to the existing-request-display component

- added back the "back" button to applicant-info-2 component

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
