### PR TITLE
entity 5122

### DIFF
--- a/client/src/components/common/applicant-info-1.vue
+++ b/client/src/components/common/applicant-info-1.vue
@@ -383,7 +383,7 @@ export default class ApplicantInfo1 extends Vue {
     this.$el.addEventListener('keydown', this.handleKeydown)
     // CanadaPost Address Complete needs a country to begin working right away, assume Canada
     if (!this.editMode) {
-      this.updateApplicant('countryTypeCd', 'CA')
+      newReqModule.updateApplicantDetails({ key: 'countryTypeCd', value: 'CA' })
       return
     }
   }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -15,6 +15,7 @@ import designations from '@/store/list-data/designations'
 import canJurisdictions from '@/store/list-data/canada-jurisdictions'
 import intJurisdictions from '@/store/list-data/intl-jurisdictions'
 import USAStateCodes from '@/store/list-data/us-states'
+import * as mapping from '@/store/list-data/request-action-mapping'
 
 Vue.config.productionTip = true
 Vue.config.devtools = true
@@ -25,6 +26,7 @@ async function startVue () {
   Vue.prototype.$intJurisdictions = intJurisdictions
   Vue.prototype.$PAYMENT_PORTAL_URL = await getConfig()
   Vue.prototype.$USAStateCodes = USAStateCodes
+  Vue.prototype.$xproMapping = mapping.xproMapping
 
   // // configure Keycloak Service
   // await KeyCloakService.setKeycloakConfigUrl(sessionStorage.getItem('KEYCLOAK_CONFIG_PATH'))

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1702,6 +1702,7 @@ export class NewRequestModule extends VuexModule {
   }
   @Action
   resetAnalyzeName () {
+    this.clearAssumedNameOriginal()
     this.mutateAnalysisJSON(null)
     this.mutateCorpNum('')
     this.mutateEditMode(false)
@@ -2239,7 +2240,10 @@ export class NewRequestModule extends VuexModule {
   mutateConditionsModalVisible (value: boolean) {
     this.conditionsModalVisible = value
   }
-
+  @Mutation
+  clearAssumedNameOriginal () {
+    this.assumedNameOriginal = ''
+  }
   getEntities (category) {
     return this.entityTypesBC.filter(type => type.cat === category)
   }

--- a/client/src/vue.d.ts
+++ b/client/src/vue.d.ts
@@ -11,11 +11,17 @@ export interface JurisdictionI {
   SHORT_DESC: string
 }
 
+export interface MappingI {
+  ASSUMED: string[]
+  [propname: string]: string[]
+}
+
 declare module 'vue/types/vue' {
   interface Vue {
     $PAYMENT_PORTAL_URL?: string
     $designations: DesignationI[]
     $canJurisdictions: JurisdictionI[]
     $intJurisdictions: JurisdictionI[]
+    $xproMapping: MappingI[]
   }
 }

--- a/client/tests/unit/reserve-submit.spec.ts
+++ b/client/tests/unit/reserve-submit.spec.ts
@@ -2,45 +2,295 @@ import ReserveSubmit from '@/components/new-request/submit-request/reserve-submi
 import { createLocalVue, shallowMount } from '@vue/test-utils'
 import newReqModule from '@/store/new-request-module'
 import Vuetify from 'vuetify'
+import sinon from 'sinon'
+import { xproMapping } from '@/store/list-data/request-action-mapping'
 
 const localVue = createLocalVue()
 const vuetify = new Vuetify()
 
 localVue.use(Vuetify)
 
-describe('reserve-submit.vue', () => {
-  it('renders a Send For Examination button', () => {
-    let wrapper = shallowMount(ReserveSubmit, {
-      vuetify,
-      localVue,
-      propsData: {
-        setup: 'examine'
-      }
+async function provideWrapper (setup) {
+  let wrapper = shallowMount(ReserveSubmit, {
+    localVue,
+    vuetify,
+    mocks: {
+      $xproMapping: xproMapping
+    },
+    propsData: {
+      setup
+    }
+
+  })
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+let sandbox = sinon.createSandbox()
+
+describe('reserve-submit', () => {
+  describe('Case: it handles the NORMAL route (!setup) properly', () => {
+    sandbox.spy(newReqModule, 'postNameRequests')
+    let wrapper: any
+
+    beforeEach(async (done) => {
+      wrapper = await provideWrapper('')
+      done()
     })
-    expect(wrapper.html()).toContain('Send for Examination')
+    afterAll(() => {
+      newReqModule.mutateLocation('BC')
+    })
+    afterEach(() => {
+      sandbox.reset()
+      wrapper.destroy()
+    })
+    test('The button is labelled "Reserve and Continue"', async () => {
+      await newReqModule.mutateLocation('BC')
+      wrapper.vm.$nextTick()
+      expect(wrapper.text()).toBe('Reserve and Continue')
+    })
+    describe('If location === "BC", it acts as a RESERVED name', () => {
+      test('postNameRequests("reserved") is called with correct argument', async () => {
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.postNameRequests.calledOnce).toBeTruthy()
+        expect(newReqModule.postNameRequests.getCall(0).args[0] === 'reserved').toBeTruthy()
+      })
+      test('submissionType is set to "normal"', async () => {
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionType === 'normal').toBeTruthy()
+      })
+      test('The UI displays Applicant-Info-1', async () => {
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionTabNumber === 2).toBeTruthy()
+      })
+    })
+    describe('If location !== "BC", it sends to examination', async () => {
+      test('postNameRequests is not called', async () => {
+        newReqModule.mutateLocation('CA')
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.postNameRequests.calledOnce).toBeFalsy()
+      })
+      test('submissionType is set to "examination"', async () => {
+        newReqModule.mutateLocation('CA')
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionType === 'examination').toBeTruthy()
+      })
+      test('The UI displays NamesCapture', async () => {
+        newReqModule.mutateLocation('CA')
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionTabNumber === 1).toBeTruthy()
+      })
+    })
   })
 
-  it('renders a conditional reserve button', () => {
-    let wrapper = shallowMount(ReserveSubmit, {
-      localVue,
-      vuetify,
-      propsData: {
-        setup: 'consent'
-      }
+  describe('Case: it handles the CONDITIONAL route (setup === "consent") properly', () => {
+    let wrapper: any
+    beforeEach(async (done) => {
+      wrapper = await provideWrapper('consent')
+      done()
     })
-    expect(wrapper.html()).toContain('Conditionally Reserve')
-    expect(wrapper.html()).toContain(`color=\"red\"`)
+    afterEach(() => {
+      sandbox.reset()
+      wrapper.destroy()
+    })
+    test('The button is labelled "Conditionally Reserve"', () => {
+      expect(wrapper.html()).toContain('Conditionally Reserve')
+    })
+    describe('If location === "BC", it acts as a RESERVED-CONDITION name', () => {
+      test('postNameRequests("conditional") is called with correct argument', async () => {
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.postNameRequests.calledOnce).toBeTruthy()
+        expect(newReqModule.postNameRequests.getCall(0).args[0] === 'conditional').toBeTruthy()
+      })
+      test('submissionType is set to "consent"', async () => {
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionType === 'consent').toBeTruthy()
+      })
+      test('The UI displays Applicant-Info-1', async () => {
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionTabNumber === 2).toBeTruthy()
+      })
+    })
+    describe('If location !== "BC", it sends to examination', () => {
+      test('postNameRequests is not called', async () => {
+        newReqModule.mutateLocation('CA')
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.postNameRequests.calledOnce).toBeFalsy()
+      })
+      test('submissionType is set to "examination"', async () => {
+        newReqModule.mutateLocation('CA')
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionType === 'examination').toBeTruthy()
+      })
+      test('The UI displays NamesCapture', async () => {
+        newReqModule.mutateLocation('CA')
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionTabNumber === 1).toBeTruthy()
+      })
+    })
   })
 
-  it('renders a conditional reserve button', () => {
-    let wrapper = shallowMount(ReserveSubmit, {
-      localVue,
-      vuetify,
-      propsData: {
-        setup: 'consent'
-      }
+  describe('Case: it handles the EXAMINATION route (setup === "examine") properly', () => {
+    let wrapper: any
+    beforeEach(async (done) => {
+      wrapper = await provideWrapper('examine')
+      done()
     })
-    expect(wrapper.html()).toContain('Conditionally Reserve')
-    expect(wrapper.html()).toContain(`color=\"red\"`)
+    afterEach(() => {
+      sandbox.reset()
+      wrapper.destroy()
+    })
+    test('The button is labelled "Send for Examination"', () => {
+      expect(wrapper.text()).toBe('Send for Examination')
+    })
+    describe('If location === "BC", it sends to examination', () => {
+      newReqModule.mutateLocation('BC')
+      test('postNameRequests is not called', async () => {
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.postNameRequests.calledOnce).toBeFalsy()
+      })
+      test('submissionType is set to "examination"', async () => {
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionType === 'examination').toBeTruthy()
+      })
+      test('The UI displays NamesCapture', async () => {
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionTabNumber === 1).toBeTruthy()
+      })
+    })
+    describe('If location !== "BC", it sends to examination', () => {
+      test('postNameRequests is not called', async () => {
+        newReqModule.mutateLocation('CA')
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.postNameRequests.calledOnce).toBeFalsy()
+      })
+      test('submissionType is set to "examination"', async () => {
+        newReqModule.mutateLocation('CA')
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionType === 'examination').toBeTruthy()
+      })
+      test('The UI displays NamesCapture', async () => {
+        newReqModule.mutateLocation('CA')
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionTabNumber === 1).toBeTruthy()
+      })
+    })
+  })
+
+  describe('Case: it handles the ASSUMED route (setup === "assumed") properly', () => {
+    let wrapper: any
+    newReqModule.mutateName('Original Assumed Name Ltd.')
+
+    beforeEach(async (done) => {
+      wrapper = await provideWrapper('assumed')
+      done()
+    })
+    afterAll(() => {
+      sandbox.restore()
+    })
+    afterEach(() => {
+      sandbox.reset()
+      wrapper.destroy()
+    })
+    test('The button is labelled "Continue"', () => {
+      expect(wrapper.text()).toBe('Assume a name in BC')
+    })
+
+    for (let code of ['XCR', 'RLC', 'XUL']) {
+      let createTest = async () => {
+        describe(`If the entity_type_cd is ${code}`, () => {
+          newReqModule.mutateLocation('CA')
+          newReqModule.mutateEntityType(`${code}`)
+          test('postNameRequests is not called', async () => {
+            wrapper.vm.handleSubmit()
+            await wrapper.vm.$nextTick()
+            expect(newReqModule.postNameRequests.calledOnce).toBeFalsy()
+            newReqModule.mutateRequestAction('NEW')
+          })
+          test('request_action_cd is set to "ASSUMED"', async () => {
+            newReqModule.mutateRequestAction('NEW')
+            wrapper.vm.handleSubmit()
+            await wrapper.vm.$nextTick()
+            expect(newReqModule.request_action_cd === 'ASSUMED').toBeTruthy()
+          })
+          test(`requestActionOriginal is set to the original request type`, async () => {
+            newReqModule.mutateRequestAction('NEW')
+            wrapper.vm.handleSubmit()
+            await wrapper.vm.$nextTick()
+            expect(newReqModule.requestActionOriginal === 'NEW').toBeTruthy()
+          })
+          test(`assumedNameOriginal is set to newReqModule.name`, async () => {
+            wrapper.vm.handleSubmit()
+            await wrapper.vm.$nextTick()
+            expect(newReqModule.assumedNameOriginal === newReqModule.name).toBeTruthy()
+          })
+          test('submissionType is set to "examination"', async () => {
+            newReqModule.mutateLocation('CA')
+            wrapper.vm.handleSubmit()
+            await wrapper.vm.$nextTick()
+            expect(newReqModule.submissionType === 'examination').toBeTruthy()
+          })
+          test('The UI displays NamesCapture', async () => {
+            newReqModule.mutateLocation('CA')
+            wrapper.vm.handleSubmit()
+            await wrapper.vm.$nextTick()
+            expect(newReqModule.submissionTabNumber === 1).toBeTruthy()
+          })
+        })
+      }
+      createTest()
+    }
+    describe('If the entity_type_cd is not one that can be ASSUMED', () => {
+      newReqModule.mutateLocation('CA')
+      newReqModule.mutateName('Another Test Name Ltd.')
+      test('requestActionOriginal is not set', async () => {
+        newReqModule.mutateEntityType('XCP')
+        newReqModule.mutateRequestActionOriginal('')
+        await wrapper.vm.$nextTick()
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.requestActionOriginal).toBeFalsy()
+      })
+      test('request_action_cd !== "ASSUMED"', async () => {
+        newReqModule.mutateEntityType('XCP')
+        newReqModule.mutateRequestAction('NEW')
+        await wrapper.vm.$nextTick()
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.request_action_cd === 'ASSUMED').toBeFalsy()
+      })
+      test('assumedNameOriginal is set to newRequestModule.name', async () => {
+        expect(newReqModule.assumedNameOriginal === newReqModule.name).toBeTruthy()
+      })
+      test('submissionType is set to "examination"', async () => {
+        newReqModule.mutateLocation('CA')
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionType === 'examination').toBeTruthy()
+      })
+      test('The UI displays NamesCapture', async () => {
+        newReqModule.mutateLocation('CA')
+        wrapper.vm.handleSubmit()
+        await wrapper.vm.$nextTick()
+        expect(newReqModule.submissionTabNumber === 1).toBeTruthy()
+      })
+    })
   })
 })


### PR DESCRIPTION
Refactored reserve-submit.vue
- corrected issues with displaying the NamesCapture component
- fixed logic in handleSubmit method

Wrote detailed/useful tests for aforementioned component

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
