### PR TITLE
entity 3963

### DIFF
--- a/client/src/components/common/applicant-info-2.vue
+++ b/client/src/components/common/applicant-info-2.vue
@@ -213,16 +213,10 @@ export default class ApplicantInfo2 extends Vue {
     } else {
       const { nrNum } = this
       if (!nrNum) {
-        // eslint-disable-next-line
-        console.log('!nrNum 216 applicant-info-2')
         await newReqModule.postNameRequests('draft')
       } else {
-        // eslint-disable-next-line
-        console.log('inner else 216 applicant-info-2')
         await newReqModule.putNameReservation(nrNum)
       }
-      // eslint-disable-next-line
-      console.log('outer else 224 appliocant-info-2')
       await paymentModule.togglePaymentModal(true)
     }
   }

--- a/client/src/components/new-request/submit-request/reserve-submit.vue
+++ b/client/src/components/new-request/submit-request/reserve-submit.vue
@@ -41,7 +41,9 @@ export default class ReserveSubmitButton extends Vue {
       newReqModule.mutateSubmissionType('examination')
       newReqModule.mutateSubmissionTabComponent('NamesCapture')
       if (this.setup === 'assumed') {
-        newReqModule.mutateRequestAction('ASSUMED')
+        if (xproMapping['ASSUMED'].includes(this.entity_type_cd)) {
+          newReqModule.mutateRequestAction('ASSUMED')
+        }
         newReqModule.mutateAssumedNameOriginal()
         return
       }

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1127,8 +1127,6 @@ export class NewRequestModule extends VuexModule {
         cancelToken: source.token
       })
       let json = resp.data
-      // eslint-disable-next-line
-      console.log(json)
       this.mutateAnalysisJSON(json)
       if (Array.isArray(json.issues) && json.issues.length > 0) {
         let corpConflict = json.issues.find(issue => issue.issue_type === 'corp_conflict')


### PR DESCRIPTION
- fixed bug which was causing the request_action_cd to be set to 'ASSUMED' innapropriately.  now only sets for entity types XCR, XUL, RLC as it did previously.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
