### PR TITLE
entity 4782 - Bug fixes

### DIFF
--- a/client/src/components/new-request/search.vue
+++ b/client/src/components/new-request/search.vue
@@ -115,11 +115,11 @@ export default class Search extends Vue {
   }
   @Watch('request_action_cd')
   handleRequestAction (newVal) {
-    if (Object.keys(bcMapping).includes(newVal)) {
+    if (Object.keys(bcMapping).includes(newVal) && ['BC'].includes(this.location)) {
       let { value } = newReqModule.entityTypesBCData.find(ent => ent.rank === 1)
       newReqModule.mutateEntityType(value)
     }
-    if (Object.keys(xproMapping).includes(newVal)) {
+    if (Object.keys(xproMapping).includes(newVal) && ['CA', 'IN'].includes(this.location)) {
       let { value } = newReqModule.entityTypesXPROData.find(ent => ent.rank === 1)
       newReqModule.mutateEntityType(value)
     }

--- a/client/src/components/new-request/search.vue
+++ b/client/src/components/new-request/search.vue
@@ -123,7 +123,7 @@ export default class Search extends Vue {
       let { value } = newReqModule.entityTypesXPROData.find(ent => ent.rank === 1)
       newReqModule.mutateEntityType(value)
     }
-    if (['AML', 'CNV'].includes(newVal)) {
+    if (['AML', 'CNV', 'MVE'].includes(newVal)) {
       this.location = 'BC'
       return
     }

--- a/client/src/components/new-request/submit-request/reserve-submit.vue
+++ b/client/src/components/new-request/submit-request/reserve-submit.vue
@@ -6,6 +6,7 @@
 </template>
 
 <script lang="ts">
+import { xproMapping } from '@/store/list-data/request-action-mapping'
 import newReqModule from '@/store/new-request-module'
 import { Component, Vue, Prop } from 'vue-property-decorator'
 
@@ -30,6 +31,9 @@ export default class ReserveSubmitButton extends Vue {
   get location () {
     return newReqModule.location
   }
+  get entity_type_cd () {
+    return newReqModule.entity_type_cd
+  }
 
   showNextStep () {
     newReqModule.mutateDisplayedComponent('SubmissionTabs')
@@ -37,7 +41,9 @@ export default class ReserveSubmitButton extends Vue {
       newReqModule.mutateSubmissionType('examination')
       newReqModule.mutateSubmissionTabComponent('NamesCapture')
       if (this.setup === 'assumed') {
-        newReqModule.mutateRequestAction('ASSUMED')
+        if (xproMapping['ASSUMED'].includes(this.entity_type_cd)) {
+          newReqModule.mutateRequestAction('ASSUMED')
+        }
         newReqModule.mutateAssumedNameOriginal()
         return
       }

--- a/client/src/store/list-data/request-action-mapping.ts
+++ b/client/src/store/list-data/request-action-mapping.ts
@@ -8,7 +8,8 @@ export const bcMapping: RequestActionMappingI = {
   AML: ['UL', 'CR', 'CC', 'CP', 'BC'],
   REN: ['CR', 'CP', 'CC', 'UL', 'FI', 'BC'],
   REH: ['CR', 'CP', 'CC', 'UL', 'FI', 'BC'],
-  CHG: entityTypesBC.filter(ent => ent !== 'PAR' && ent !== 'PA')
+  CHG: entityTypesBC.filter(ent => ent !== 'PAR' && ent !== 'PA'),
+  MVE: ['CR', 'CC', 'CP', 'UL', 'SO', 'BC']
 }
 
 export const xproMapping: RequestActionMappingI = {

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -591,10 +591,14 @@ export class NewRequestModule extends VuexModule {
       let generateEntities = (entities) => {
         let output = []
         for (let entity of entities) {
-          let obj = entityTypesXPROData.find(ent => ent.value === entity)
+          // using this.entityTypesXPROData instead of scoped entityTypesXPROData here so that RLC can be included
+          let obj = this.entityTypesXPROData.find(ent => ent.value === entity)
           // "CR" type is shortlisted. if XCR exists in filtered entity_types, preserve its rank and shortlist keys
           if (entity === 'XCR') {
             output.push(obj)
+            continue
+          }
+          if (this.location === 'CA' && entity === 'RLC') {
             continue
           }
           let objSansRankAndShortlist = {}
@@ -658,7 +662,7 @@ export class NewRequestModule extends VuexModule {
     })
   }
   get isAssumedName () {
-    return this.request_action_cd === 'ASSUMED'
+    return !!this.assumedNameOriginal
   }
   get locationOptions () {
     let options = [
@@ -667,10 +671,10 @@ export class NewRequestModule extends VuexModule {
       { text: 'Foreign', value: 'IN' },
       { text: 'Help', value: 'INFO' }
     ]
-    if (['CNV', 'AML'].includes(this.request_action_cd)) {
+    if (['CNV', 'AML', 'MVE'].includes(this.request_action_cd)) {
       return options.filter(location => location.value === 'BC' || location.value === 'INFO')
     }
-    if (['MVE', 'ASSUMED'].includes(this.request_action_cd)) {
+    if (['ASSUMED'].includes(this.request_action_cd)) {
       return options.filter(location => location.value !== 'BC')
     }
     return options

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1452,7 +1452,7 @@ export class NewRequestModule extends VuexModule {
     this.mutateName(name)
     if (this.location === 'BC') {
       if (this.nameIsEnglish && !this.isPersonsName && !this.doNotAnalyzeEntities.includes(this.entity_type_cd)) {
-        if (['NEW', 'DBA', 'CHG'].includes(this.request_action_cd)) {
+        if (['NEW', 'DBA', 'CHG', 'MVE'].includes(this.request_action_cd)) {
           this.getNameAnalysis()
           return
         }


### PR DESCRIPTION
- Changed request_action "MVE" to only show "BC" for location options and limited it to entity_types CR, CC, CP, UL, SO and BC
-  Made sure that request_action_cd === "ASSUMED" set for only entity_types XCR, RLC, and XUL
-  Fixed the pick-entity-modal which did not display when request_action_cd === "ASSUMED" presently



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
