### PR TITLE
entity 5282 & 5366

### DIFF
--- a/client/src/components/common/applicant-info-1.vue
+++ b/client/src/components/common/applicant-info-1.vue
@@ -317,7 +317,7 @@
 <script lang="ts">
 import newReqModule from '@/store/new-request-module'
 import { Component, Vue, Watch } from 'vue-property-decorator'
-import ApplicantInfoNav from '@/components/common/ApplicantInfoNav.vue'
+import ApplicantInfoNav from '@/components/common/applicant-info-nav.vue'
 
 const _debounce = require('lodash/debounce')
 

--- a/client/src/components/common/applicant-info-2.vue
+++ b/client/src/components/common/applicant-info-2.vue
@@ -146,7 +146,7 @@
 import newReqModule, { NewRequestModule } from '@/store/new-request-module'
 import paymentModule from '@/modules/payment'
 import { Component, Vue, Watch } from 'vue-property-decorator'
-import ApplicantInfoNav from '@/components/common/ApplicantInfoNav.vue'
+import ApplicantInfoNav from '@/components/common/applicant-info-nav.vue'
 
 @Component({
   components: {

--- a/client/src/components/common/applicant-info-3.vue
+++ b/client/src/components/common/applicant-info-3.vue
@@ -153,7 +153,7 @@
 </template>
 
 <script lang="ts">
-import ApplicantInfoNav from '@/components/common/ApplicantInfoNav.vue'
+import ApplicantInfoNav from '@/components/common/applicant-info-nav.vue'
 import newReqModule, { NewRequestModule } from '@/store/new-request-module'
 import paymentModule from '@/modules/payment'
 import { Component, Vue, Watch } from 'vue-property-decorator'

--- a/client/src/components/common/applicant-info-nav.vue
+++ b/client/src/components/common/applicant-info-nav.vue
@@ -10,7 +10,7 @@
     </v-btn>
     <v-btn x-large
            @click="next"
-           :disabled="!isValid || clicked"
+           :disabled="!isValid"
            id="submit-continue-btn">
       {{ nextText }}
     </v-btn>
@@ -25,8 +25,6 @@ import timerModule from '@/modules/vx-timer'
 
 @Component({})
 export default class ApplicantInfoNav extends Vue {
-  clicked: boolean = false
-
   @Prop(Boolean) isValid: boolean
 
   get backText () {
@@ -78,8 +76,7 @@ export default class ApplicantInfoNav extends Vue {
     newReqModule.mutateSubmissionTabNumber(this.tab - 1)
   }
   next () {
-    if (this.tab === 3 && !this.clicked) {
-      this.clicked = true
+    if (this.tab === 3) {
       this.submit()
       return
     }

--- a/client/src/components/common/names-capture.vue
+++ b/client/src/components/common/names-capture.vue
@@ -166,7 +166,7 @@
 </template>
 
 <script lang="ts">
-import ApplicantInfoNav from '@/components/common/ApplicantInfoNav.vue'
+import ApplicantInfoNav from '@/components/common/applicant-info-nav.vue'
 import { LocationT } from '@/models'
 import { sanitizeName } from '@/plugins/utilities'
 import newReqModule from '@/store/new-request-module'

--- a/client/src/components/existing-request/existing-request-display.vue
+++ b/client/src/components/existing-request/existing-request-display.vue
@@ -261,7 +261,7 @@ export default class ExistingRequestDisplay extends Vue {
   }
   async goBack () {
     await newReqModule.cancelEditExistingRequest()
-    newReqModule.cancelAnalyzeName()
+    newReqModule.cancelAnalyzeName('Tabs')
   }
   async refresh (event) {
     this.refreshCount += 1

--- a/client/src/components/new-request/analyze-characters.vue
+++ b/client/src/components/new-request/analyze-characters.vue
@@ -76,7 +76,7 @@ export default class AnalyzeCharacters extends Vue {
   }
 
   startOver () {
-    newReqModule.cancelAnalyzeName()
+    newReqModule.cancelAnalyzeName('Tabs')
   }
 }
 

--- a/client/src/components/new-request/analyze-pending.vue
+++ b/client/src/components/new-request/analyze-pending.vue
@@ -32,6 +32,9 @@
       <v-col cols="auto">
         <v-btn id="analyze-pending-stop-button" @click="startOver">Stop Search</v-btn>
       </v-col>
+      <v-col cols="auto">
+        <ReserveSubmit setup="cancel" />
+      </v-col>
     </v-row>
     </template>
   </MainContainer>
@@ -39,12 +42,13 @@
 
 <script lang="ts">
 import MainContainer from '@/components/new-request/main-container.vue'
+import ReserveSubmit from '@/components/new-request/submit-request/reserve-submit.vue'
 import newReqModule from '@/store/new-request-module'
 import NameInput from '@/components/new-request/name-input.vue'
 import { Component, Vue } from 'vue-property-decorator'
 
 @Component({
-  components: { MainContainer, NameInput }
+  components: { ReserveSubmit, MainContainer, NameInput }
 })
 export default class AnalyzePending extends Vue {
   get entityObject () {
@@ -71,10 +75,8 @@ export default class AnalyzePending extends Vue {
         return 'a new'
     }
   }
-
-  async startOver () {
-    await newReqModule.userClickedStopAnalysis(newReqModule.analysisJSONCancelled)
-    newReqModule.cancelAnalyzeName('AnalyzeResults')
+  startOver () {
+    newReqModule.cancelAnalyzeName('Tabs')
   }
 }
 

--- a/client/src/components/new-request/analyze-pending.vue
+++ b/client/src/components/new-request/analyze-pending.vue
@@ -72,8 +72,9 @@ export default class AnalyzePending extends Vue {
     }
   }
 
-  startOver () {
-    newReqModule.cancelAnalyzeName()
+  async startOver () {
+    await newReqModule.userClickedStopAnalysis(newReqModule.analysisJSONCancelled)
+    newReqModule.cancelAnalyzeName('AnalyzeResults')
   }
 }
 

--- a/client/src/components/new-request/grey-box.vue
+++ b/client/src/components/new-request/grey-box.vue
@@ -10,105 +10,121 @@
         </div>
       </div>
     </v-col>
-    <transition :name="i === 0 ? 'fade' : '' " mode="out-in">
-      <v-row class="copy-small colour-p-blue-text"
-             align-content="start"
-             :key="changesInBaseName+designationIsFixed+'key'+i">
-        <!-- Header, Line 1 and Line 2-->
+    <template v-if="issueType === 'user_cancelled'">
+      <v-col class="copy-small colour-p-blue-text pt-0" cols="12">
+        <p v-if="option.line1" class="ma-0 pa-0" v-html="option.line1" />
+        <p v-if="option.line2" class="ma-0 pa-0 pt-2" v-html="option.line2" />
+      </v-col>
+      <v-col cols="12" class="text-center" v-if="option.type === 'cancel_to_examiner'">
+        <ReserveSubmit setup="examine"
+                       id="reserve-submit-button"
+                       style="display: inline" />
+      </v-col>
+      <v-col cols="12" class="text-center" v-else>
+        <v-btn @click="cancelAnalyzeName('Tabs')">Start Over</v-btn>
+      </v-col>
+    </template>
+    <template v-else>
+      <transition :name="i === 0 ? 'fade' : '' " mode="out-in">
+        <v-row class="copy-small colour-p-blue-text"
+               align-content="start"
+               :key="changesInBaseName+designationIsFixed+'key'+i">
+          <!-- Header, Line 1 and Line 2-->
 
-        <v-col class="copy-small colour-p-blue-text pt-0"
-               v-if="designationIsFixed && isDesignationIssueType && i === 0"
-               cols="12">
-          {{ isLastIndex ? 'No additional issues were identified with your name.  You may proceed.' :
-                           'Please click the "Next Issue" button to continue' }}
-        </v-col>
-        <v-col class="copy-small colour-p-blue-text pt-0"
-               v-else-if="changesInBaseName && isDesignationIssueType && i === 0"
-               cols="12">
-          You have altered the base text of your name.  You must
-          either change it back or click the magnifying glass to run a new search for your edited name.
-        </v-col>
-        <v-col class="copy-small colour-p-blue-text pt-0"
-               v-else
-               cols="12">
-          <p v-if="option.line1" class="ma-0 pa-0" v-html="option.line1" />
-          <p v-if="option.line2" class="ma-0 pa-0 pt-2" v-html="option.line2" />
-        </v-col>
-
-        <!-- NAME/DESIGNATION-MANIPULATING OPTION BOXES -->
-        <template v-if="isDesignationIssueType">
-          <transition name="fade"
-                      mode="out-in">
-            <v-col v-if="!designationIsFixed && !changesInBaseName && i === 0"
-                   class="text-center"
-                   key="designation-error-col">
-              <template v-if="Array.isArray(designations) && designations.length > 0">
-                <div class="designation-buttons">
-                  <button tag="div"
-                          :key="'designation-'+d"
-                          :id="'designation-'+d"
-                          @click.once.prevent="changeDesignation(des)"
-                          class="link-sm ma-0 pa-0 px-1"
-                          v-for="(des, d) in designations">
-                    {{ des }}{{ (d !== issue.designations.length - 1) ? ',' : '' }}
-                  </button>
-                </div>
-              </template>
-              <template v-if="option.type === 'change designation at the end'">
-                <v-btn @click="moveDesignation" id="move-designation-btn">Move Designation</v-btn>
-              </template>
-            </v-col>
-            <v-col v-if="designationIsFixed && i === 0 && issueIndex + 1 === issueLength"
-                   key="designation-fixed-col" class="text-center">
-              <ReserveSubmit id="reserve-submit-button"
-                             style="display: inline"
-                             :setup="reserveSubmitConfig" />
-            </v-col>
-          </transition>
-        </template>
-
-        <!-- CHANGE_ENTITY_TYPE OPTION BOX -->
-        <template v-if="option.type === 'change_entity_type'">
-           <v-col class="text-center mt-4">
-            <v-btn @click="cancelAnalyzeName()">Restart and Change Type</v-btn>
+          <v-col class="copy-small colour-p-blue-text pt-0"
+                 v-if="designationIsFixed && isDesignationIssueType && i === 0"
+                 cols="12">
+            {{ isLastIndex ? 'No additional issues were identified with your name.  You may proceed.' :
+            'Please click the "Next Issue" button to continue' }}
           </v-col>
-        </template>
-        <!-- ASSUMED NAME OPTION BOX -->
-        <template v-else-if="option.type === 'assumed_name'">
-          <v-col :id="option.type + '-button-checkbox-col'"
-                 class="pa-0 grey-box-checkbox-button text-center">
-            <transition name="fade" mode="out-in" >
-              <ReserveSubmit :key="option.type+'-reserve-submit'"
-                             setup="assumed"
-                             id="reserve-submit-comp"
-                             v-if="isLastIndex"
-                             style="display: inline" />
+          <v-col class="copy-small colour-p-blue-text pt-0"
+                 v-else-if="changesInBaseName && isDesignationIssueType && i === 0"
+                 cols="12">
+            You have altered the base text of your name.  You must
+            either change it back or click the magnifying glass to run a new search for your edited name.
+          </v-col>
+          <v-col class="copy-small colour-p-blue-text pt-0"
+                 v-else
+                 cols="12">
+            <p v-if="option.line1" class="ma-0 pa-0" v-html="option.line1" />
+            <p v-if="option.line2" class="ma-0 pa-0 pt-2" v-html="option.line2" />
+          </v-col>
+
+          <!-- NAME/DESIGNATION-MANIPULATING OPTION BOXES -->
+          <template v-if="isDesignationIssueType">
+            <transition name="fade"
+                        mode="out-in">
+              <v-col v-if="!designationIsFixed && !changesInBaseName && i === 0"
+                     class="text-center"
+                     key="designation-error-col">
+                <template v-if="Array.isArray(designations) && designations.length > 0">
+                  <div class="designation-buttons">
+                    <button tag="div"
+                            :key="'designation-'+d"
+                            :id="'designation-'+d"
+                            @click.once.prevent="changeDesignation(des)"
+                            class="link-sm ma-0 pa-0 px-1"
+                            v-for="(des, d) in designations">
+                      {{ des }}{{ (d !== issue.designations.length - 1) ? ',' : '' }}
+                    </button>
+                  </div>
+                </template>
+                <template v-if="option.type === 'change designation at the end'">
+                  <v-btn @click="moveDesignation" id="move-designation-btn">Move Designation</v-btn>
+                </template>
+              </v-col>
+              <v-col v-if="designationIsFixed && i === 0 && issueIndex + 1 === issueLength"
+                     key="designation-fixed-col" class="text-center">
+                <ReserveSubmit id="reserve-submit-button"
+                               style="display: inline"
+                               :setup="reserveSubmitConfig" />
+              </v-col>
             </transition>
-          </v-col>
-        </template>
-        <!-- ALL OTHER TYPES OF OPTION BOXES -->
-        <template v-else>
-          <v-col :id="option.type + '-button-checkbox-col'"
-                 v-if="i !== 0"
-                 class="pa-0 grey-box-checkbox-button text-center">
-            <transition name="fade" mode="out-in" >
-              <v-checkbox :error="showError"
-                          :key="option.type+'-checkbox'"
-                          :label="checkBoxLabel"
-                          class="ma-0 pa-0"
-                          id="provide-consent-checkbox"
-                          v-if="showCheckBoxOrButton === 'checkbox'"
-                          v-model="boxIsChecked" />
-              <ReserveSubmit :key="option.type+'-reserve-submit'"
-                             :setup="reserveSubmitConfig"
-                             id="reserve-submit-button"
-                             style="display: inline"
-                             v-if="showCheckBoxOrButton === 'button'" />
-            </transition>
-          </v-col>
-        </template>
-      </v-row>
-    </transition>
+          </template>
+
+          <!-- CHANGE_ENTITY_TYPE OPTION BOX -->
+          <template v-if="option.type === 'change_entity_type'">
+            <v-col class="text-center mt-4">
+              <v-btn @click="cancelAnalyzeName('Tabs')">Restart and Change Type</v-btn>
+            </v-col>
+          </template>
+          <!-- ASSUMED NAME OPTION BOX -->
+          <template v-else-if="option.type === 'assumed_name'">
+            <v-col :id="option.type + '-button-checkbox-col'"
+                   class="pa-0 grey-box-checkbox-button text-center">
+              <transition name="fade" mode="out-in" >
+                <ReserveSubmit :key="option.type+'-reserve-submit'"
+                               setup="assumed"
+                               id="reserve-submit-comp"
+                               v-if="isLastIndex"
+                               style="display: inline" />
+              </transition>
+            </v-col>
+          </template>
+          <!-- ALL OTHER TYPES OF OPTION BOXES -->
+          <template v-else>
+            <v-col :id="option.type + '-button-checkbox-col'"
+                   v-if="i !== 0"
+                   class="pa-0 grey-box-checkbox-button text-center">
+              <transition name="fade" mode="out-in" >
+                <v-checkbox :error="showError"
+                            :key="option.type+'-checkbox'"
+                            :label="checkBoxLabel"
+                            class="ma-0 pa-0"
+                            id="provide-consent-checkbox"
+                            v-if="showCheckBoxOrButton === 'checkbox'"
+                            v-model="boxIsChecked" />
+                <ReserveSubmit :key="option.type+'-reserve-submit'"
+                               :setup="reserveSubmitConfig"
+                               id="reserve-submit-button"
+                               style="display: inline"
+                               v-if="showCheckBoxOrButton === 'button'" />
+              </transition>
+            </v-col>
+          </template>
+        </v-row>
+      </transition>
+    </template>
   </v-container>
 </template>
 
@@ -245,6 +261,7 @@ export default class GreyBox extends Vue {
   }
   get designationIsFixed () {
     try {
+      if (this.userCancelled) return false
       if (!this.changesInBaseName) {
         let AllDesignationsList = allDesignationsList
         const designationEntityTypes = allDesignations[this.entity_type_cd]
@@ -387,8 +404,11 @@ export default class GreyBox extends Vue {
   get isAssumedName () {
     return this.issue.setup.some(box => box.type === 'assumed_name')
   }
+  get lastIndex () {
+    return this.issueLength - 1
+  }
   get isLastIndex () {
-    return (this.issueIndex === this.issueLength - 1)
+    return (this.issueIndex === this.lastIndex)
   }
   get issueLength () {
     if (Array.isArray(newReqModule.analysisJSON.issues)) {
@@ -444,12 +464,28 @@ export default class GreyBox extends Vue {
       }
       return ''
     }
-    if (this.examinationRequested) {
-      return 'examine'
-    }
-    for (let n of [0, 1, 2]) {
-      if (this.requestExaminationOrProvideConsent[n].obtain_consent ||
-        this.requestExaminationOrProvideConsent[n].conflict_self_consent) {
+    if (this.isLastIndex) {
+      let priorIndexes = () => {
+        let output = []
+        let i = this.issueIndex
+        while (i > 0) {
+          i--
+          output.push(i)
+        }
+        return output
+      }
+
+      if (priorIndexes().some(index => this.requestExaminationOrProvideConsent[index].send_to_examiner)) {
+        return 'examine'
+      }
+      if (this.option.type === 'send_to_examiner') {
+        return 'examine'
+      }
+      if (priorIndexes().some(index => this.requestExaminationOrProvideConsent[index].obtain_consent ||
+      this.requestExaminationOrProvideConsent[index].conflict_self_consent)) {
+        return 'consent'
+      }
+      if (['conflict_self_consent', 'obtain_consent'].includes(this.option.type)) {
         return 'consent'
       }
     }
@@ -459,6 +495,9 @@ export default class GreyBox extends Vue {
     let { type } = this.option
     if (this.issueIndex + 1 === this.issueLength) {
       switch (type) {
+        case 'cancel_to_examiner':
+        case 'cancel_to_start':
+          return 'button'
         case 'send_to_examiner':
           if (this.showLastStepButtons.send_to_examiner) {
             return 'button'
@@ -496,9 +535,12 @@ export default class GreyBox extends Vue {
     }
     return ''
   }
+  get userCancelled () {
+    return newReqModule.userCancelledAnalysis
+  }
 
-  cancelAnalyzeName () {
-    newReqModule.cancelAnalyzeName()
+  cancelAnalyzeName (destination) {
+    newReqModule.cancelAnalyzeName(destination)
   }
   changeDesignation (designation) {
     newReqModule.mutateShowActualInput(true)

--- a/client/src/components/new-request/grey-box.vue
+++ b/client/src/components/new-request/grey-box.vue
@@ -144,15 +144,14 @@ export default class GreyBox extends Vue {
   @Prop(Number) issueIndex: number
   @Prop(Object) option: OptionI
   @Prop(String) originalName: string
-  @Watch('changesInBaseName')
+
+  @Watch('changesInBaseName', { immediate: true })
   updateChangesInBaseName (newVal) {
     newReqModule.mutateChangesInBaseName(newVal)
   }
-  @Watch('designationIsFixed')
+  @Watch('designationIsFixed', { immediate: true })
   updateDesignationIsFixed (newVal) {
-    if (this.designationIsFixedStore !== newVal) {
-      newReqModule.mutateDesignationIsFixed(newVal)
-    }
+    newReqModule.mutateDesignationIsFixed(newVal)
   }
   @Watch('designationIsFixedStore', { immediate: true })
   syncDesignationIsFixed () {

--- a/client/src/components/new-request/main-container.vue
+++ b/client/src/components/new-request/main-container.vue
@@ -38,7 +38,7 @@ export default class MainContainer extends Vue {
       // Avoided redundant navigation to current location: "/"
       await this.$router.replace('/').catch(() => {})
     } else {
-      await newReqModule.cancelAnalyzeName()
+      await newReqModule.cancelAnalyzeName('Tabs')
       // Redirect to the start
       // Catch any errors, so we don't get errors like:
       // Avoided redundant navigation to current location: "/"

--- a/client/src/components/new-request/submit-request/entity-cannot-be-auto-analyzed.vue
+++ b/client/src/components/new-request/submit-request/entity-cannot-be-auto-analyzed.vue
@@ -198,7 +198,7 @@ export default class EntityCannotBeAutoAnalyzed extends Vue {
   }
   cancelAnalyzeName () {
     this.$root.$emit('start-search-again')
-    newReqModule.cancelAnalyzeName()
+    newReqModule.cancelAnalyzeName('Tabs')
   }
 }
 </script>

--- a/client/src/components/new-request/submit-request/reserve-submit.vue
+++ b/client/src/components/new-request/submit-request/reserve-submit.vue
@@ -35,6 +35,8 @@ export default class ReserveSubmitButton extends Vue {
       return 'Send for Examination'
     }
     switch (this.setup) {
+      case 'cancel':
+        return 'Stop & Send To Examination'
       case 'consent':
         return 'Conditionally Reserve'
       case 'examine':
@@ -48,9 +50,19 @@ export default class ReserveSubmitButton extends Vue {
         return 'Reserve and Continue'
     }
   }
+  async sendToExamination () {
+    await newReqModule.userClickedStopAnalysis()
+    newReqModule.cancelAnalyzeName('NamesCapture')
+  }
 
   handleSubmit () {
     let { setup, location, entity_type_cd, request_action_cd } = this
+
+    if (setup === 'cancel') {
+      this.sendToExamination()
+      return
+    }
+
     let goToNames = () => {
       newReqModule.mutateSubmissionType('examination')
       newReqModule.mutateSubmissionTabComponent('NamesCapture')
@@ -72,6 +84,9 @@ export default class ReserveSubmitButton extends Vue {
         return
       case 'examine':
         goToNames()
+        return
+      case 'cancel':
+        this.sendToExamination()
         return
       case 'consent':
         newReqModule.postNameRequests('conditional')

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -133,40 +133,6 @@ export class NewRequestModule extends VuexModule {
   actingOnOwnBehalf: boolean = true
   addressSuggestions: object | null = null
   analysisJSON: AnalysisJSONI | null = null
-  analysisJSONCancelled = {
-    "header": "Name Analysis Cancelled",
-    "status": "fa",
-    "issues": [
-      {
-        "line1": "You have chosen to cancel name-analysis.",
-        "issue_type": "user_cancelled",
-        "show_next_button": false,
-        "show_examination_button": false,
-        "conflicts": [],
-        "name_actions": [],
-        "setup": [
-          {
-            "button": true,
-            "checkbox": "",
-            "type": "cancel_to_examiner",
-            "header": "Option 1",
-            "line1": "You can choose to submit this name for examination. Please check wait times at the top of the" +
-            " screen.",
-            "line2": "",
-            "label": "Send For Examination"
-          },
-          {
-            "checkbox": "",
-            "type": "cancel_to_start",
-            "header": "Option 2",
-            "line1": "You may click the button below to start over",
-            "line2": "",
-            "label": "Start Over"
-          }
-        ]
-      }
-    ]
-  }
   applicant: ApplicantI = {
     addrLine1: '',
     addrLine2: '',
@@ -1372,7 +1338,7 @@ export class NewRequestModule extends VuexModule {
         return
       }
       if (this.userCancelledAnalysis) {
-        this.setActiveComponent('AnalyzeResults')
+        this.setActiveComponent('NamesCapture')
         return
       }
       this.mutateDisplayedComponent('Tabs')
@@ -1917,9 +1883,9 @@ export class NewRequestModule extends VuexModule {
     }
   }
   @Action
-  userClickedStopAnalysis (payload) {
+  userClickedStopAnalysis () {
     this.mutateUserCancelledAnalysis(true)
-    this.mutateAnalysisJSON(payload)
+    this.mutateSubmissionType('examination')
   }
   @Action
   resetAnalyzeName () {
@@ -1946,6 +1912,7 @@ export class NewRequestModule extends VuexModule {
       source = null
     }
     if (destination === 'Tabs') {
+      this.mutateName('')
       this.mutateUserCancelledAnalysis(false)
     }
     this.setActiveComponent(destination)


### PR DESCRIPTION
#### 5282
- When user clicks button to cancel name-analysis, they are now given the option to send to examiner. CHECKED. PASSED.

#### 5366
- fixed the ReserveSubmit button-type determination logic

#### Also...
- fixed issue with "You May Proceed" vs "Further Action Required" messaging
- fixed issue with "Continue and Pay" Button which needed to be clickable more than once

##

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
