### PR TITLE
Set longer NR timeout when in dev mode

### DIFF
--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -41,7 +41,8 @@ import { ErrorI } from '@/modules/error/store/actions'
 import * as types from '@/store/types'
 
 const qs: any = querystring
-const ANALYSIS_TIMEOUT_MS = 180 * 1000 // 3 minuteslet source: any
+const ANALYSIS_TIMEOUT_MS = 180 * 1000 // 3 minutes
+let source: any
 
 const MINUTES_60_IN_MS = 60 * (60 * 1000)
 const MINUTES_5_IN_MS = 5 * (60 * 1000)

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -41,14 +41,15 @@ import { ErrorI } from '@/modules/error/store/actions'
 import * as types from '@/store/types'
 
 const qs: any = querystring
-const debounce = require('lodash/debounce')
-const analysisTimeout: number = 180000
-let source: any
+const ANALYSIS_TIMEOUT_MS = 180 * 1000 // 3 minuteslet source: any
+
+const MINUTES_60_IN_MS = 60 * (60 * 1000)
+const MINUTES_5_IN_MS = 5 * (60 * 1000)
 
 export const NR_COMPLETION_TIMER_NAME = 'nrCompletionTimer'
-export const NR_COMPLETION_TIMEOUT_MS = 5 * (60 * 1000) // Set to 5 minutes
+export const NR_COMPLETION_TIMEOUT_MS = window['webpackHotUpdate'] ? MINUTES_60_IN_MS : MINUTES_5_IN_MS
 export const EXISTING_NR_TIMER_NAME = 'existingNrTimer'
-export const EXISTING_NR_TIMEOUT_MS = 5 * (60 * 1000) // Set to 5 minutes
+export const EXISTING_NR_TIMEOUT_MS = window['webpackHotUpdate'] ? MINUTES_60_IN_MS : MINUTES_5_IN_MS
 
 export class ApiError extends Error {}
 
@@ -1340,7 +1341,7 @@ export class NewRequestModule extends VuexModule {
       let resp = await axios.get('name-analysis', {
         params,
         cancelToken: source.token,
-        timeout: analysisTimeout
+        timeout: ANALYSIS_TIMEOUT_MS
       })
       let json = resp.data
       this.mutateAnalysisJSON(json)
@@ -1390,7 +1391,7 @@ export class NewRequestModule extends VuexModule {
       let resp = await axios.get('/xpro-name-analysis', {
         params,
         cancelToken: source.token,
-        timeout: analysisTimeout
+        timeout: ANALYSIS_TIMEOUT_MS
       })
       let json = resp.data
       this.mutateAnalysisJSON(json)

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -41,15 +41,17 @@ import { ErrorI } from '@/modules/error/store/actions'
 import * as types from '@/store/types'
 
 const qs: any = querystring
-const ANALYSIS_TIMEOUT_MS = 180 * 1000 // 3 minutes
+const ANALYSIS_TIMEOUT_MS = 3 * 60 * 1000 // 3 minutes
 let source: any
 
+export const NR_COMPLETION_TIMER_NAME = 'nrCompletionTimer'
+export const EXISTING_NR_TIMER_NAME = 'existingNrTimer'
+
+// give developers more time while coding
 const MINUTES_60_IN_MS = 60 * (60 * 1000)
 const MINUTES_5_IN_MS = 5 * (60 * 1000)
-
-export const NR_COMPLETION_TIMER_NAME = 'nrCompletionTimer'
+// NB: window['webpackHotUpdate'] is a function when running locally, otherwise it's undefined
 export const NR_COMPLETION_TIMEOUT_MS = window['webpackHotUpdate'] ? MINUTES_60_IN_MS : MINUTES_5_IN_MS
-export const EXISTING_NR_TIMER_NAME = 'existingNrTimer'
 export const EXISTING_NR_TIMEOUT_MS = window['webpackHotUpdate'] ? MINUTES_60_IN_MS : MINUTES_5_IN_MS
 
 export class ApiError extends Error {}


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*
- set NR timeouts to 60 min (instead of 5 min) when in dev mode
- deleted unused debounce()
- renamed a const for consistency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).