### PR TITLE
Remove Canadian and Foreign Unlimited Liability Company request types

### DIFF
--- a/client/src/store/list-data/request-action-mapping.ts
+++ b/client/src/store/list-data/request-action-mapping.ts
@@ -13,10 +13,10 @@ export const bcMapping: RequestActionMappingI = {
 }
 
 export const xproMapping: RequestActionMappingI = {
-  ASSUMED: ['XCR', 'RLC', 'XUL'],
-  REN: ['XCR', 'XCP', 'RLC', 'XUL'],
-  REH: ['XCR', 'XCP', 'RLC', 'XUL'],
-  AML: ['XCR', 'XCP', 'XUL']
+  ASSUMED: ['XCR', 'RLC'],
+  REN: ['XCR', 'XCP', 'RLC'],
+  REH: ['XCR', 'XCP', 'RLC'],
+  AML: ['XCR', 'XCP']
 }
 
 export const $colinRequestActions = ['AML', 'CHG', 'REH', 'REN']

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -563,7 +563,7 @@ export class NewRequestModule extends VuexModule {
     if (this.location === 'BC' && this.request_action_cd === 'CNV') {
       return 'colin'
     }
-    let mrasEntities = ['XUL', 'XCR', 'XLP', 'UL', 'CR', 'CP', 'BC', 'CC']
+    let mrasEntities = ['XCR', 'XLP', 'UL', 'CR', 'CP', 'BC', 'CC']
     let { xproJurisdiction } = this.nrData
 
     if ($mrasJurisdictions.includes(xproJurisdiction) && mrasEntities.includes(this.entity_type_cd)) {
@@ -946,8 +946,6 @@ export class NewRequestModule extends VuexModule {
           return 'AL'
         case 'XCR':
           return 'AS'
-        case 'XUL':
-          return 'UA'
         default:
           return ''
       }

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -374,15 +374,6 @@ export class NewRequestModule extends VuexModule {
       rank: 1
     },
     {
-      text: 'Unlimited Liability Co.',
-      cat: 'Corporations',
-      blurb: [
-        'ULC established and operating in another province or country. Plans to operate in BC as well. ',
-        'Has name protection in BC'
-      ],
-      value: 'XUL'
-    },
-    {
       text: 'Limited Liability Co.',
       cat: 'Corporations',
       blurb: [


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5586

*Description of changes:*
Removed XUL from xpro entity types
Removed XUL from the entity type mapping for specified request action codes

Note: There is a reference to 'XUL' in line 949 and 566 in new-request-module. I am not sure whether this should be removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
