### PR TITLE
entity 4529, 5047, 5055

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -5,6 +5,7 @@
       <router-view />
     </div>
     <!--All v-dialogue (modal) components App-wide-->
+    <Conditions />
     <LocationInfoModal />
     <HelpMeChoose />
     <NrNotRequired />
@@ -19,6 +20,7 @@
 </template>
 
 <script lang="ts">
+import Conditions from '@/components/modals/conditions.vue'
 import HelpMeChoose from '@/components/modals/help-me-choose.vue'
 import LocationInfoModal from '@/components/modals/location-info.vue'
 import NrNotRequired from '@/components/modals/nr-not-required.vue'
@@ -37,6 +39,7 @@ import Header from '@/components/header.vue'
 
 @Component({
   components: {
+    Conditions,
     Header,
     LocationInfoModal,
     NrNotRequired,

--- a/client/src/components/existing-request/existing-request-display.vue
+++ b/client/src/components/existing-request/existing-request-display.vue
@@ -1,5 +1,5 @@
 <template>
-  <MainContainer id="analyze-pending-container">
+  <MainContainer id="existing-request-display">
     <template v-slot:container-header>
       <v-col cols="auto">
         <b>Your search returned the following Name Request:</b>
@@ -18,6 +18,10 @@
               <v-icon v-if="getNameFormating(name).icon" :class="getNameFormating(name).class"
                       style="font-size: 20px; position: relative; top: -3px;">
                 {{ getNameFormating(name).icon }}</v-icon>
+              <a class="link-sm ml-3"
+                 @click.prevent="showConditionsModal"
+                 href="#"
+                 v-if="name.state === 'CONDITION'">Conditions</a>
             </div>
           </div>
         </v-col>
@@ -179,6 +183,9 @@ export default class ExistingRequestDisplay extends Vue {
       return
     }
     newReqModule.patchNameRequestsByAction(action)
+  }
+  showConditionsModal () {
+    newReqModule.mutateConditionsModalVisible(true)
   }
   upgrade () {
     if (!this.priorityReq) {

--- a/client/src/components/modals/conditions.vue
+++ b/client/src/components/modals/conditions.vue
@@ -1,0 +1,47 @@
+<template>
+  <v-dialog v-model="showModal" max-width="40%">
+    <v-card class="pa-9">
+      <v-card-text class="h4">{{ nameObject.name }}</v-card-text>
+      <v-card-text class="h5 my-n2">Has been approved, subject to the following conditions:</v-card-text>
+      <v-card-text class="copy-normal">
+        <div class="pre-line px-2 pt-2 mb-n6">
+          {{ nameObject.decision_text }}
+        </div>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn text id="nr-required-close-btn" @click="showModal = false">Close</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import newReqModule from '@/store/new-request-module'
+import { Component, Vue } from 'vue-property-decorator'
+
+@Component({})
+export default class ConditionsModal extends Vue {
+  get nameObject () {
+    if (this.nrNames.some(name => name.state === 'CONDITION' && name.decision_text)) {
+      return this.nrNames.find(name => name.state === 'CONDITION' && name.decision_text)
+    }
+    return {}
+  }
+  get showModal () {
+    return newReqModule.conditionsModalVisible
+  }
+  set showModal (value: boolean) {
+    newReqModule.mutateConditionsModalVisible(value)
+  }
+  get nrNames () {
+    return newReqModule.nrNames
+  }
+}
+
+</script>
+
+<style lang="sass" scoped>
+.pre-line
+  white-space: pre-line
+</style>

--- a/client/src/components/modals/conditions.vue
+++ b/client/src/components/modals/conditions.vue
@@ -23,7 +23,7 @@ import { Component, Vue } from 'vue-property-decorator'
 @Component({})
 export default class ConditionsModal extends Vue {
   get nameObject () {
-    if (this.nrNames.some(name => name.state === 'CONDITION' && name.decision_text)) {
+    if ((this.nrNames || []).some(name => name.state === 'CONDITION' && name.decision_text)) {
       return this.nrNames.find(name => name.state === 'CONDITION' && name.decision_text)
     }
     return {}

--- a/client/src/store/list-data/request-action-mapping.ts
+++ b/client/src/store/list-data/request-action-mapping.ts
@@ -15,7 +15,8 @@ export const bcMapping: RequestActionMappingI = {
 export const xproMapping: RequestActionMappingI = {
   ASSUMED: ['XCR', 'RLC', 'XUL'],
   REN: ['XCR', 'XCP', 'RLC', 'XUL'],
-  REH: ['XCR', 'XCP', 'RLC', 'XUL']
+  REH: ['XCR', 'XCP', 'RLC', 'XUL'],
+  AML: ['XCR', 'XCP', 'XUL', 'XLP', 'XLL', 'XSO']
 }
 
 export const $colinRequestActions = ['AML', 'CHG', 'REH', 'REN']

--- a/client/src/store/list-data/request-action-mapping.ts
+++ b/client/src/store/list-data/request-action-mapping.ts
@@ -16,7 +16,7 @@ export const xproMapping: RequestActionMappingI = {
   ASSUMED: ['XCR', 'RLC', 'XUL'],
   REN: ['XCR', 'XCP', 'RLC', 'XUL'],
   REH: ['XCR', 'XCP', 'RLC', 'XUL'],
-  AML: ['XCR', 'XCP', 'XUL', 'XLP', 'XLL', 'XSO']
+  AML: ['XCR', 'XCP', 'XUL']
 }
 
 export const $colinRequestActions = ['AML', 'CHG', 'REH', 'REN']

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -144,6 +144,7 @@ export class NewRequestModule extends VuexModule {
   }
   assumedNameOriginal: string = ''
   changesInBaseName: boolean = false
+  conditionsModalVisible: boolean = false
   conflictId: string | null = null
   conversionType: string = ''
   conversionTypeAddToSelect: ConversionTypesI | null = null
@@ -2141,6 +2142,10 @@ export class NewRequestModule extends VuexModule {
   @Mutation
   mutateNameAnalysisTimedOut (value: boolean) {
     this.nameAnalysisTimedOut = value
+  }
+  @Mutation
+  mutateConditionsModalVisible (value: boolean) {
+    this.conditionsModalVisible = value
   }
 
   getEntities (category) {

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -627,7 +627,8 @@ export class NewRequestModule extends VuexModule {
     let consentWords = []
     for (let step in this.requestExaminationOrProvideConsent) {
       if (this.requestExaminationOrProvideConsent[step].obtain_consent) {
-        consentWords.push(this.analysisJSON.issues[step].name_actions[0].word)
+        let words = this.analysisJSON.issues[step].name_actions.map(action => action.word)
+        consentWords = consentWords.concat(words)
       }
     }
     return consentWords


### PR DESCRIPTION
#### 4529
- now have a conditions button to show name's decision_text when applicable.  launches conditions modal.

#### 5055
- removed RLC from the possible entity type options when Foreign -> AML is selected

#### 5047
- now submit multiple consent words if there are more than one.
- fixed a bug in earlier commit

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
