### PR TITLE
Entity 5174

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1097,6 +1097,24 @@
         }
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
@@ -1855,6 +1873,269 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.24.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.3.tgz",
+      "integrity": "sha512-6eW9fUhEbR423FZvoHRwbWm9RUUByLWGayYFNVvqTnQLYvsNpBS4uEuKH9aqr3trhxFwGVneJUonehL3B1sHJw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.1",
+        "pretty-format": "^26.4.2"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@jest/types": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.7",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+          "integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "dev": true,
+              "requires": {
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+              "dev": true,
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "dev": true,
+              "requires": {
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+              "dev": true,
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/vue": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/vue/-/vue-5.1.0.tgz",
+      "integrity": "sha512-RuV63Ywys7rhF+UpdSKpFrcQfyiGj9ecxAL76HCOCGbtlXdyqUbGegZ+vZpC22scTCSxmr42l0g0gJEyp00W+g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "@testing-library/dom": "^7.24.3",
+        "@types/testing-library__vue": "^5.0.0",
+        "@vue/test-utils": "^1.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@vue/test-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.1.0.tgz",
+          "integrity": "sha512-M+3jtVqNYIrvzO5gaxogre5a5+96h0hN/dXw+5Lj0t+dp6fAhYcUjpLrC9j9cEEkl2Rcuh/gKYRUmR5N4vcqPw==",
+          "dev": true,
+          "requires": {
+            "dom-event-types": "^1.0.0",
+            "lodash": "^4.17.15",
+            "pretty": "^2.0.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.8",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.8.tgz",
@@ -2012,6 +2293,122 @@
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
+    },
+    "@types/testing-library__vue": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__vue/-/testing-library__vue-5.0.0.tgz",
+      "integrity": "sha512-R94Vv9UfDoW/Vvb+ZBsy9evZO7utmFhEoe4F7+Xo8G/DpO5TZM/BdL07zkF3sjqWSyRhbHYHwXIrPwJAXQZGHg==",
+      "dev": true,
+      "requires": {
+        "@testing-library/dom": "^7.5.7",
+        "@vue/test-utils": "^1.0.3",
+        "pretty-format": "^25.5.0",
+        "vue": "^2.6.10",
+        "vue-router": "^3.0",
+        "vuex": "^3.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.7",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+          "integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "@vue/test-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.1.0.tgz",
+          "integrity": "sha512-M+3jtVqNYIrvzO5gaxogre5a5+96h0hN/dXw+5Lj0t+dp6fAhYcUjpLrC9j9cEEkl2Rcuh/gKYRUmR5N4vcqPw==",
+          "dev": true,
+          "requires": {
+            "dom-event-types": "^1.0.0",
+            "lodash": "^4.17.15",
+            "pretty": "^2.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "@types/webpack-env": {
       "version": "1.15.2",
@@ -2776,9 +3173,9 @@
       "dev": true
     },
     "@vue/test-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0.tgz",
-      "integrity": "sha512-lB0xDlOAGrmQZXZEWDbmfTWy2zE1BKfbbyR6dxlgiunm149it1JTghD6zfruBU+ujm7vW8YHWgx62O57VK4JOg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.1.0.tgz",
+      "integrity": "sha512-M+3jtVqNYIrvzO5gaxogre5a5+96h0hN/dXw+5Lj0t+dp6fAhYcUjpLrC9j9cEEkl2Rcuh/gKYRUmR5N4vcqPw==",
       "dev": true,
       "requires": {
         "dom-event-types": "^1.0.0",
@@ -3251,6 +3648,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -3344,14 +3751,15 @@
       }
     },
     "asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
       },
       "dependencies": {
         "bn.js": {
@@ -4000,9 +4408,9 @@
       "dev": true
     },
     "bn.js": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-      "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+      "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
       "dev": true
     },
     "body-parser": {
@@ -4310,16 +4718,16 @@
       }
     },
     "browserify-sign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.0.tgz",
-      "integrity": "sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
       "dev": true,
       "requires": {
         "bn.js": "^5.1.1",
         "browserify-rsa": "^4.0.1",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.5.3",
         "inherits": "^2.0.4",
         "parse-asn1": "^5.1.5",
         "readable-stream": "^3.6.0",
@@ -5585,9 +5993,9 @@
       "dev": true
     },
     "copy-webpack-plugin": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
-      "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
+      "integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.3",
@@ -5600,7 +6008,7 @@
         "normalize-path": "^3.0.0",
         "p-limit": "^2.2.1",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^4.0.0",
         "webpack-log": "^2.0.0"
       },
       "dependencies": {
@@ -5708,6 +6116,12 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -5753,13 +6167,13 @@
       "integrity": "sha512-AS21pllCp72LmUztqXPVKXK3TRyap1XlohGLqN04cXH2rFB9vo7SnH5sMnqltZPnu9ie/x1se3UuCZJbGXErfw=="
     },
     "create-ecdh": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "elliptic": "^6.5.3"
       },
       "dependencies": {
         "bn.js": {
@@ -6614,6 +7028,12 @@
         "esutils": "^2.0.2",
         "isarray": "^1.0.0"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.3.tgz",
+      "integrity": "sha512-yfqzAi1GFxK6EoJIZKgxqJyK6j/OjEFEUi2qkNThD/kUhoCFSG1izq31B5xuxzbJBGw9/67uPtkPMYAzWL7L7Q==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -7604,9 +8024,9 @@
       "dev": true
     },
     "events": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
       "dev": true
     },
     "eventsource": {
@@ -13324,14 +13744,13 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
       "dev": true,
       "requires": {
-        "asn1.js": "^4.0.0",
+        "asn1.js": "^5.2.0",
         "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
@@ -13457,9 +13876,9 @@
       }
     },
     "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -15502,10 +15921,13 @@
       }
     },
     "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "serve-index": {
       "version": "1.9.1",
@@ -16769,16 +17191,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -16794,6 +17216,15 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
           }
         },
         "source-map": {
@@ -18041,6 +18472,74 @@
         "makeerror": "1.0.x"
       }
     },
+    "watchpack": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+      "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.4.1",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+          "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.4.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true,
+          "optional": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "watchpack-chokidar2": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
@@ -18185,9 +18684,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
-      "integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
+      "version": "4.44.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
+      "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
@@ -18215,33 +18714,6 @@
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "chokidar": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-          "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.4.0"
-          }
-        },
         "enhanced-resolve": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
@@ -18265,23 +18737,6 @@
             }
           }
         },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true,
-          "optional": true
-        },
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -18291,28 +18746,6 @@
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        },
-        "watchpack": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
-          "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
-          "dev": true,
-          "requires": {
-            "chokidar": "^3.4.1",
-            "graceful-fs": "^4.1.2",
-            "neo-async": "^2.5.0",
-            "watchpack-chokidar2": "^2.0.0"
           }
         }
       }

--- a/client/package.json
+++ b/client/package.json
@@ -31,6 +31,7 @@
     "vuex-class": "^0.3.2"
   },
   "devDependencies": {
+    "@testing-library/vue": "^5.1.0",
     "@types/jest": "^24.9.0",
     "@types/sinon": "^7.5.1",
     "@vue/cli-plugin-babel": "^4.0.0",
@@ -42,7 +43,7 @@
     "@vue/cli-service": "^4.2.3",
     "@vue/eslint-config-standard": "^4.0.0",
     "@vue/eslint-config-typescript": "^4.0.0",
-    "@vue/test-utils": "^1.0.0-beta.30",
+    "@vue/test-utils": "^1.1.0",
     "cross-env": "^7.0.0",
     "eslint": "^5.16.0",
     "eslint-plugin-vue": "^5.0.0",

--- a/client/src/components/existing-request/existing-request-display.vue
+++ b/client/src/components/existing-request/existing-request-display.vue
@@ -201,9 +201,6 @@ export default class ExistingRequestDisplay extends Vue {
   }
 
   async handleButtonClick (action) {
-    if (this.disableUnfurnished) {
-      return
-    }
     let outcome = await newReqModule.confirmAction(action)
     if (outcome) {
       switch (action) {

--- a/client/src/components/existing-request/existing-request-display.vue
+++ b/client/src/components/existing-request/existing-request-display.vue
@@ -26,60 +26,68 @@
           </div>
         </v-col>
       </v-row>
-      <v-row style="background-color: rgba(165,205,230,0.31)" class="mx-1">
-        <v-col cols="12"
-               class="copy-normal font-italic"
+      <transition mode="out-in" name="fade">
+        <v-row style="background-color: rgba(165,205,230,0.31)"
+               :key="furnished"
+               class="mx-1"
                v-if="disableUnfurnished">
-          We are currently processing your request.
-          Please click <a class="link" href="#" @click.prevent="refresh">Refresh</a> after 5 mins to enable all the
-          buttons below.
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col cols="12">
-          <v-row class="pt-3">
-            <v-col cols="9">
-              <v-row dense class="mt-n5">
-                <v-col cols="12">
-                  <span class="fw-700">Last Update: </span> {{ lastUpdate }}
-                </v-col>
-                <v-col cols="12">
-                  <span class="fw-700">Status: </span> {{ nr.state }}
-                </v-col>
-                <v-col cols="12">
-                  <span class="fw-700">Priority Request: </span> {{ priorityReq ? 'Yes' : 'No' }}
-                </v-col>
-                <v-col cols="12">
-                  <span class="fw-700">Expiry Date: </span> {{ expiryDate }}
-                </v-col>
-                <v-col cols="12">
-                  <span class="fw-700">Submit Count: </span>{{ nr.submitCount }}
-                </v-col>
-                <v-col cols="12" v-if="nr.consentFlag && nr.consentFlag !== 'N'">
-                  <span class="fw-700">Consent Rec'd: </span> {{ consentDate }}
-                </v-col>
-                <v-col cols="12">
-                  <span class="fw-700">Submitting Party: </span> {{ nr.applicants.lastName }},
-                  {{ nr.applicants.firstName }}
-                </v-col>
-                <v-col cols="12">
-                  <span class="fw-700">Address: </span> {{ address }}
-                </v-col>
-              </v-row>
-            </v-col>
-            <v-col cols="3" v-if="nr.state !== 'CANCELLED'">
-              <v-row dense>
-                <v-col cols="12" v-for="action of actions" :key="action+'-button'">
-                  <v-btn @click="handleButtonClick(action)"
-                         block
-                         :disabled="disableUnfurnished && action !== 'RECEIPT'">{{ action }}</v-btn>
-                </v-col>
-                <!--<v-btn @click="activateILModal">incorporate now</v-btn>-->
-              </v-row>
-            </v-col>
-          </v-row>
-        </v-col>
-      </v-row>
+          <v-col cols="12"
+                 key="initial-msg"
+                 class="copy-normal font-italic">
+            We are currently processing your request.
+            Click<a class="link" href="#" @click.prevent="refresh"> Refresh </a>
+            {{ $route.query && $route.query.paymentId ? '' : 'or retry your search ' }}
+            after 5 mins to enable all the buttons below.
+          </v-col>
+        </v-row>
+      </transition>
+      <transition mode="out-in" name="fade">
+        <v-row :key="refreshCount">
+          <v-col cols="12">
+            <v-row class="pt-3">
+              <v-col cols="9">
+                <v-row dense class="mt-n5">
+                  <v-col cols="12">
+                    <span class="fw-700">Last Update: </span> {{ lastUpdate }}
+                  </v-col>
+                  <v-col cols="12">
+                    <span class="fw-700">Status: </span> {{ nr.state }}
+                  </v-col>
+                  <v-col cols="12">
+                    <span class="fw-700">Priority Request: </span> {{ priorityReq ? 'Yes' : 'No' }}
+                  </v-col>
+                  <v-col cols="12">
+                    <span class="fw-700">Expiry Date: </span> {{ expiryDate }}
+                  </v-col>
+                  <v-col cols="12">
+                    <span class="fw-700">Submit Count: </span>{{ nr.submitCount }}
+                  </v-col>
+                  <v-col cols="12" v-if="nr.consentFlag && nr.consentFlag !== 'N'">
+                    <span class="fw-700">Consent Rec'd: </span> {{ consentDate }}
+                  </v-col>
+                  <v-col cols="12">
+                    <span class="fw-700">Submitting Party: </span> {{ nr.applicants.lastName }},
+                    {{ nr.applicants.firstName }}
+                  </v-col>
+                  <v-col cols="12">
+                    <span class="fw-700">Address: </span> {{ address }}
+                  </v-col>
+                </v-row>
+              </v-col>
+              <v-col cols="3" v-if="nr.state !== 'CANCELLED'">
+                <v-row dense>
+                  <v-col cols="12" v-for="action of actions" :key="action+'-button'">
+                    <v-btn @click="handleButtonClick(action)"
+                           block
+                           :disabled="disableUnfurnished && action !== 'RECEIPT'">{{ action }}</v-btn>
+                  </v-col>
+                  <!--<v-btn @click="activateILModal">incorporate now</v-btn>-->
+                </v-row>
+              </v-col>
+            </v-row>
+          </v-col>
+        </v-row>
+      </transition>
     </template>
   </MainContainer>
 </template>
@@ -97,7 +105,13 @@ import paymentModule from '@/modules/payment'
 })
 export default class ExistingRequestDisplay extends Vue {
   daysBeforeExpiry: number = 5
-
+  checking: boolean = false
+  refreshCount: number = 0
+  furnished: string = 'notfurnished'
+  mounted () {
+    // eslint-disable-next-line
+    console.log(this.$route.query)
+  }
   get actions () {
     return this.nr.actions
   }
@@ -228,8 +242,19 @@ export default class ExistingRequestDisplay extends Vue {
     await newReqModule.cancelEditExistingRequest()
     newReqModule.cancelAnalyzeName()
   }
-  refresh (event) {
-    window.location.assign(this.$route.fullPath)
+  async refresh (event) {
+    this.refreshCount += 1
+    this.checking = true
+    try {
+      let resp = await newReqModule.getNameRequest(this.nr.id)
+      this.checking = false
+      if (resp.furnished === 'Y') {
+        this.furnished = 'furnished'
+        newReqModule.setNrResponse(resp)
+      }
+    } catch (error) {
+      this.checking = false
+    }
   }
   showConditionsModal () {
     newReqModule.mutateConditionsModalVisible(true)

--- a/client/src/components/existing-request/existing-request-display.vue
+++ b/client/src/components/existing-request/existing-request-display.vue
@@ -6,14 +6,7 @@
       </v-col>
     </template>
     <template v-slot:content>
-      <v-row align="center" v-if="showUnfurnishedError" class="mt-5 mb-5">
-        <v-col cols="12" class="h4 text-center">We are currently updating the status of your NR</v-col>
-        <v-col cols="12" class="text-center mt-n2">Please allow 5 minutes before trying your search again.</v-col>
-        <v-col cols="12" class="text-center">
-          <v-btn @click="goBack">Go Back</v-btn>
-        </v-col>
-      </v-row>
-      <v-row align="start" v-if="nr.nrNum && !showUnfurnishedError">
+      <v-row align="start" v-if="nr.nrNum">
         <v-col cols="auto" class="fs-24">
           <span class="h3 mr-2">{{ nr.nrNum }}</span>
         </v-col>
@@ -32,6 +25,17 @@
             </div>
           </div>
         </v-col>
+      </v-row>
+      <v-row style="background-color: rgba(165,205,230,0.31)" class="mx-1">
+        <v-col cols="12"
+               class="copy-normal font-italic"
+               v-if="disableUnfurnished">
+          We are currently processing your request.
+          Please click <a class="link" href="#" @click.prevent="refresh">Refresh</a> after 5 mins to enable all the
+          buttons below.
+        </v-col>
+      </v-row>
+      <v-row>
         <v-col cols="12">
           <v-row class="pt-3">
             <v-col cols="9">
@@ -66,7 +70,9 @@
             <v-col cols="3" v-if="nr.state !== 'CANCELLED'">
               <v-row dense>
                 <v-col cols="12" v-for="action of actions" :key="action+'-button'">
-                  <v-btn block @click="handleButtonClick(action)">{{ action }}</v-btn>
+                  <v-btn @click="handleButtonClick(action)"
+                         block
+                         :disabled="disableUnfurnished && action !== 'RECEIPT'">{{ action }}</v-btn>
                 </v-col>
                 <!--<v-btn @click="activateILModal">incorporate now</v-btn>-->
               </v-row>
@@ -145,7 +151,7 @@ export default class ExistingRequestDisplay extends Vue {
     let nameObj = this.nr.names.find(name => name.choice === 1)
     return nameObj.name
   }
-  get showUnfurnishedError (): boolean {
+  get disableUnfurnished (): boolean {
     return (['CONDITIONAL', 'REJECTED', 'APPROVED'].includes(this.nr.stateCd) && this.nr.furnished === 'N')
   }
   get names () {
@@ -195,7 +201,7 @@ export default class ExistingRequestDisplay extends Vue {
   }
 
   async handleButtonClick (action) {
-    if (this.showUnfurnishedError) {
+    if (this.disableUnfurnished) {
       return
     }
     let outcome = await newReqModule.confirmAction(action)
@@ -224,6 +230,9 @@ export default class ExistingRequestDisplay extends Vue {
   async goBack () {
     await newReqModule.cancelEditExistingRequest()
     newReqModule.cancelAnalyzeName()
+  }
+  refresh (event) {
+    window.location.assign(this.$route.fullPath)
   }
   showConditionsModal () {
     newReqModule.mutateConditionsModalVisible(true)

--- a/client/src/components/existing-request/invalid-action-message.vue
+++ b/client/src/components/existing-request/invalid-action-message.vue
@@ -54,7 +54,6 @@ export default class InvalidActionMessage extends Vue {
   }
 
   async goBack () {
-    await newReqModule.editExistingRequest()
     newReqModule.setActiveComponent('ExistingRequestDisplay')
   }
 }

--- a/client/src/components/existing-request/invalid-action-message.vue
+++ b/client/src/components/existing-request/invalid-action-message.vue
@@ -1,0 +1,61 @@
+<template>
+  <v-row class="my-3 py-3">
+    <v-col cols="12" class="text-center h4">
+      {{ details.heading }}
+    </v-col>
+    <v-col cols="12" class="text-center copy-normal mt-n2 mb-2" v-html="details.details" />
+    <v-col cols="12" class="text-center">
+      <v-btn @click="goBack">Return to NR Summary</v-btn>
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import newReqModule from '@/store/new-request-module'
+import { Component, Vue, Watch } from 'vue-property-decorator'
+import MainContainer from '@/components/new-request/main-container.vue'
+
+@Component({
+  components: { MainContainer }
+})
+export default class InvalidActionMessage extends Vue {
+  /* mounted () {
+    setTimeout(() => {
+      newReqModule.mutateDisplayedComponent('ExistingRequestDisplay')
+    }, 10000)
+  } */
+  get nr () {
+    return newReqModule.nr
+  }
+  get stateCd (): string {
+    return ((this.nr || {}).stateCd) || ''
+  }
+  get details () {
+    switch (this.stateCd) {
+      case 'APPROVED':
+      case 'CONDITIONAL':
+      case 'REJECTED':
+        return {
+          heading: 'We have finished examining your Name Request',
+          details: `Your request has been ${this.stateCd === 'CONDITIONAL' ? 'CONDITIONALLY APPROVED' : this.stateCd}`
+        }
+      case 'CANCELLED':
+        return {
+          heading: 'Unfortunately your Name Request has been CANCELLED',
+          details: 'Please contact <i>Registries and Online Services</i> at 250-387-7848 if you require ' +
+           'further assistance.'
+        }
+      default:
+        return {
+          heading: 'Your Name Request is currently being examined',
+          details: 'Please check back later to see the result.'
+        }
+    }
+  }
+
+  async goBack () {
+    await newReqModule.editExistingRequest()
+    newReqModule.setActiveComponent('ExistingRequestDisplay')
+  }
+}
+</script>

--- a/client/src/components/new-request/submit-request/submission-tabs.vue
+++ b/client/src/components/new-request/submit-request/submission-tabs.vue
@@ -27,6 +27,9 @@
             <ApplicantInfo2 v-if="actingOnOwnBehalf" />
             <ApplicantInfo3 v-else />
           </v-tab-item>
+          <v-tab-item>
+            <InvalidActionMessage />
+          </v-tab-item>
         </v-tabs-items>
       </v-tabs>
     </template>
@@ -40,6 +43,7 @@ import ApplicantInfo2 from '../../common/applicant-info-2.vue'
 import ApplicantInfo3 from '../../common/applicant-info-3.vue'
 import EntityCannotBeAutoAnalyzed from './entity-cannot-be-auto-analyzed.vue'
 import NamesCapture from '../../common/names-capture.vue'
+import InvalidActionMessage from '../../existing-request/invalid-action-message.vue'
 import newReqModule from '@/store/new-request-module'
 import { Component, Vue } from 'vue-property-decorator'
 
@@ -50,7 +54,8 @@ import { Component, Vue } from 'vue-property-decorator'
     NamesCapture,
     ApplicantInfo1,
     ApplicantInfo2,
-    MainContainer
+    MainContainer,
+    InvalidActionMessage
   }
 })
 export default class SubmissionTabs extends Vue {

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1379,18 +1379,12 @@ export class NewRequestModule extends VuexModule {
   }
   @Action
   async confirmAction (action: string) {
-    // eslint-disable-next-line
-    console.log('confirm action called')
     try {
       let resp = await this.getNameRequest(this.nr.id)
       this.mutateNameRequest(resp)
       if (!resp.actions.includes(action)) {
-        // eslint-disable-next-line
-        console.log('no way jose')
         return false
       }
-      // eslint-disable-next-line
-      console.log('good 2 go')
       return true
     } catch (error) {
       if (error instanceof ApiError) {
@@ -1475,8 +1469,6 @@ export class NewRequestModule extends VuexModule {
     } catch (err) {
       // eslint-disable-next-line
       console.log(err)
-      // eslint-disable-next-line
-      console.log('error')
       return data
     }
   }

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1381,7 +1381,7 @@ export class NewRequestModule extends VuexModule {
   async confirmAction (action: string) {
     try {
       let resp = await this.getNameRequest(this.nr.id)
-      this.mutateNameRequest(resp)
+      this.setNrResponse(resp)
       if (!resp.actions.includes(action)) {
         return false
       }

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1,3 +1,4 @@
+import ExistingRequestEdit from '@/components/existing-request/existing-request-edit.vue'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 import querystring from 'qs'
 import Vue from 'vue'
@@ -1150,6 +1151,50 @@ export class NewRequestModule extends VuexModule {
   }
 
   @Action
+  setActiveComponent (component: string) {
+    switch (component) {
+      case 'EntityNotAutoAnalyzed':
+        this.mutateSubmissionTabNumber(0)
+        this.mutateDisplayedComponent('SubmissionTabs')
+        return
+      case 'NamesCapture':
+        this.mutateSubmissionTabNumber(1)
+        this.mutateDisplayedComponent('SubmissionTabs')
+        return
+      case 'ApplicantInfo1':
+        this.mutateSubmissionTabNumber(2)
+        this.mutateDisplayedComponent('SubmissionTabs')
+        return
+      case 'ApplicantInfo2':
+      case 'ApplicantInfo3':
+        this.mutateSubmissionTabNumber(3)
+        this.mutateDisplayedComponent('SubmissionTabs')
+        return
+      case 'InvalidActionMessage':
+        this.mutateSubmissionTabNumber(4)
+        this.mutateDisplayedComponent('SubmissionTabs')
+        return
+      case 'NameAnalysis':
+      case 'Tabs':
+        this.mutateTabNumber(0)
+        this.mutateDisplayedComponent('Tabs')
+        return
+      case 'ExistingRequestSearch':
+        this.mutateTabNumber(1)
+        this.mutateDisplayedComponent('Tabs')
+        return
+      case 'AnalyzeCharacters':
+      case 'AnalyzePending':
+      case 'AnalyzeResults':
+      case 'ExistingRequestDisplay':
+      case 'ExistingRequestEdit':
+      case 'SubmissionTabs':
+      case 'Success':
+        this.mutateDisplayedComponent(component)
+        return
+    }
+  }
+  @Action
   async getAddressDetails (id) {
     const url = 'https://ws1.postescanada-canadapost.ca/AddressComplete/Interactive/Retrieve/v2.11/json3.ws'
     let params = {
@@ -1333,6 +1378,32 @@ export class NewRequestModule extends VuexModule {
     }
   }
   @Action
+  async confirmAction (action: string) {
+    // eslint-disable-next-line
+    console.log('confirm action called')
+    try {
+      let resp = await this.getNameRequest(this.nr.id)
+      this.mutateNameRequest(resp)
+      if (!resp.actions.includes(action)) {
+        // eslint-disable-next-line
+        console.log('no way jose')
+        return false
+      }
+      // eslint-disable-next-line
+      console.log('good 2 go')
+      return true
+    } catch (error) {
+      if (error instanceof ApiError) {
+        await errorModule.setAppError({ id: 'get-name-requests-api-error', error: error.message } as ErrorI)
+      } else {
+        await errorModule.setAppError({ id: 'get-name-requests-error', error: error.message } as ErrorI)
+      }
+      // eslint-disable-next-line
+      console.log(error)
+      return false
+    }
+  }
+  @Action
   async findNameRequest () {
     this.resetAnalyzeName()
     this.mutateDisplayedComponent('AnalyzePending')
@@ -1450,7 +1521,8 @@ export class NewRequestModule extends VuexModule {
     const handleEmptyResults = () => {
       this.mutateNameRequest(
         {
-          text: 'There were no records found that match the information you have entered. Please verify the NR Number and the phone / email and try again.',
+          text: 'There were no records found that match the information you have entered. Please verify the NR' +
+            ' Number  and the phone / email and try again.',
           failed: true
         }
       )

--- a/client/src/views/landing.vue
+++ b/client/src/views/landing.vue
@@ -35,11 +35,11 @@ import ExistingRequestEdit from '@/components/existing-request/existing-request-
 
 @Component({
   components: {
-    ExistingRequestEdit,
     AnalyzeCharacters,
     AnalyzePending,
     AnalyzeResults,
     ExistingRequestDisplay,
+    ExistingRequestEdit,
     LowerContainer,
     Stats,
     SubmissionTabs,

--- a/client/tests/unit/applicant-info-1.spec.ts
+++ b/client/tests/unit/applicant-info-1.spec.ts
@@ -2,6 +2,8 @@ import ApplicantInfo1 from '@/components/common/applicant-info-1.vue'
 import { createLocalVue, shallowMount, mount } from '@vue/test-utils'
 import newReqModule from '@/store/new-request-module'
 import Vuetify from 'vuetify'
+import $intJurisdictions from '@/store/list-data/intl-jurisdictions'
+import $canJurisdictions from '@/store/list-data/canada-jurisdictions'
 
 const store = newReqModule
 const localVue = createLocalVue()
@@ -15,7 +17,11 @@ describe('applicant-info-1.vue', () => {
   beforeAll(async (done) => {
     wrapper = mount(ApplicantInfo1, {
       localVue,
-      vuetify
+      vuetify,
+      mocks: {
+        $canJurisdictions,
+        $intJurisdictions
+      }
     })
     await wrapper.vm.$nextTick()
     done()

--- a/client/tests/unit/applicant-info-2.spec.ts
+++ b/client/tests/unit/applicant-info-2.spec.ts
@@ -1,13 +1,13 @@
 import ApplicantInfo2 from '@/components/common/applicant-info-2.vue'
 import { createLocalVue, shallowMount, mount } from '@vue/test-utils'
-import newReqModule from '@/store/new-request-module'
+import module from '@/store/new-request-module'
 import Vuetify from 'vuetify'
+import Vuex from 'vuex'
 
-const store = newReqModule
 const localVue = createLocalVue()
 const vuetify = new Vuetify()
-
 localVue.use(Vuetify)
+
 describe('It initially renders correctly', () => {
   let wrapper: any
 
@@ -19,12 +19,12 @@ describe('It initially renders correctly', () => {
     await wrapper.vm.$nextTick()
     done()
   })
-
-  it('renders the form', () => {
-    expect(wrapper.find('#applicant-info-2-form').element).toBeTruthy()
-  })
-  it('Initially renders the disabled continue button', () => {
-    expect(wrapper.find('#submit-continue-btn-disabled').element).toBeTruthy()
-    expect(wrapper.find('#submit-continue-btn').element).toBeFalsy()
+  it('checks the corpNum against the appropriate database given the setup: BC location' async () => {
+    const mrasJurisdictions = ['Alberta', 'Saskatchewan', 'Manitoba']
+    const mrasActions = []
+    function setStore (jurisdiction, action) {
+      module.mutateNRData({ key: 'xproJurisdiction', value: 'Alberta'})
+    }
+    setStore()
   })
 })

--- a/client/tests/unit/applicant-info-2.spec.ts
+++ b/client/tests/unit/applicant-info-2.spec.ts
@@ -19,12 +19,11 @@ describe('It initially renders correctly', () => {
     await wrapper.vm.$nextTick()
     done()
   })
-  it('checks the corpNum against the appropriate database given the setup: BC location' async () => {
+  it('checks the corpNum against the appropriate database given the setup: BC location', async () => {
     const mrasJurisdictions = ['Alberta', 'Saskatchewan', 'Manitoba']
     const mrasActions = []
     function setStore (jurisdiction, action) {
       module.mutateNRData({ key: 'xproJurisdiction', value: 'Alberta'})
     }
-    setStore()
   })
 })

--- a/client/tests/unit/applicant-info-2.spec.ts
+++ b/client/tests/unit/applicant-info-2.spec.ts
@@ -23,7 +23,7 @@ describe('It initially renders correctly', () => {
     const mrasJurisdictions = ['Alberta', 'Saskatchewan', 'Manitoba']
     const mrasActions = []
     function setStore (jurisdiction, action) {
-      module.mutateNRData({ key: 'xproJurisdiction', value: 'Alberta'})
+      module.mutateNRData({ key: 'xproJurisdiction', value: 'Alberta' })
     }
   })
 })

--- a/client/tests/unit/new-request-module.spec.ts
+++ b/client/tests/unit/new-request-module.spec.ts
@@ -1,0 +1,101 @@
+import store from '@/store/new-request-module'
+
+describe('Testing behavior of getters.showCorpNum: (state) => return value', () => {
+  /* -- SETUP CONSTANTS FOR TESTING --*/
+  function setState({entityType, requestAction, location, jurisdiction}) {
+    store.mutateEntityType(entityType)
+    store.mutateRequestAction(requestAction)
+    store.mutateLocation(location)
+    store.mutateNRData({ key: 'xproJurisdiction', value: jurisdiction})
+  }
+  const spreadSheetData = [
+    { number: 1, location: 'BC', requestAction: 'NEW', entityType: 'FR',  showCorpNum: 'N/A' },
+    { number: 2, location: 'BC', requestAction: 'NEW', entityType: 'CR',  showCorpNum: 'N/A'},
+    { number: 3, location: 'BC', requestAction: 'NEW', entityType: 'CR',  showCorpNum: 'N/A' },
+    { number: 4, location: 'BC', requestAction: 'NEW', entityType: 'UL',  showCorpNum: 'N/A' },
+    { number: 5, location: 'BC', requestAction: 'NEW', entityType: 'BC',  showCorpNum: 'N/A' },
+    { number: 6, location: 'BC', requestAction: 'NEW', entityType: 'GP',  showCorpNum: 'N/A' },
+    { number: 7, location: 'BC', requestAction: 'NEW', entityType: 'LP',  showCorpNum: 'N/A' },
+    { number: 8, location: 'BC', requestAction: 'NEW', entityType: 'LL',  showCorpNum: 'N/A' },
+    { number: 9, location: 'BC', requestAction: 'NEW', entityType: 'CP',  showCorpNum: 'N/A' },
+    { number: 10, location: 'BC', requestAction: 'NEW', entityType: 'CC',  showCorpNum: 'N/A' },
+    { number: 12, location: 'BC', requestAction: 'NEW', entityType: 'PA',  showCorpNum: 'N/A' },
+    { number: 13, location: 'BC', requestAction: 'NEW', entityType: 'FI',  showCorpNum: 'N/A' },
+    { number: 14, location: 'BC', requestAction: 'CHG', entityType: 'FR',  showCorpNum: 'COLIN' },
+    { number: 15, location: 'BC', requestAction: 'CHG', entityType: 'DBA',  showCorpNum: 'COLIN' },
+    { number: 16, location: 'BC', requestAction: 'CHG', entityType: 'CR',  showCorpNum: 'COLIN' },
+    { number: 17, location: 'BC', requestAction: 'CHG', entityType: 'UL',  showCorpNum: 'COLIN' },
+    { number: 18, location: 'BC', requestAction: 'CHG', entityType: 'BC',  showCorpNum: 'COLIN' },
+    { number: 19, location: 'BC', requestAction: 'CHG', entityType: 'GP',  showCorpNum: 'COLIN' },
+    { number: 20, location: 'BC', requestAction: 'CHG', entityType: 'LP',  showCorpNum: 'COLIN' },
+    { number: 21, location: 'BC', requestAction: 'CHG', entityType: 'LL',  showCorpNum: 'COLIN' },
+    { number: 22, location: 'BC', requestAction: 'CHG', entityType: 'CP',  showCorpNum: 'COLIN' },
+    { number: 23, location: 'BC', requestAction: 'CHG', entityType: 'CC',  showCorpNum: 'COLIN' },
+    { number: 25, location: 'BC', requestAction: 'CHG', entityType: 'FI',  showCorpNum: 'COLIN' },
+    { number: 26, location: 'BC', requestAction: 'MVE', entityType: 'CR',  showCorpNum: 'MRAS' },
+    { number: 27, location: 'BC', requestAction: 'MVE', entityType: 'UL',  showCorpNum: 'MRAS' },
+    { number: 28, location: 'BC', requestAction: 'MVE', entityType: 'BC',  showCorpNum: 'MRAS' },
+    { number: 29, location: 'BC', requestAction: 'MVE', entityType: 'CC',  showCorpNum: 'MRAS' },
+    { number: 30, location: 'BC', requestAction: 'MVE', entityType: 'CP',  showCorpNum: 'MRAS' },
+    { number: 32, location: 'BC', requestAction: 'AML', entityType: 'UL',  showCorpNum: 'COLIN' },
+    { number: 33, location: 'BC', requestAction: 'AML', entityType: 'CR',  showCorpNum: 'COLIN' },
+    { number: 34, location: 'BC', requestAction: 'AML', entityType: 'BC',  showCorpNum: 'COLIN' },
+    { number: 35, location: 'BC', requestAction: 'AML', entityType: 'CC',  showCorpNum: 'COLIN' },
+    { number: 36, location: 'BC', requestAction: 'AML', entityType: 'CP',  showCorpNum: 'COLIN' },
+    { number: 37, location: 'BC', requestAction: 'CNV', entityType: 'UL',  showCorpNum: 'COLIN' },
+    { number: 38, location: 'BC', requestAction: 'CNV', entityType: 'CC',  showCorpNum: 'COLIN' },
+    { number: 39, location: 'BC', requestAction: 'CNV', entityType: 'BC',  showCorpNum: 'COLIN' },
+    { number: 40, location: 'BC', requestAction: 'CNV', entityType: 'CR',  showCorpNum: 'COLIN' },
+    { number: 41, location: 'BC', requestAction: 'REH', entityType: 'CR',  showCorpNum: 'COLIN' },
+    { number: 42, location: 'BC', requestAction: 'REN', entityType: 'UL',  showCorpNum: 'COLIN' },
+    { number: 43, location: 'BC', requestAction: 'REH', entityType: 'BC',  showCorpNum: 'COLIN' },
+    { number: 44, location: 'BC', requestAction: 'REN', entityType: 'CP',  showCorpNum: 'COLIN' },
+    { number: 45, location: 'BC', requestAction: 'REH', entityType: 'CC',  showCorpNum: 'COLIN' },
+    { number: 46, location: 'BC', requestAction: 'REN', entityType: 'FI',  showCorpNum: 'COLIN' }
+  ]
+
+  const testJurisdictions = ['ALBERTA', 'SASKATCHEWAN', 'MANITOBA', 'ONTARIO', 'QUEBEC', 'NEW BRUNSWICK']
+  const mrasJurisdictions = ['ALBERTA', 'SASKATCHEWAN', 'MANITOBA']
+
+
+  let testData = []
+  for (let row of spreadSheetData) {
+    let obj = { ...row }
+    obj['showCorpNum'] as any = obj['showCorpNum'].toLowerCase()
+    if (obj['showCorpNum'] as any === 'n/a') {
+      obj['showCorpNum'] as any = false
+      obj['xproJurisdiction'] as any = null
+    } else {
+      if (obj['showCorpNum'] === 'colin') {
+        obj['xproJurisdiction'] = null
+      } else {
+        let n = Math.round(Math.random() * 5)
+        obj['xproJurisdiction'] = testJurisdictions[n]
+      }
+    }
+    testData.push(obj)
+  }
+
+  /* -- ACTUAL TESTS --*/
+  let createTests = (i) => {
+    let row = testData[i]
+    let text = `#${row.number} (location: BC, request_action_cd: ${row.requestAction}, entity_type_cd:` +
+    ` ${row.entityType}, xproJurisdiction: ${row.jurisdiction ? row.jurisdiction : 'null'}) => returns` +
+    ` ${row.showCorpNum}`
+    test(text, () => {
+      let obj = {
+        entityType: row.entityType,
+        requestAction: row.requestAction,
+        location: 'BC',
+        jurisdiction: row.jurisdiction
+      }
+      setState(obj)
+      setTimeout(() => {
+        expect(store.showCorpNum ==row.showCorpNum).toBeTruthy()
+      }, 100)
+    })
+  }
+  for (let i = 0; i < 43; i++) {
+    createTests(i)
+  }
+})

--- a/client/tests/unit/new-request-module.spec.ts
+++ b/client/tests/unit/new-request-module.spec.ts
@@ -60,11 +60,15 @@ describe('Testing behavior of getters.showCorpNum: (state) => return value', () 
 
   let testData = []
   for (let row of spreadSheetData) {
-    let obj = { ...row }
-    obj['showCorpNum'] as any = obj['showCorpNum'].toLowerCase()
-    if (obj['showCorpNum'] as any === 'n/a') {
-      obj['showCorpNum'] as any = false
-      obj['xproJurisdiction'] as any = null
+    interface Obj {
+      showCorpNum: any,
+      xproJurisdiction: any
+    }
+    let obj: Partial<Obj> = { ...row }
+    obj['showCorpNum'] = obj['showCorpNum'].toLowerCase()
+    if (obj.showCorpNum === 'n/a') {
+      obj.showCorpNum = false
+      obj.xproJurisdiction = null
     } else {
       if (obj['showCorpNum'] === 'colin') {
         obj['xproJurisdiction'] = null

--- a/client/tests/unit/new-request-module.spec.ts
+++ b/client/tests/unit/new-request-module.spec.ts
@@ -1,62 +1,61 @@
 import store from '@/store/new-request-module'
 
 describe('Testing behavior of getters.showCorpNum: (state) => return value', () => {
-  /* -- SETUP CONSTANTS FOR TESTING --*/
-  function setState({entityType, requestAction, location, jurisdiction}) {
+  /* -- SETUP CONSTANTS FOR TESTING -- */
+  function setState ({ entityType, requestAction, location, jurisdiction }) {
     store.mutateEntityType(entityType)
     store.mutateRequestAction(requestAction)
     store.mutateLocation(location)
-    store.mutateNRData({ key: 'xproJurisdiction', value: jurisdiction})
+    store.mutateNRData({ key: 'xproJurisdiction', value: jurisdiction })
   }
   const spreadSheetData = [
-    { number: 1, location: 'BC', requestAction: 'NEW', entityType: 'FR',  showCorpNum: 'N/A' },
-    { number: 2, location: 'BC', requestAction: 'NEW', entityType: 'CR',  showCorpNum: 'N/A'},
-    { number: 3, location: 'BC', requestAction: 'NEW', entityType: 'CR',  showCorpNum: 'N/A' },
-    { number: 4, location: 'BC', requestAction: 'NEW', entityType: 'UL',  showCorpNum: 'N/A' },
-    { number: 5, location: 'BC', requestAction: 'NEW', entityType: 'BC',  showCorpNum: 'N/A' },
-    { number: 6, location: 'BC', requestAction: 'NEW', entityType: 'GP',  showCorpNum: 'N/A' },
-    { number: 7, location: 'BC', requestAction: 'NEW', entityType: 'LP',  showCorpNum: 'N/A' },
-    { number: 8, location: 'BC', requestAction: 'NEW', entityType: 'LL',  showCorpNum: 'N/A' },
-    { number: 9, location: 'BC', requestAction: 'NEW', entityType: 'CP',  showCorpNum: 'N/A' },
-    { number: 10, location: 'BC', requestAction: 'NEW', entityType: 'CC',  showCorpNum: 'N/A' },
-    { number: 12, location: 'BC', requestAction: 'NEW', entityType: 'PA',  showCorpNum: 'N/A' },
-    { number: 13, location: 'BC', requestAction: 'NEW', entityType: 'FI',  showCorpNum: 'N/A' },
-    { number: 14, location: 'BC', requestAction: 'CHG', entityType: 'FR',  showCorpNum: 'COLIN' },
-    { number: 15, location: 'BC', requestAction: 'CHG', entityType: 'DBA',  showCorpNum: 'COLIN' },
-    { number: 16, location: 'BC', requestAction: 'CHG', entityType: 'CR',  showCorpNum: 'COLIN' },
-    { number: 17, location: 'BC', requestAction: 'CHG', entityType: 'UL',  showCorpNum: 'COLIN' },
-    { number: 18, location: 'BC', requestAction: 'CHG', entityType: 'BC',  showCorpNum: 'COLIN' },
-    { number: 19, location: 'BC', requestAction: 'CHG', entityType: 'GP',  showCorpNum: 'COLIN' },
-    { number: 20, location: 'BC', requestAction: 'CHG', entityType: 'LP',  showCorpNum: 'COLIN' },
-    { number: 21, location: 'BC', requestAction: 'CHG', entityType: 'LL',  showCorpNum: 'COLIN' },
-    { number: 22, location: 'BC', requestAction: 'CHG', entityType: 'CP',  showCorpNum: 'COLIN' },
-    { number: 23, location: 'BC', requestAction: 'CHG', entityType: 'CC',  showCorpNum: 'COLIN' },
-    { number: 25, location: 'BC', requestAction: 'CHG', entityType: 'FI',  showCorpNum: 'COLIN' },
-    { number: 26, location: 'BC', requestAction: 'MVE', entityType: 'CR',  showCorpNum: 'MRAS' },
-    { number: 27, location: 'BC', requestAction: 'MVE', entityType: 'UL',  showCorpNum: 'MRAS' },
-    { number: 28, location: 'BC', requestAction: 'MVE', entityType: 'BC',  showCorpNum: 'MRAS' },
-    { number: 29, location: 'BC', requestAction: 'MVE', entityType: 'CC',  showCorpNum: 'MRAS' },
-    { number: 30, location: 'BC', requestAction: 'MVE', entityType: 'CP',  showCorpNum: 'MRAS' },
-    { number: 32, location: 'BC', requestAction: 'AML', entityType: 'UL',  showCorpNum: 'COLIN' },
-    { number: 33, location: 'BC', requestAction: 'AML', entityType: 'CR',  showCorpNum: 'COLIN' },
-    { number: 34, location: 'BC', requestAction: 'AML', entityType: 'BC',  showCorpNum: 'COLIN' },
-    { number: 35, location: 'BC', requestAction: 'AML', entityType: 'CC',  showCorpNum: 'COLIN' },
-    { number: 36, location: 'BC', requestAction: 'AML', entityType: 'CP',  showCorpNum: 'COLIN' },
-    { number: 37, location: 'BC', requestAction: 'CNV', entityType: 'UL',  showCorpNum: 'COLIN' },
-    { number: 38, location: 'BC', requestAction: 'CNV', entityType: 'CC',  showCorpNum: 'COLIN' },
-    { number: 39, location: 'BC', requestAction: 'CNV', entityType: 'BC',  showCorpNum: 'COLIN' },
-    { number: 40, location: 'BC', requestAction: 'CNV', entityType: 'CR',  showCorpNum: 'COLIN' },
-    { number: 41, location: 'BC', requestAction: 'REH', entityType: 'CR',  showCorpNum: 'COLIN' },
-    { number: 42, location: 'BC', requestAction: 'REN', entityType: 'UL',  showCorpNum: 'COLIN' },
-    { number: 43, location: 'BC', requestAction: 'REH', entityType: 'BC',  showCorpNum: 'COLIN' },
-    { number: 44, location: 'BC', requestAction: 'REN', entityType: 'CP',  showCorpNum: 'COLIN' },
-    { number: 45, location: 'BC', requestAction: 'REH', entityType: 'CC',  showCorpNum: 'COLIN' },
-    { number: 46, location: 'BC', requestAction: 'REN', entityType: 'FI',  showCorpNum: 'COLIN' }
+    { number: 1, location: 'BC', requestAction: 'NEW', entityType: 'FR', showCorpNum: 'N/A' },
+    { number: 2, location: 'BC', requestAction: 'NEW', entityType: 'CR', showCorpNum: 'N/A' },
+    { number: 3, location: 'BC', requestAction: 'NEW', entityType: 'CR', showCorpNum: 'N/A' },
+    { number: 4, location: 'BC', requestAction: 'NEW', entityType: 'UL', showCorpNum: 'N/A' },
+    { number: 5, location: 'BC', requestAction: 'NEW', entityType: 'BC', showCorpNum: 'N/A' },
+    { number: 6, location: 'BC', requestAction: 'NEW', entityType: 'GP', showCorpNum: 'N/A' },
+    { number: 7, location: 'BC', requestAction: 'NEW', entityType: 'LP', showCorpNum: 'N/A' },
+    { number: 8, location: 'BC', requestAction: 'NEW', entityType: 'LL', showCorpNum: 'N/A' },
+    { number: 9, location: 'BC', requestAction: 'NEW', entityType: 'CP', showCorpNum: 'N/A' },
+    { number: 10, location: 'BC', requestAction: 'NEW', entityType: 'CC', showCorpNum: 'N/A' },
+    { number: 12, location: 'BC', requestAction: 'NEW', entityType: 'PA', showCorpNum: 'N/A' },
+    { number: 13, location: 'BC', requestAction: 'NEW', entityType: 'FI', showCorpNum: 'N/A' },
+    { number: 14, location: 'BC', requestAction: 'CHG', entityType: 'FR', showCorpNum: 'COLIN' },
+    { number: 15, location: 'BC', requestAction: 'CHG', entityType: 'DBA', showCorpNum: 'COLIN' },
+    { number: 16, location: 'BC', requestAction: 'CHG', entityType: 'CR', showCorpNum: 'COLIN' },
+    { number: 17, location: 'BC', requestAction: 'CHG', entityType: 'UL', showCorpNum: 'COLIN' },
+    { number: 18, location: 'BC', requestAction: 'CHG', entityType: 'BC', showCorpNum: 'COLIN' },
+    { number: 19, location: 'BC', requestAction: 'CHG', entityType: 'GP', showCorpNum: 'COLIN' },
+    { number: 20, location: 'BC', requestAction: 'CHG', entityType: 'LP', showCorpNum: 'COLIN' },
+    { number: 21, location: 'BC', requestAction: 'CHG', entityType: 'LL', showCorpNum: 'COLIN' },
+    { number: 22, location: 'BC', requestAction: 'CHG', entityType: 'CP', showCorpNum: 'COLIN' },
+    { number: 23, location: 'BC', requestAction: 'CHG', entityType: 'CC', showCorpNum: 'COLIN' },
+    { number: 25, location: 'BC', requestAction: 'CHG', entityType: 'FI', showCorpNum: 'COLIN' },
+    { number: 26, location: 'BC', requestAction: 'MVE', entityType: 'CR', showCorpNum: 'MRAS' },
+    { number: 27, location: 'BC', requestAction: 'MVE', entityType: 'UL', showCorpNum: 'MRAS' },
+    { number: 28, location: 'BC', requestAction: 'MVE', entityType: 'BC', showCorpNum: 'MRAS' },
+    { number: 29, location: 'BC', requestAction: 'MVE', entityType: 'CC', showCorpNum: 'MRAS' },
+    { number: 30, location: 'BC', requestAction: 'MVE', entityType: 'CP', showCorpNum: 'MRAS' },
+    { number: 32, location: 'BC', requestAction: 'AML', entityType: 'UL', showCorpNum: 'COLIN' },
+    { number: 33, location: 'BC', requestAction: 'AML', entityType: 'CR', showCorpNum: 'COLIN' },
+    { number: 34, location: 'BC', requestAction: 'AML', entityType: 'BC', showCorpNum: 'COLIN' },
+    { number: 35, location: 'BC', requestAction: 'AML', entityType: 'CC', showCorpNum: 'COLIN' },
+    { number: 36, location: 'BC', requestAction: 'AML', entityType: 'CP', showCorpNum: 'COLIN' },
+    { number: 37, location: 'BC', requestAction: 'CNV', entityType: 'UL', showCorpNum: 'COLIN' },
+    { number: 38, location: 'BC', requestAction: 'CNV', entityType: 'CC', showCorpNum: 'COLIN' },
+    { number: 39, location: 'BC', requestAction: 'CNV', entityType: 'BC', showCorpNum: 'COLIN' },
+    { number: 40, location: 'BC', requestAction: 'CNV', entityType: 'CR', showCorpNum: 'COLIN' },
+    { number: 41, location: 'BC', requestAction: 'REH', entityType: 'CR', showCorpNum: 'COLIN' },
+    { number: 42, location: 'BC', requestAction: 'REN', entityType: 'UL', showCorpNum: 'COLIN' },
+    { number: 43, location: 'BC', requestAction: 'REH', entityType: 'BC', showCorpNum: 'COLIN' },
+    { number: 44, location: 'BC', requestAction: 'REN', entityType: 'CP', showCorpNum: 'COLIN' },
+    { number: 45, location: 'BC', requestAction: 'REH', entityType: 'CC', showCorpNum: 'COLIN' },
+    { number: 46, location: 'BC', requestAction: 'REN', entityType: 'FI', showCorpNum: 'COLIN' }
   ]
 
   const testJurisdictions = ['ALBERTA', 'SASKATCHEWAN', 'MANITOBA', 'ONTARIO', 'QUEBEC', 'NEW BRUNSWICK']
   const mrasJurisdictions = ['ALBERTA', 'SASKATCHEWAN', 'MANITOBA']
-
 
   let testData = []
   for (let row of spreadSheetData) {
@@ -80,7 +79,7 @@ describe('Testing behavior of getters.showCorpNum: (state) => return value', () 
     testData.push(obj)
   }
 
-  /* -- ACTUAL TESTS --*/
+  /* -- ACTUAL TESTS -- */
   let createTests = (i) => {
     let row = testData[i]
     let text = `#${row.number} (location: BC, request_action_cd: ${row.requestAction}, entity_type_cd:` +
@@ -95,7 +94,7 @@ describe('Testing behavior of getters.showCorpNum: (state) => return value', () 
       }
       setState(obj)
       setTimeout(() => {
-        expect(store.showCorpNum ==row.showCorpNum).toBeTruthy()
+        expect(store.showCorpNum === row.showCorpNum).toBeTruthy()
       }, 100)
     })
   }

--- a/client/tests/unit/reserve-submit.spec.ts
+++ b/client/tests/unit/reserve-submit.spec.ts
@@ -66,7 +66,7 @@ describe('reserve-submit', () => {
         expect(newReqModule.submissionTabNumber === 2).toBeTruthy()
       })
     })
-    describe('If location !== "BC", it sends to examination', async () => {
+    describe('If location !== "BC", it sends to examination', () => {
       test('postNameRequests is not called', async () => {
         newReqModule.mutateLocation('CA')
         wrapper.vm.handleSubmit()


### PR DESCRIPTION
- existing request searches which are unfurnished and have stateCd set to APPROVED, REJECTED or CONDITIONAL now divert to a message screen to prevent viewing them until they are fully committed to the database
    
- added logic to verify that user-clicked button action in ExistingRequestDisplay is still available by sending a GET to /namerequests and if the action cannot be utilized per the stateCd of the NR, diverts to a messaging component to explain to the user