### PR TITLE
entity 4793

### DIFF
--- a/client/src/components/new-request/stats.vue
+++ b/client/src/components/new-request/stats.vue
@@ -42,30 +42,21 @@ import { Vue, Component } from 'vue-property-decorator'
 
 @Component({})
 export default class Stats extends Vue {
-  created () {
+  created (): void {
     newReqModule.getStats()
   }
 
   get stats (): StatsI {
     return newReqModule.stats
   }
-  get autoApprovedCount () {
-    if (this.stats && this.stats.auto_approved_count) {
-      return this.stats.auto_approved_count
-    }
-    return 0
+  get autoApprovedCount (): string | number {
+    return (this.stats || {}).auto_approved_count || '0'
   }
-  get regularWaitTime () {
-    if (this.stats && this.stats.regular_wait_time) {
-      return Math.ceil(this.stats.regular_wait_time / 3600 / 24)
-    }
-    return '-'
+  get regularWaitTime (): string | number {
+    return (this.stats || {}).regular_wait_time || '-'
   }
-  get priorityWaitTime () {
-    if (this.stats && this.stats.priority_wait_time) {
-      return Math.ceil(this.stats.priority_wait_time / 3600)
-    }
-    return '-'
+  get priorityWaitTime (): string | number {
+    return (this.stats || {}).priority_wait_time || '-'
   }
 }
 

--- a/client/src/components/new-request/submit-request/reserve-submit.vue
+++ b/client/src/components/new-request/submit-request/reserve-submit.vue
@@ -19,6 +19,9 @@ export default class ReserveSubmitButton extends Vue {
   get location () {
     return newReqModule.location
   }
+  get request_action_cd () {
+    return newReqModule.request_action_cd
+  }
   get text () {
     if (this.location !== 'BC' && this.setup !== 'assumed') {
       return 'Send For Examination'
@@ -42,6 +45,7 @@ export default class ReserveSubmitButton extends Vue {
       newReqModule.mutateSubmissionTabComponent('NamesCapture')
       if (this.setup === 'assumed') {
         if (xproMapping['ASSUMED'].includes(this.entity_type_cd)) {
+          newReqModule.mutateRequestActionOriginal(this.request_action_cd)
           newReqModule.mutateRequestAction('ASSUMED')
         }
         newReqModule.mutateAssumedNameOriginal()

--- a/client/src/models.ts
+++ b/client/src/models.ts
@@ -155,6 +155,7 @@ export interface RequestActionsI {
   value: string
   blurb?: string
   rank?: number
+  shortDesc?: string
 }
 export interface RequestNameI {
   id?: number

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -2057,9 +2057,9 @@ export class NewRequestModule extends VuexModule {
   resetNameChoices () {
     for (let key in this.nameChoices) {
       Vue.set(
-      this.nameChoices,
-      key,
-      ''
+        this.nameChoices,
+        key,
+        ''
       )
     }
   }

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1544,6 +1544,8 @@ export class NewRequestModule extends VuexModule {
     this.resetApplicantDetails()
     this.resetNrData()
     this.resetRequestExaminationOrProvideConsent()
+    this.resetNameChoices()
+    this.mutateNameRequest({})
   }
   @Action
   cancelAnalyzeName () {
@@ -2050,6 +2052,16 @@ export class NewRequestModule extends VuexModule {
   @Mutation
   mutateRequestActionOriginal (action: string) {
     this.requestActionOriginal = action
+  }
+  @Mutation
+  resetNameChoices () {
+    for (let key in this.nameChoices) {
+      Vue.set(
+      this.nameChoices,
+      key,
+      ''
+      )
+    }
   }
 
   getEntities (category) {

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -442,52 +442,61 @@ export class NewRequestModule extends VuexModule {
   requestActions: RequestActionsI[] = [
     {
       text: 'Start a New',
+      shortDesc: 'New Request',
       value: 'NEW',
       blurb: `Start a new business in BC. This applies to starting fresh from here or having a business in another 
               province or country that you want to operate in BC as well.`
     },
     {
       text: 'Move your Business to BC',
+      shortDesc: 'Move Request',
       value: 'MVE',
       blurb: `You have an existing business in another province. You are closing your business there and moving your 
               business to BC.`
     },
     {
       text: 'Assume a New Name in BC',
+      shortDesc: 'Assumed Name Request',
       value: 'ASSUMED',
       blurb: `You have an existing business in another province. You are closing your business there and moving your 
               business to BC, however, the name of your business is already in use in BC`
     },
     {
       text: 'Change your Name',
+      shortDesc: 'Change of Name Request',
       value: 'CHG',
       blurb: `You have an existing business that is registered in BC and you want to change your name. You will need 
               your incorporation or firm number assigned to you by Registries.`
     },
     {
       text: 'Amalgamate',
+      shortDesc: 'Amalgamation Request',
       value: 'AML',
       blurb: 'You are merging with another company and you want a new name.'
     },
     {
       text: 'Convert to Another Structure',
+      shortDesc: 'Conversion Request',
       value: 'CNV',
       blurb: `Convert from one business structure to another. Such as converting from a ULC to a BC Corp. You will need 
               to identify your business with your Corp. #/Firm # (assigned by Registries).`
     },
     {
       text: 'Restore Using a Historical Name',
+      shortDesc: 'Restore-Historical Request',
       value: 'REH',
       blurb: 'You have a business that has been dissolved or cancelled. You want to start up again and use the same' +
         ' name. You will need your incorporation or firm number assigned to you by Registries.'
     },
     {
       text: 'Restore with a New Name',
+      shortDesc: 'Restore-New Request',
       value: 'REN',
       blurb: 'You have a business that has been dissolved or cancelled. You want to start up again with a new name.' +
         ' You will need your incorporation or firm number assigned to you by Registries.'
     }
   ]
+  requestActionOriginal: string = ''
   showActualInput: boolean = false
   stats: StatsI | null = null
   submissionTabNumber: number = 0
@@ -959,14 +968,21 @@ export class NewRequestModule extends VuexModule {
     if (this.xproRequestTypeCd) {
       data['request_type_cd'] = this.xproRequestTypeCd
     }
+    if (!data.additionalInfo) {
+      data.additionalInfo = ''
+    }
     if (this.isAssumedName) {
-      if (!data.additionalInfo) {
-        data.additionalInfo = ''
-      }
       if (!data.additionalInfo.includes('*** Registered Name:')) {
         let notice = `*** Registered Name: ${this.assumedNameOriginal} ***`
         data.additionalInfo = data.additionalInfo + ' ' + notice
       }
+    }
+    if (this.request_action_cd === 'ASSUMED' && this.requestActionOriginal) {
+      if (!data.additionalInfo) {
+        data['additionalInfo'] = ''
+      }
+      let { shortDesc } = this.requestActions.find(request => request.value === this.requestActionOriginal)
+      data.additionalInfo += ` *** ${shortDesc} ***`
     }
     return data
   }
@@ -1523,6 +1539,7 @@ export class NewRequestModule extends VuexModule {
     this.mutateAnalysisJSON(null)
     this.mutateCorpNum('')
     this.mutateEditMode(false)
+    this.mutateRequestActionOriginal('')
     this.mutateShowActualInput(false)
     this.resetApplicantDetails()
     this.resetNrData()
@@ -2029,6 +2046,10 @@ export class NewRequestModule extends VuexModule {
   @Mutation
   mutateAssumedNameOriginal () {
     this.assumedNameOriginal = this.name
+  }
+  @Mutation
+  mutateRequestActionOriginal (action: string) {
+    this.requestActionOriginal = action
   }
 
   getEntities (category) {


### PR DESCRIPTION
when request_action_cd === 'ASSUMED', we now capture the original request_action and store it in additional_info field

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
