### PR TITLE
entity tickets 4954, 4973, 5011, 5018

### DIFF
--- a/client/src/components/common/applicant-info-1.vue
+++ b/client/src/components/common/applicant-info-1.vue
@@ -307,6 +307,17 @@ export default class ApplicantInfo1 extends Vue {
     ref.focus()
   }
 
+  @Watch('xproJurisdiction')
+  watchXproJurisdiction (newVal, oldVal) {
+    if (newVal !== oldVal) {
+      if (this.editMode && newVal === this.nr.xproJurisdiction) {
+        newReqModule.mutateCorpNum(this.nr.corpNum)
+        return
+      }
+      newReqModule.mutateCorpNum('')
+    }
+  }
+
   beforeDestoy () {
     this.$el.removeEventListener('keydown', this.handleKeydown)
   }
@@ -345,6 +356,9 @@ export default class ApplicantInfo1 extends Vue {
   }
   get location () {
     return newReqModule.location
+  }
+  get nr () {
+    return newReqModule.nr
   }
   get nrData () {
     return newReqModule.nrData

--- a/client/src/components/common/applicant-info-2.vue
+++ b/client/src/components/common/applicant-info-2.vue
@@ -6,12 +6,15 @@
           Contact Info
         </v-col>
         <v-col cols="5">
+          <label for="emailAddress" class="hidden">Email Address (for notifications)</label>
           <v-text-field :messages="messages['email']"
                         :rules="emailRules"
                         :value="applicant.emailAddress"
                         @blur="messages = {}"
                         @focus="messages['email'] = 'Notification Email'"
                         @input="mutateApplicant('emailAddress', $event)"
+                        id="emailAddress"
+                        name="emailAddress"
                         filled
                         hide-details="auto"
                         placeholder="Email Address (for notifications)" />
@@ -21,21 +24,27 @@
       <v-row>
         <v-col cols="2" />
         <v-col cols="5">
+          <label for="faxNumber" class="hidden">Phone Number (Optional)</label>
           <v-text-field :messages="messages['phone']"
                         :value="applicant.phoneNumber"
                         @blur="messages = {}"
                         @focus="messages['phone'] = 'Phone Number (Optional)'"
                         @input="mutateApplicant('phoneNumber', $event)"
+                        id="phoneNumber"
+                        name="phoneNumber"
                         filled
                         hide-details="auto"
                         placeholder="Phone Number (Optional)" />
         </v-col>
         <v-col cols="5">
+          <label for="faxNumber" class="hidden">Fax Number (Optional)</label>
           <v-text-field :messages="messages['fax']"
                         :value="applicant.faxNumber"
                         @blur="messages = {}"
                         @focus="messages['fax'] = 'Fax Number (Optional)'"
                         @input="mutateApplicant('faxNumber', $event)"
+                        id="faxNumber"
+                        name="faxNumber"
                         filled
                         hide-details="auto"
                         placeholder="Fax Number (Optional)" />
@@ -46,23 +55,29 @@
           About Your Business
         </v-col>
         <v-col cols="5" align-self="start">
+          <label for="natureBusinessInfo" class="hidden">Nature of Business</label>
           <v-textarea :messages="messages['nature']"
                       :rules="requiredRule"
                       :value="nrData.natureBusinessInfo"
                       @blur="messages = {}"
                       @focus="messages['nature'] = 'Nature of Business'"
                       @input="mutateNRData('natureBusinessInfo', $event)"
+                      id="natureBusinessInfo"
+                      name="natureBusinessInfo"
                       filled
                       hide-details="auto"
                       placeholder="Nature of Business"
                       rows="3" />
         </v-col>
         <v-col cols="5" align-self="start">
+          <label for="additionalInfo" class="hidden">Additional Business Info (Optional)</label>
           <v-textarea :messages="messages['additional']"
                       :value="nrData.additionalInfo"
                       @blur="messages = {}"
                       @focus="messages['additional'] = 'Additional Info'"
                       @input="mutateNRData('additionalInfo', $event)"
+                      id="additionalInfo"
+                      name="additionalInfo"
                       filled
                       hide-details="auto"
                       placeholder="Additional Business Info (Optional)"
@@ -70,31 +85,37 @@
         </v-col>
         <v-col cols="2" />
         <v-col cols="5" v-if="showCorpNum">
-          <v-text-field :messages="messages['corpNum']"
-                        :rules="corpNumRules"
-                        :error-messages="corpNumError"
-                        validate-on-blur
-                        @blur="messages = {}"
-                        :loading="loading"
-                        @focus="messages['corpNum'] = 'Incorporation Number (required)'"
-                        filled
-                        v-on:update:error="setError"
+          <label for="corpNum" class="hidden">Incorporation Number (required)</label>
+          <v-text-field :error-messages="corpNumError"
                         :hide-details="hideCorpNum"
+                        :loading="loading"
+                        :messages="messages['corpNum']"
+                        :rules="corpNumRules"
+                        @blur="messages = {}; isEditingCorpNum = false"
+                        @focus="messages['corpNum'] = 'Incorporation Number (required)'; isEditingCorpNum = true"
+                        id="corpNum"
+                        name="corpNum"
+                        filled
                         placeholder="Incorporation Number (required)"
-                        v-model="corpNum">
+                        v-model="corpNum"
+                        v-on:update:error="setError"
+                        validate-on-blur>
             <template v-slot:append>
-              <v-icon :class="showCorpNumErrorState ? 'red--text' : 'green--text'"
-                      v-if="hideCorpNum === 'auto'">
-                {{ error || loading || corpNumDirty ? 'close' : 'check' }}</v-icon>
+              <v-icon :class="error || corpNumError || corpNumDirty ? 'red--text' : 'green--text'"
+                      v-if="hideCorpNum === 'auto' && !isEditingCorpNum && !loading">
+                {{ error || corpNumError || corpNumDirty ? 'close' : 'check' }}</v-icon>
             </template>
           </v-text-field>
         </v-col>
         <v-col cols="5">
+          <label for="tradeMark" class="hidden">Registered Trademark (Optional)</label>
           <v-text-field :messages="messages['tradeMark']"
                         :value="nrData.tradeMark"
                         @blur="messages = {}"
                         @focus="messages['tradeMark'] = 'Registered Trademark (Optional)'"
                         @input="mutateNRData('tradeMark', $event)"
+                        id="tradeMark"
+                        name="tradeMark"
                         filled
                         hide-details="auto"
                         placeholder="Registered Trademark (Optional)" />
@@ -151,6 +172,7 @@ export default class ApplicantInfo2 extends Vue {
     v => /.+@.+/.test(v) || 'Not a valid email'
   ]
   error: boolean = false
+  isEditingCorpNum: boolean = false
   isValid: boolean = false
   hideCorpNum: boolean | 'auto' = true
   loading: boolean = false
@@ -158,6 +180,14 @@ export default class ApplicantInfo2 extends Vue {
   requiredRule = [
     v => !!v || 'Required field'
   ]
+
+  @Watch('xproJurisdiction')
+  async hanldeJurisdiction (newVal, oldVal) {
+    if (newVal !== oldVal) {
+      await this.$nextTick()
+      this.validate()
+    }
+  }
 
   get applicant () {
     return newReqModule.applicant
@@ -218,12 +248,6 @@ export default class ApplicantInfo2 extends Vue {
   get showCorpNum () {
     return newReqModule.showCorpNum
   }
-  get showCorpNumErrorState () {
-    if (this.loading || this.corpNumDirty) {
-      return true
-    }
-    return !!this.corpNumError
-  }
   get showPriorityRequest () {
     return newReqModule.showPriorityRequest
   }
@@ -235,6 +259,9 @@ export default class ApplicantInfo2 extends Vue {
   }
   set submissionTabNumber (value) {
     newReqModule.mutateSubmissionTabNumber(value)
+  }
+  get xproJurisdiction () {
+    return (newReqModule.nrData || {}).xproJurisdiction
   }
 
   async submit () {
@@ -258,6 +285,7 @@ export default class ApplicantInfo2 extends Vue {
     this.corpNumError = ''
   }
   async getCorpNum (num) {
+    this.isEditingCorpNum = false
     if (!num) {
       return
     }

--- a/client/src/components/common/applicant-info-3.vue
+++ b/client/src/components/common/applicant-info-3.vue
@@ -197,6 +197,14 @@ export default class ApplicantInfo3 extends Vue {
     v => !!v || 'Required field'
   ]
 
+  @Watch('xproJurisdiction')
+  async hanldeJurisdiction (newVal, oldVal) {
+    if (newVal !== oldVal) {
+      await this.$nextTick()
+      this.validate()
+    }
+  }
+
   get applicant () {
     return newReqModule.applicant
   }
@@ -253,12 +261,6 @@ export default class ApplicantInfo3 extends Vue {
   get showCorpNum () {
     return newReqModule.showCorpNum
   }
-  get showCorpNumErrorState () {
-    if (this.loading || this.corpNumDirty) {
-      return true
-    }
-    return !!this.corpNumError
-  }
   get request_action_cd () {
     return newReqModule.request_action_cd
   }
@@ -267,6 +269,9 @@ export default class ApplicantInfo3 extends Vue {
   }
   set priorityRequest (value) {
     newReqModule.mutatePriorityRequest(value)
+  }
+  get xproJurisdiction () {
+    return (newReqModule.nrData || {}).xproJurisdiction
   }
 
   async submit () {

--- a/client/src/components/new-request/stats.vue
+++ b/client/src/components/new-request/stats.vue
@@ -42,30 +42,21 @@ import { Vue, Component } from 'vue-property-decorator'
 
 @Component({})
 export default class Stats extends Vue {
-  created () {
+  created (): void {
     newReqModule.getStats()
   }
 
   get stats (): StatsI {
     return newReqModule.stats
   }
-  get autoApprovedCount () {
-    if (this.stats && this.stats.auto_approved_count) {
-      return this.stats.auto_approved_count
-    }
-    return 0
+  get autoApprovedCount (): string | number {
+    return (this.stats || {}).auto_approved_count || '0'
   }
-  get regularWaitTime () {
-    if (this.stats && this.stats.regular_wait_time) {
-      return Math.ceil(this.stats.regular_wait_time / 3600 / 24)
-    }
-    return '-'
+  get regularWaitTime (): string | number {
+    return (this.stats || {}).regular_wait_time || '-'
   }
-  get priorityWaitTime () {
-    if (this.stats && this.stats.priority_wait_time) {
-      return Math.ceil(this.stats.priority_wait_time / 3600)
-    }
-    return '-'
+  get priorityWaitTime (): string | number {
+    return (this.stats || {}).priority_wait_time || '-'
   }
 }
 

--- a/client/src/components/new-request/submit-request/entity-cannot-be-auto-analyzed.vue
+++ b/client/src/components/new-request/submit-request/entity-cannot-be-auto-analyzed.vue
@@ -54,7 +54,27 @@ export default class EntityCannotBeAutoAnalyzed extends Vue {
       this.englishOnlyName = this.name.split('/')[0]
     }
   }
+
+  get nameAnalysisTimedOut () {
+    return newReqModule.nameAnalysisTimedOut
+  }
   get boxes () {
+    let timeoutExplanation1 = {
+      title: 'Option 1',
+      class: 'square-card-x2',
+      button: 'examine',
+      text:
+      'This name cannot be auto-analyzed and will need to be reviewed by a name examiner.' +
+      ' Please check the wait times listed at the top of' +
+      ' the screen.  Rush services are also available.'
+    }
+    let timeoutExplanation2 = {
+      title: 'Option 2',
+      class: 'square-card-x2',
+      button: 'restart',
+      text: 'You can enter a different name and try your search again.  Click the button below to cancel this request' +
+      'and start again.'
+    }
     let entityExplanation = {
       title: 'Option 2',
       class: 'square-card-x2',
@@ -89,6 +109,9 @@ export default class EntityCannotBeAutoAnalyzed extends Vue {
       class: 'square-card-x2',
       button: 'examine',
       text: 'You can choose to submit this name to examination. Please check wait times at the top of the screen.'
+    }
+    if (this.nameAnalysisTimedOut) {
+      return [timeoutExplanation1, timeoutExplanation2]
     }
     if (this.requestActionNotSupported) {
       return [requestActionExplanation]
@@ -142,6 +165,9 @@ export default class EntityCannotBeAutoAnalyzed extends Vue {
     return newReqModule.requestTextFromValue
   }
   get title () {
+    if (this.nameAnalysisTimedOut) {
+      return 'Your name took too long to analyze'
+    }
     if (this.requestActionNotSupported) {
       return `Name requests to <b>${this.requestActionText}</b> cannot be auto-analyzed and must be sent<br> to
       examination for review`

--- a/client/src/components/new-request/submit-request/reserve-submit.vue
+++ b/client/src/components/new-request/submit-request/reserve-submit.vue
@@ -19,6 +19,9 @@ export default class ReserveSubmitButton extends Vue {
   get location () {
     return newReqModule.location
   }
+  get request_action_cd () {
+    return newReqModule.request_action_cd
+  }
   get text () {
     if (this.location !== 'BC' && this.setup !== 'assumed') {
       return 'Send For Examination'
@@ -42,6 +45,7 @@ export default class ReserveSubmitButton extends Vue {
       newReqModule.mutateSubmissionTabComponent('NamesCapture')
       if (this.setup === 'assumed') {
         if (xproMapping['ASSUMED'].includes(this.entity_type_cd)) {
+          newReqModule.mutateRequestActionOriginal(this.request_action_cd)
           newReqModule.mutateRequestAction('ASSUMED')
         }
         newReqModule.mutateAssumedNameOriginal()

--- a/client/src/models.ts
+++ b/client/src/models.ts
@@ -155,6 +155,7 @@ export interface RequestActionsI {
   value: string
   blurb?: string
   rank?: number
+  shortDesc?: string
 }
 export interface RequestNameI {
   id?: number

--- a/client/src/sass/main.sass
+++ b/client/src/sass/main.sass
@@ -285,6 +285,10 @@
   color: $link
   cursor: pointer
 
+.hidden
+  visibility: hidden !important
+  display: none !important
+
 // @bizpal/open-services-bst imports Buefy which uses the .container class name which conflicts with vuetify
 // the following CSS fixes the issues from including the open-services-bst
 #landing-container, .container


### PR DESCRIPTION
#### 4954
- Removed "Additional Services" row when ***Priority Request*** is not an option in applicant-info forms

#### 4973
- Now records the original `request_action_cd` in `additionalInfo` field when ***`"ASSUMED"`*** is assigned

#### 5011
- Increased axios request timeout failure threshold to 180000ms (3 mins) for requests made to ***`/name-analysis`*** and ***`/xpro-name-analysis`***
- Added messaging to divert user to name examination if their requests times out

#### 5018
- Added logic to clear the `corpNum` field when the `xproJurisdiction` field is cleared or changed and to ensure the form maintains proper validated/unvalidated state


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
