### PR TITLE
entity 4702 + 5079

### DIFF
--- a/client/src/components/common/applicant-info-1.vue
+++ b/client/src/components/common/applicant-info-1.vue
@@ -9,6 +9,7 @@
           <!--FIRST NAME, LAST NAME, MIDDLE NAME-->
           <v-row>
             <v-col cols="4">
+              <label for="lastname" class="hidden">Last Name</label>
               <v-text-field :messages="messages['lastName']"
                             :rules="requiredRules"
                             :value="applicant.lastName"
@@ -20,23 +21,27 @@
                             height="50"
                             hide-details="auto"
                             id="lastname"
+                            name="lastname"
                             placeholder="Last Name" />
             </v-col>
             <v-col cols="4" >
+              <label for="firstname" class="hidden">First Name</label>
               <v-text-field :messages="messages['firstName']"
                             :rules="requiredRules"
                             :value="applicant.firstName"
-                            @blur="message21s = {}"
+                            @blur="messages = {}"
                             @focus="handleFocus('firstName', 'First Name')"
                             @input="updateApplicant('firstName', $event)"
                             dense
                             filled
                             height="50"
                             hide-details="auto"
-                            id="firstName"
+                            id="firstname"
+                            name="firstname"
                             placeholder="First Name" />
             </v-col>
             <v-col cols="4">
+              <label for="middlename" class="hidden">Middle Name (Optional)</label>
               <v-text-field :messages="messages['middleName']"
                             :value="applicant.middleName"
                             @blur="messages = {}"
@@ -46,6 +51,8 @@
                             filled
                             height="50"
                             hide-details="auto"
+                            id="middlename"
+                            name="middlename"
                             placeholder="Middle Name (Optional)" />
             </v-col>
           </v-row>
@@ -72,7 +79,8 @@
                                 filled
                                 height="50"
                                 hide-details="auto"
-                                id="Line1"
+                                id="line1"
+                                name="Street Address"
                                 placeholder="Start typing an address here..."
                                 ref="Line1"
                                 single-line />
@@ -96,17 +104,17 @@
                                style="cursor: pointer"
                                v-for="(address, i) of addressSuggestions">
                     <a :ref="address.Id"
-                       href="#"
-                       @focus="highlightedSuggestion = address.Id"
                        @click.prevent="queryAddress(address.Id)"
-                       class="link-sm-dk-text">{{ address.Text + ', ' + address.Description }}</a>
+                       @focus="highlightedSuggestion = address.Id"
+                       class="link-sm-dk-text"
+                       href="#">{{ address.Text + ', ' + address.Description }}</a>
                   </v-list-item>
                   <v-divider class="mb-2"/>
                   <v-list-item>
                     <v-container class="ma-0 pa-0 copy-small">
                       <v-row>
                         <v-col class="ma-0 px-6 pb-4 text-right"
-                               align-self="center"><h5>Country</h5></v-col>
+                               align-self="center"><label class="h5" for="country2">Country</label></v-col>
                         <v-col cols="5" class="ma-0 pa-0"><v-select :items="countryOptions"
                                                                     :menu-props="{ auto: true, eager: true }"
                                                                     :value="applicant.countryTypeCd"
@@ -117,7 +125,8 @@
                                                                     eager
                                                                     filled
                                                                     hide-details
-                                                                    id="Country2"
+                                                                    id="country2"
+                                                                    name="country2"
                                                                     ref="Country2" />
                         </v-col>
                       </v-row>
@@ -129,6 +138,7 @@
           </v-row>
           <v-row class="mt-2" v-if="applicant.addrLine1 && !showAddressMenu">
             <v-col cols="12" class="py-0 my-0">
+              <label for="line2" class="hidden">Additional Street Address (Optional)</label>
               <v-text-field :messages="messages['Line2']"
                             :value="applicant.addrLine2"
                             @blur="messages = {}"
@@ -138,13 +148,15 @@
                             filled
                             height="50"
                             hide-details="auto"
-                            id="Line2"
+                            id="1ine2"
+                            name="line2"
                             placeholder="Additional Street Address (Optional)"
                             ref="Line2" />
             </v-col>
           </v-row>
           <v-row class="mt-2" v-if="(applicant.addrLine2 || applicant.addrLine3) && !showAddressMenu">
             <v-col cols="12" class="py-0 my-0">
+              <label for="line3" class="hidden">Additional Street Address (Optional)</label>
               <v-text-field :messages="messages['Line3']"
                             :value="applicant.addrLine3"
                             @blur="messages = {}"
@@ -154,15 +166,16 @@
                             filled
                             height="50"
                             hide-details="auto"
-                            id="Line3"
+                            id="line3"
+                            name="line3"
                             placeholder="Additional Street Address (Optional)"
                             ref="Line3" />
             </v-col>
           </v-row>
           <v-row class="mt-2">
             <v-col cols="6" class="py-0 my-0">
-              <v-text-field
-                            :messages="messages['City']"
+              <label for="city" class="hidden">City</label>
+              <v-text-field :messages="messages['City']"
                             :rules="requiredRules"
                             :value="applicant.city"
                             @blur="messages = {}"
@@ -172,7 +185,8 @@
                             filled
                             height="50"
                             hide-details="auto"
-                            id="City"
+                            id="city"
+                            name="city"
                             placeholder="City"
                             ref="City"
               />
@@ -180,9 +194,12 @@
             <v-col cols="6" class="py-0 my-0" v-if="applicant.countryTypeCd === 'CA'">
               <label for="province" class="hidden">Province</label>
               <v-select :items="provinceOptions"
+                        :messages="messages['Province']"
                         :rules="requiredRules"
                         :value="applicant.stateProvinceCd"
                         @input="updateApplicant('stateProvinceCd', $event)"
+                        @blur="messages = {}"
+                        @focus="handleFocus('Province', 'Province')"
                         dense
                         filled
                         height="50"
@@ -195,9 +212,12 @@
             <v-col cols="6" class="py-0 my-0" v-else-if="applicant.countryTypeCd === 'US'">
               <label for="state" class="hidden">State</label>
               <v-select :items="$USAStateCodes"
+                        :messages="messages['State']"
                         :rules="requiredRules"
                         :value="applicant.stateProvinceCd"
                         @input="updateApplicant('stateProvinceCd', $event)"
+                        @blur="messages = {}"
+                        @focus="handleFocus('State', 'State')"
                         dense
                         filled
                         height="50"
@@ -208,67 +228,77 @@
                         ref="state" />
             </v-col>
             <v-col cols="6" class="py-0 my-0" v-else>
-              <label for="state" class="hidden">Province/State (Optional, 2 letter code)</label>
-              <v-text-field
-                        :rules="provStateRules"
-                        :value="applicant.stateProvinceCd"
-                        @input="updateApplicant('stateProvinceCd', $event)"
-                        dense
-                        filled
-                        height="50"
-                        hide-details="auto"
-                        id="state"
-                        name="state"
-                        placeholder="Province/State (Optional, 2 letter code)"
-                        ref="state" />
-            </v-col>
-          </v-row>
-          <v-row class="mt-2">
-            <v-col cols="6" class="py-0 my-0">
-              <v-select :items="countryOptions"
-                        :rules="requiredRules"
-                        dense
-                        :menu-props="{eager: true, auto: true}"
-                        filled
-                        eager
-                        cache-items
-                        height="50"
-                        hide-details="auto"
-                        id="Country"
-                        placeholder="Country"
-                        ref="Country"
-                        @input="updateApplicant('countryTypeCd', $event)"
-                        :value="applicant.countryTypeCd" />
-            </v-col>
-            <v-col cols="6" class="py-0 my-0">
-              <v-text-field :messages="messages['PostalCode']"
-                            :rules="requiredRules"
+              <label for="state" class="hidden">Province/State (Optional, 2 letters max)</label>
+              <v-text-field :messages="messages['Province']"
+                            :rules="provStateRules"
+                            :value="applicant.stateProvinceCd"
                             @blur="messages = {}"
-                            @focus="handleFocus('PostalCode', 'Postal / Zip Code')"
+                            @focus="handleFocus('Province', 'Province/State (Optional, 2 letters max)')"
+                            @input="updateApplicant('stateProvinceCd', $event)"
                             dense
                             filled
                             height="50"
                             hide-details="auto"
-                            placeholder="Postal/Zip Code"
+                            id="state"
+                            name="state"
+                            placeholder="Province/State (Optional, 2 letters max)"
+                            ref="state" />
+            </v-col>
+          </v-row>
+          <v-row class="mt-2">
+            <v-col cols="6" class="py-0 my-0">
+              <label for="country" class="hidden">Country</label>
+              <v-select :items="countryOptions"
+                        :menu-props="{eager: true, auto: true}"
+                        :rules="requiredRules"
+                        :value="applicant.countryTypeCd"
+                        @input="updateApplicant('countryTypeCd', $event)"
+                        cache-items
+                        dense
+                        eager
+                        filled
+                        height="50"
+                        hide-details="auto"
+                        id="country"
+                        name="country"
+                        placeholder="Country"
+                        ref="Country" />
+            </v-col>
+            <v-col cols="6" class="py-0 my-0">
+              <label for="postalcode" class="hidden">Postal/Zip Code</label>
+              <v-text-field :messages="messages['PostalCode']"
+                            :rules="requiredRules"
+                            :value="applicant.postalCd"
+                            @blur="messages = {}"
+                            @focus="handleFocus('PostalCode', 'Postal / Zip Code')"
                             @input="updateApplicant('postalCd', $event)"
-                            :value="applicant.postalCd" />
+                            dense
+                            filled
+                            height="50"
+                            hide-details="auto"
+                            id="postalcode"
+                            name="postalcode"
+                            placeholder="Postal/Zip Code" />
             </v-col>
           </v-row>
           <v-row class="mt-2" v-if="showXproJurisdiction && showAllFields">
             <v-col cols="6" class="py-0 my-0">
+              <label for="xprojurisdiction" class="hidden">Business Jurisdiction</label>
               <v-select :messages="messages['xproJurisdiction']"
+                        :items="jurisdictionOptions"
                         :rules="requiredRules"
+                        :value="nrData.xproJurisdiction"
                         @blur="messages = {}"
                         @focus="handleFocus('xproJurisdiction', 'Business xproJurisdiction')"
+                        @input="updateBusinessInfo('xproJurisdiction', $event)"
                         dense
-                        filled
                         eager
-                        :items="jurisdictionOptions"
+                        filled
                         height="50"
                         hide-details="auto"
-                        placeholder="Business xproJurisdiction"
-                        @input="updateBusinessInfo('xproJurisdiction', $event)"
-                        :value="nrData.xproJurisdiction" />
+                        id="xprojurisdiction"
+                        name="xprojurisdiction"
+                        placeholder="Business Jurisdiction" />
             </v-col>
             <v-col cols="6" class="py-0 my-0" />
           </v-row>
@@ -313,7 +343,7 @@ export default class ApplicantInfo1 extends Vue {
   ]
   provStateRules = [
     v => typeof v === 'string' || 'Must be letters only',
-    v => v.length === 2 || 'Max 2 characters'
+    v => v.length <= 2 || 'Max 2 characters'
   ]
   showAddressMenu: boolean = false
   step1Valid: boolean = false
@@ -454,6 +484,9 @@ export default class ApplicantInfo1 extends Vue {
     if (!this.showAddressMenu) {
       return event
     }
+    if (this.showAddressMenu && event.key === 'Escape') {
+      this.showAddressMenu = false
+    }
     if (this.addressSuggestions && this.showAddressMenu) {
       if (event.key === 'Tab') {
         event.preventDefault()
@@ -487,6 +520,7 @@ export default class ApplicantInfo1 extends Vue {
         this.queryAddress(this.highlightedSuggestion)
         this.showAddressMenu = false
       }
+      return event
     }
   }
   queryAddress (id) {

--- a/client/src/components/existing-request/existing-request-search.vue
+++ b/client/src/components/existing-request/existing-request-search.vue
@@ -99,20 +99,7 @@ export default class ExistingRequstSearch extends Vue {
     let data = this.existingRequestSearch
     return (data.nrNum && (data.emailAddress || data.phoneNumber))
   }
-  reformatNR () {
-    this.$nextTick(function () {
-      if (this.existingRequestSearch.nrNum) {
-        // let number = this.existingRequestSearch.nrNum.trim().replace(/((([Nn][Rr])(\s*))|^(\d+))/, 'NR' + '$5')
-        // TODO: Reformat number if necessary, API will accept whatever format
-        let number = this.existingRequestSearch.nrNum
-        if (number) {
-          this.setExistingRequestSearch('nrNum', number)
-        }
-      }
-    })
-  }
   handleSubmit () {
-    this.reformatNR()
     newReqModule.getNameRequests()
   }
   setExistingRequestSearch (key, value) {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -14,6 +14,7 @@ import '@/sass/overrides.sass'
 import designations from '@/store/list-data/designations'
 import canJurisdictions from '@/store/list-data/canada-jurisdictions'
 import intJurisdictions from '@/store/list-data/intl-jurisdictions'
+import USAStateCodes from '@/store/list-data/us-states'
 
 Vue.config.productionTip = true
 Vue.config.devtools = true
@@ -23,6 +24,7 @@ async function startVue () {
   Vue.prototype.$canJurisdictions = canJurisdictions
   Vue.prototype.$intJurisdictions = intJurisdictions
   Vue.prototype.$PAYMENT_PORTAL_URL = await getConfig()
+  Vue.prototype.$USAStateCodes = USAStateCodes
 
   // // configure Keycloak Service
   // await KeyCloakService.setKeycloakConfigUrl(sessionStorage.getItem('KEYCLOAK_CONFIG_PATH'))

--- a/client/src/models.ts
+++ b/client/src/models.ts
@@ -12,6 +12,7 @@ export interface AnalysisJSONI {
 export interface ApplicantI {
   addrLine1: string
   addrLine2?: string
+  addrLine3?: string
   city: string
   clientFirstName?: string
   clientLastName?: string

--- a/client/src/sass/main.sass
+++ b/client/src/sass/main.sass
@@ -286,7 +286,6 @@
   cursor: pointer
 
 .hidden
-  visibility: hidden !important
   display: none !important
 
 // @bizpal/open-services-bst imports Buefy which uses the .container class name which conflicts with vuetify

--- a/client/src/store/list-data/intl-jurisdictions.ts
+++ b/client/src/store/list-data/intl-jurisdictions.ts
@@ -40,11 +40,6 @@ const jurisdictions = [
     "text": "UNITED STATES MINOR OUTLYING ISLANDS"
   },
   {
-    "value": "US",
-    "SHORT_DESC": "UNITED STATES",
-    "text": "UNITED STATES"
-  },
-  {
     "value": "UY",
     "SHORT_DESC": "URUGUAY",
     "text": "URUGUAY"
@@ -142,7 +137,7 @@ const jurisdictions = [
   {
     "value": "VG",
     "text": "VIRGIN ISLANDS",
-    "LONG_DESC": ""
+    "SHORT_DESC": "VIRGIN ISLANDS"
   },
   {
     "value": "WF",
@@ -358,11 +353,6 @@ const jurisdictions = [
     "value": "CM",
     "SHORT_DESC": "CAMEROON",
     "text": "CAMEROON"
-  },
-  {
-    "value": "CA",
-    "SHORT_DESC": "CANADA",
-    "text": "CANADA"
   },
   {
     "value": "CV",
@@ -1267,5 +1257,20 @@ let jurisdictionsSorted = jurisdictions.sort((a, b) => {
     return 0
   }
 })
+
+let canUSA = [
+  {
+    "value": "CA",
+    "SHORT_DESC": "CANADA",
+    "text": "CANADA"
+  },
+  {
+    "value": "US",
+    "SHORT_DESC": "UNITED STATES",
+    "text": "UNITED STATES"
+  }
+]
+
+jurisdictionsSorted = canUSA.concat(jurisdictionsSorted)
 
 export default jurisdictionsSorted

--- a/client/src/store/list-data/us-states.ts
+++ b/client/src/store/list-data/us-states.ts
@@ -1,0 +1,269 @@
+const USAStateCodes = [
+  {
+    text: 'Alabama',
+    SHORT_DESC: 'Alabama',
+    value: 'AL'
+  },
+  {
+    text: 'Alaska',
+    SHORT_DESC: 'Alaska',
+    value: 'AK'
+  },
+  {
+    text: 'Arizona',
+    SHORT_DESC: 'Arizona',
+    value: 'AZ'
+  },
+  {
+    text: 'Arkansas',
+    SHORT_DESC: 'Arkansas',
+    value: 'AR'
+  },
+  {
+    text: 'California',
+    SHORT_DESC: 'California',
+    value: 'CA'
+  },
+  {
+    text: 'Colorado',
+    SHORT_DESC: 'Colorado',
+    value: 'CO'
+  },
+  {
+    text: 'Connecticut',
+    SHORT_DESC: 'Connecticut',
+    value: 'CT'
+  },
+  {
+    text: 'Delaware',
+    SHORT_DESC: 'Delaware',
+    value: 'DE'
+  },
+  {
+    text: 'District of Columbia',
+    SHORT_DESC: 'District of Columbia',
+    value: 'DC'
+  },
+  {
+    text: 'Florida',
+    SHORT_DESC: 'Florida',
+    value: 'FL'
+  },
+  {
+    text: 'Georgia',
+    SHORT_DESC: 'Georgia',
+    value: 'GA'
+  },
+  {
+    text: 'Hawaii',
+    SHORT_DESC: 'Hawaii',
+    value: 'HI'
+  },
+  {
+    text: 'Idaho',
+    SHORT_DESC: 'Idaho',
+    value: 'ID'
+  },
+  {
+    text: 'Illinois',
+    SHORT_DESC: 'Illinois',
+    value: 'IL'
+  },
+  {
+    text: 'Indiana',
+    SHORT_DESC: 'Indiana',
+    value: 'IN'
+  },
+  {
+    text: 'Iowa',
+    SHORT_DESC: 'Iowa',
+    value: 'IA'
+  },
+  {
+    text: 'Kansas',
+    SHORT_DESC: 'Kansas',
+    value: 'KS'
+  },
+  {
+    text: 'Kentucky',
+    SHORT_DESC: 'Kentucky',
+    value: 'KY'
+  },
+  {
+    text: 'Louisiana',
+    SHORT_DESC: 'Louisiana',
+    value: 'LA'
+  },
+  {
+    text: 'Maine',
+    SHORT_DESC: 'Maine',
+    value: 'ME'
+  },
+  {
+    text: 'Maryland',
+    SHORT_DESC: 'Maryland',
+    value: 'MD'
+  },
+  {
+    text: 'Massachusetts',
+    SHORT_DESC: 'Massachusetts',
+    value: 'MA'
+  },
+  {
+    text: 'Michigan',
+    SHORT_DESC: 'Michigan',
+    value: 'MI'
+  },
+  {
+    text: 'Minnesota',
+    SHORT_DESC: 'Minnesota',
+    value: 'MN'
+  },
+  {
+    text: 'Mississippi',
+    SHORT_DESC: 'Mississippi',
+    value: 'MS'
+  },
+  {
+    text: 'Missouri',
+    SHORT_DESC: 'Missouri',
+    value: 'MO'
+  },
+  {
+    text: 'Montana',
+    SHORT_DESC: 'Montana',
+    value: 'MT'
+  },
+  {
+    text: 'Nebraska',
+    SHORT_DESC: 'Nebraska',
+    value: 'NE'
+  },
+  {
+    text: 'Nevada',
+    SHORT_DESC: 'Nevada',
+    value: 'NV'
+  },
+  {
+    text: 'New Hampshire',
+    SHORT_DESC: 'New Hampshire',
+    value: 'NH'
+  },
+  {
+    text: 'New Jersey',
+    SHORT_DESC: 'New Jersey',
+    value: 'NJ'
+  },
+  {
+    text: 'New Mexico',
+    SHORT_DESC: 'New Mexico',
+    value: 'NM'
+  },
+  {
+    text: 'New York',
+    SHORT_DESC: 'New York',
+    value: 'NY'
+  },
+  {
+    text: 'North Carolina',
+    SHORT_DESC: 'North Carolina',
+    value: 'NC'
+  },
+  {
+    text: 'North Dakota',
+    SHORT_DESC: 'North Dakota',
+    value: 'ND'
+  },
+  {
+    text: 'Ohio',
+    SHORT_DESC: 'Ohio',
+    value: 'OH'
+  },
+  {
+    text: 'Oklahoma',
+    SHORT_DESC: 'Oklahoma',
+    value: 'OK'
+  },
+  {
+    text: 'Oregon',
+    SHORT_DESC: 'Oregon',
+    value: 'OR'
+  },
+  {
+    text: 'Pennsylvania',
+    SHORT_DESC: 'Pennsylvania',
+    value: 'PA'
+  },
+  {
+    text: 'Puerto Rico',
+    SHORT_DESC: 'Puerto Rico',
+    value: 'PR'
+  },
+  {
+    text: 'Rhode Island',
+    SHORT_DESC: 'Rhode Island',
+    value: 'RI'
+  },
+  {
+    text: 'South Carolina',
+    SHORT_DESC: 'South Carolina',
+    value: 'SC'
+  },
+  {
+    text: 'South Dakota',
+    SHORT_DESC: 'South Dakota',
+    value: 'SD'
+  },
+  {
+    text: 'Tennessee',
+    SHORT_DESC: 'Tennessee',
+    value: 'TN'
+  },
+  {
+    text: 'Texas',
+    SHORT_DESC: 'Texas',
+    value: 'TX'
+  },
+  {
+    text: 'Utah',
+    SHORT_DESC: 'Utah',
+    value: 'UT'
+  },
+  {
+    text: 'Vermont',
+    SHORT_DESC: 'Vermont',
+    value: 'VT'
+  },
+  {
+    text: 'Virginia',
+    SHORT_DESC: 'Virginia',
+    value: 'VA'
+  },
+  {
+    text: 'Virgin Islands',
+    SHORT_DESC: 'Virgin Islands',
+    value: 'VI'
+  },
+  {
+    text: 'Washington',
+    SHORT_DESC: 'Washington',
+    value: 'WA'
+  },
+  {
+    text: 'West Virginia',
+    SHORT_DESC: 'West Virginia',
+    value: 'WV'
+  },
+  {
+    text: 'Wisconsin',
+    SHORT_DESC: 'Wisconsin',
+    value: 'WI'
+  },
+  {
+    text: 'Wyoming',
+    SHORT_DESC: 'Wyoming',
+    value: 'WY'
+  }
+]
+
+export default USAStateCodes

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -128,6 +128,7 @@ export class NewRequestModule extends VuexModule {
   applicant: ApplicantI = {
     addrLine1: '',
     addrLine2: '',
+    addrLine3: '',
     city: '',
     clientFirstName: '',
     clientLastName: '',

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1341,8 +1341,8 @@ export class NewRequestModule extends VuexModule {
   }
   @Action
   async getNameRequests () {
+    this.resetAnalyzeName()
     this.mutateDisplayedComponent('AnalyzePending')
-    this.mutateSubmissionType('normal')
     let params = {
       nrNum: this.existingRequestSearch.nrNum,
       phoneNumber: this.existingRequestSearch.phoneNumber,
@@ -1637,6 +1637,7 @@ export class NewRequestModule extends VuexModule {
     this.mutateCorpNum('')
     this.mutateEditMode(false)
     this.mutateRequestActionOriginal('')
+    this.mutateSubmissionType('normal')
     this.mutateShowActualInput(false)
     this.resetApplicantDetails()
     this.resetNrData()

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -552,7 +552,7 @@ export class NewRequestModule extends VuexModule {
     if (this.location === 'BC' && this.request_action_cd === 'CNV') {
       return 'colin'
     }
-    let mrasEntities = ['XUL', 'XCR', 'XCP', 'UL', 'CR', 'CP', 'BC', 'CC']
+    let mrasEntities = ['XUL', 'XCR', 'XLP', 'UL', 'CR', 'CP', 'BC', 'CC']
     let { xproJurisdiction } = this.nrData
 
     if ($mrasJurisdictions.includes(xproJurisdiction) && mrasEntities.includes(this.entity_type_cd)) {


### PR DESCRIPTION
## entity 4702
- changes to accomdate 3-letter or greater ProvinceCodes or ProvinceName only being returned by AddressComplete
- changes to clear out the form between AddressComplete searches
- added the US states to the static data and use for state dropdown when country === US
- other improvements to AddressSearch form handling
## entity 5079
- logic to add the *** {{Request Action}} *** message to the request with the **PUT, POST and PATCH** to `/namerequests` without duplication and updating existing message on edit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
