### PR TITLE
Extraprovincial Assumed Name flow - Create Name Request

### DIFF
--- a/client/src/components/common/names-capture.vue
+++ b/client/src/components/common/names-capture.vue
@@ -45,79 +45,79 @@
                class="h4 mb-3 ml-n1"
                v-if="editMode">Name Choices
         </v-col>
-        <v-col cols="12" v-if="!editMode && isAssumedName" class="main-message-style">
+        <v-col cols="12" v-if="!editMode && isAssumedName" class="text-body-3">
               Name in Home Jurisdiction: {{name}}
         </v-col>
       </v-row>
-        <v-row>
-          <v-col cols="2" class="py-0 label-style" align-self="start" key="static-1">
-            {{choicesLabelsAndHints[0].label}}
+      <v-row>
+        <v-col cols="2" class="py-0 label-style" align-self="start" key="static-1">
+          {{choicesLabelsAndHints[0].label}}
+        </v-col>
+        <transition name="fade" mode="out-in">
+          <v-col :key="transitionKey(1)" class="ma-0 pa-0" cols="10">
+            <v-row class="ma-0 pa-0" v-if="location === 'BC'">
+              <v-col :cols="designationAtEnd ? 8 : 12" class="py-0" >
+                <v-text-field :autofocus="autofocusField === 'name1'"
+                              :error-messages="messages.name1"
+                              :hide-details="hide"
+                              :value="nameChoices.name1"
+                              @blur="handleBlur()"
+                              @input="editChoices('name1', $event, true)"
+                              filled
+                              id="choice-1-text-field"
+                              :label="choicesLabelsAndHints[0].hint"/>
+              </v-col>
+              <v-col cols="4" class="py-0" v-if="designationAtEnd">
+                <v-select :autofocus="autofocusField === 'des1'"
+                          :error-messages="des1Message"
+                          :hide-details="hide"
+                          :items="items"
+                          :menu-props="props"
+                          :value="nameChoices.designation1"
+                          @blur="handleBlur(); showDesignationErrors.des1 = true"
+                          @input="editChoices('designation1', $event, true)"
+                          filled
+                          id="designation-1-select"
+                          placeholder="Designation" />
+              </v-col>
+            </v-row>
+            <v-row class="ma-0 pa-0" v-else>
+              <v-col :cols="isAssumedName ? 8 : 12" class="py-0" >
+                <v-text-field :autofocus="autofocusField === 'name1'"
+                              :error-messages="messages.name1"
+                              :hide-details="hide"
+                              :value="xproNameWithoutConflict"
+                              @blur="handleBlur()"
+                              @input="editChoices('name1', $event, true)"
+                              :filled="isAssumedName"
+                              id="choice-1-text-field"
+                              :label="choicesLabelsAndHints[0].hint"
+                              :disabled="!isAssumedName"/>
+              </v-col>
+              <v-col cols="4" class="py-0" v-if="isAssumedName">
+                <v-select :autofocus="autofocusField === 'des1'"
+                          :error-messages="des1Message"
+                          :hide-details="hide"
+                          :items="items"
+                          :menu-props="props"
+                          :value="nameChoices.designation1"
+                          @blur="handleBlur(); showDesignationErrors.des1 = true"
+                          @input="editChoices('designation1', $event, true)"
+                          filled
+                          id="designation-1-select"
+                          placeholder="Designation" />
+              </v-col>
+            </v-row>
           </v-col>
-          <transition name="fade" mode="out-in">
-            <v-col :key="transitionKey(1)" class="ma-0 pa-0" cols="10">
-              <v-row class="ma-0 pa-0" v-if="location === 'BC'">
-                <v-col :cols="designationAtEnd ? 8 : 12" class="py-0" >
-                  <v-text-field :autofocus="autofocusField === 'name1'"
-                                :error-messages="messages.name1"
-                                :hide-details="hide"
-                                :value="nameChoices.name1"
-                                @blur="handleBlur()"
-                                @input="editChoices('name1', $event, true)"
-                                filled
-                                id="choice-1-text-field"
-                                :placeholder="choicesLabelsAndHints[0].hint"/>
-                </v-col>
-                <v-col cols="4" class="py-0" v-if="designationAtEnd">
-                  <v-select :autofocus="autofocusField === 'des1'"
-                            :error-messages="des1Message"
-                            :hide-details="hide"
-                            :items="items"
-                            :menu-props="props"
-                            :value="nameChoices.designation1"
-                            @blur="handleBlur(); showDesignationErrors.des1 = true"
-                            @input="editChoices('designation1', $event, true)"
-                            filled
-                            id="designation-1-select"
-                            placeholder="Designation" />
-                </v-col>
-              </v-row>
-              <v-row class="ma-0 pa-0" v-else>
-                <v-col :cols="isAssumedName ? 8 : 12" class="py-0" >
-                  <v-text-field :autofocus="autofocusField === 'name1'"
-                                :error-messages="messages.name1"
-                                :hide-details="hide"
-                                :value="xproNameWithoutConflict"
-                                @blur="handleBlur()"
-                                @input="editChoices('name1', $event, true)"
-                                :filled="isAssumedName"
-                                id="choice-1-text-field"
-                                :placeholder="choicesLabelsAndHints[0].hint"
-                                :disabled="!isAssumedName"/>
-                </v-col>
-                <v-col cols="4" class="py-0" v-if="isAssumedName">
-                  <v-select :autofocus="autofocusField === 'des1'"
-                            :error-messages="des1Message"
-                            :hide-details="hide"
-                            :items="items"
-                            :menu-props="props"
-                            :value="nameChoices.designation1"
-                            @blur="handleBlur(); showDesignationErrors.des1 = true"
-                            @input="editChoices('designation1', $event, true)"
-                            filled
-                            id="designation-1-select"
-                            placeholder="Designation" />
-                </v-col>
-              </v-row>
-            </v-col>
-          </transition>
-        </v-row>
+        </transition>
+      </v-row>
       <v-row v-if="!editMode" class="my-1 py-0 colour-text mt-5">
         <v-col cols="2" class="py-0"></v-col>
-        <v-col cols="10" class="py-0 main-message-style">
+        <v-col cols="10" class="py-0 text-body-3">
           <span v-if="location!=='BC'">
             <span v-if="isAssumedName">
               You may provide up to two additional assumed names which will be considered at no further cost,
-              in the order provided, f your first choice cannot be approved. Be sure to follow
+              in the order provided, if your first choice cannot be approved. Be sure to follow
               all <a :href="buildNameURL" target='_blank'>guidelines for how to build a name.</a>
               <v-icon class="launch-icon">mdi-launch</v-icon>
             </span>
@@ -150,7 +150,7 @@
                               @input="editChoices('name2', $event, true)"
                               filled
                               id="choice-2-text-field"
-                              :placeholder="choicesLabelsAndHints[1].hint" />
+                              :label="choicesLabelsAndHints[1].hint" />
               </v-col>
               <v-col cols="4" class="py-0" v-if="designationAtEnd">
                 <v-select :error-messages="des2Message"
@@ -183,7 +183,7 @@
                               @input="editChoices('name3', $event)"
                               filled
                               id="choice-3-text-field"
-                              :placeholder="choicesLabelsAndHints[2].hint" />
+                              :label="choicesLabelsAndHints[2].hint" />
               </v-col>
               <v-col cols="4" class="py-0" style="height: 60px" v-if="designationAtEnd">
                 <v-select :error-messages="des3Message"
@@ -787,12 +787,8 @@ export default class NamesCapture extends Vue {
   line-height: 14px !important;
 }
 
-.main-message-style {
-  font-size: 14px;
-  color: #495057;
-}
 .label-style {
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: bold;
   color: #212529;
 }

--- a/client/src/components/common/names-capture.vue
+++ b/client/src/components/common/names-capture.vue
@@ -45,11 +45,13 @@
                class="h4 mb-3 ml-n1"
                v-if="editMode">Name Choices
         </v-col>
+        <v-col cols="12" v-if="!editMode && isAssumedName" class="main-message-style">
+              Name in Home Jurisdiction: {{name}}
+        </v-col>
       </v-row>
-
         <v-row>
-          <v-col cols="2" class="py-0 h5" align-self="start" key="static-1">
-            First Choice
+          <v-col cols="2" class="py-0 label-style" align-self="start" key="static-1">
+            {{choicesLabelsAndHints[0].label}}
           </v-col>
           <transition name="fade" mode="out-in">
             <v-col :key="transitionKey(1)" class="ma-0 pa-0" cols="10"><v-row class="ma-0 pa-0">
@@ -61,7 +63,8 @@
                           @blur="handleBlur()"
                           @input="editChoices('name1', $event, true)"
                           filled
-                          id="choice-1-text-field" />
+                          id="choice-1-text-field"
+                          :placeholder="choicesLabelsAndHints[0].hint"/>
           </v-col>
           <v-col cols="4" class="py-0" v-if="designationAtEnd">
             <v-select :autofocus="autofocusField === 'des1'"
@@ -79,15 +82,15 @@
             </v-row></v-col>
           </transition>
         </v-row>
-      <v-row v-if="!editMode" class="my-1 py-0 colour-text">
-        <v-col cols="2" v-if="isAssumedName" class="py-0"></v-col>
-        <v-col cols="10" class="py-0" :class="isAssumedName ? 'copy-bold' : ''">
-          {{ mainMessage}}
+      <v-row v-if="!editMode" class="my-1 py-0 colour-text mt-5">
+        <v-col cols="2" class="py-0"></v-col>
+        <v-col cols="10" class="py-0 main-message-style"
+        v-html='mainMessage'>
         </v-col>
       </v-row>
-      <v-row class="mt-2">
-        <v-col cols="2" class="py-0 h5" align-self="start" key="static-2">
-          Second Choice
+      <v-row class="mt-5">
+        <v-col cols="2" class="py-0 label-style" align-self="start" key="static-2">
+          {{choicesLabelsAndHints[1].label}}
         </v-col>
         <transition name="fade" mode="out-in">
           <v-col :key="transitionKey(2)" class="ma-0 pa-0" cols="10">
@@ -101,7 +104,7 @@
                               @input="editChoices('name2', $event, true)"
                               filled
                               id="choice-2-text-field"
-                              placeholder="Second Alternate Name (Optional)" />
+                              :placeholder="choicesLabelsAndHints[1].hint" />
               </v-col>
               <v-col cols="4" class="py-0" v-if="designationAtEnd">
                 <v-select :error-messages="des2Message"
@@ -119,14 +122,14 @@
           </v-col>
         </transition>
       </v-row>
-      <v-row no gutters class="mt-2" key="static-3">
-        <v-col cols="2" class="py-0 h5" align-self="start">
-          Third Choice
+      <v-row no gutters class="mt-5" key="static-3">
+        <v-col cols="2" class="py-0 label-style" align-self="start">
+          {{choicesLabelsAndHints[2].label}}
         </v-col>
         <transition name="fade" mode="out-in">
           <v-col :key="transitionKey(3)" class="ma-0 pa-0" cols="10">
             <v-row class="ma-0 pa-0">
-              <v-col :cols="designationAtEnd ? 8: 12" class="py-0" style="height:60px">
+              <v-col :cols="designationAtEnd? 8: 12" class="py-0" style="height:60px">
                 <v-text-field :error-messages="messages.name3"
                               :hide-details="hide"
                               :value="nameChoices.name3"
@@ -134,7 +137,7 @@
                               @input="editChoices('name3', $event)"
                               filled
                               id="choice-3-text-field"
-                              placeholder="Third Alternate Name (Optional)" />
+                              :placeholder="choicesLabelsAndHints[2].hint" />
               </v-col>
               <v-col cols="4" class="py-0" style="height: 60px" v-if="designationAtEnd">
                 <v-select :error-messages="des3Message"
@@ -301,13 +304,46 @@ export default class NamesCapture extends Vue {
     return ''
   }
   get designationAtEnd () {
-    if (this.location === 'BC') {
-      if (this.entity_type_cd && this.$designations[this.entity_type_cd]) {
-        return this.$designations[this.entity_type_cd].end
-      }
+    if (this.entity_type_cd && this.$designations[this.entity_type_cd]) {
+      return this.$designations[this.entity_type_cd].end
     }
     return false
   }
+
+  get choicesLabelsAndHints () {
+    if (this.isAssumedName) {
+      return [
+        {
+          'label': 'Assumed Name First Choice',
+          'hint': 'Enter your first choice for an assumed name (Optional)'
+        },
+        {
+          'label': 'Assumed Name Second Choice',
+          'hint': 'Enter your second choice for an assumed name (Optional)'
+        },
+        {
+          'label': 'Assumed Name Third Choice',
+          'hint': 'Enter your third choice for an assumed name (Optional)'
+        }
+      ]
+    } else {
+      return [
+        {
+          'label': 'Name in Home Jurisdiction',
+          'hint': ''
+        },
+        {
+          'label': 'Assumed Name First Choice',
+          'hint': 'Enter your first choice for an assumed name (Optional)'
+        },
+        {
+          'label': 'Assumed Name Second Choice',
+          'hint': 'Enter your second choice for an assumed name (Optional)'
+        }
+      ]
+    }
+  }
+
   get editMode () {
     return newReqModule.editMode
   }
@@ -490,11 +526,13 @@ export default class NamesCapture extends Vue {
   }
   get mainMessage () {
     if (this.isAssumedName) {
-      return `${this.name} is too similar to a name already in use. Please enter a new name such as your
-        corporation number.`
+      return `You may provide up to two additional assumed names which will be considered at no further cost, in the
+        order provided, if your first choice cannot be approved. Be sure to follow all 
+        <a href='' target='_blank'>guidelines for how to build a name.</a>`
     }
-    return `You may provide up to two additional names which will be considered at no further cost, in the
-        order provided, only if your First Choice cannot be approved.`
+    return `You may provide up to two additional assumed names which will be considered at no further cost, in the
+        order provided, if the name in the home jurisdiction cannot be approved. Be sure to follow all 
+        <a href='' target='_blank'>guidelines for how to build a name.</a>`
   }
   get name () {
     return newReqModule.name
@@ -676,4 +714,12 @@ export default class NamesCapture extends Vue {
 <style scoped lang="sass">
 ::v-deep .v-messages__message
   line-height: 14px !important
+
+.main-message-style
+  font-size: 14px
+  color: #495057
+.label-style
+  font-size: 16px
+  font-weight: bold
+  color: #212529
 </style>

--- a/client/src/components/common/names-capture.vue
+++ b/client/src/components/common/names-capture.vue
@@ -426,7 +426,7 @@ export default class NamesCapture extends Vue {
     return newReqModule.isAssumedName
   }
   get isValid () {
-    let { nameChoices, messages, designationAtEnd, validatePhrases } = this
+    let { nameChoices, messages, designationAtEnd, validatePhrases, location, isAssumedName } = this
     if (this.isAssumedName && this.editMode) {
       if (!nameChoices['name1']) {
         messages['name1'] = 'Please enter at least one name'
@@ -444,6 +444,9 @@ export default class NamesCapture extends Vue {
           messages['name1'] = 'Please enter a first choice before any subsequent choices'
           return false
         }
+      }
+      if (designationAtEnd && !nameChoices.designation1) {
+        return false
       }
       let outcome = true
       for (let choice of [1, 2, 3]) {
@@ -468,8 +471,10 @@ export default class NamesCapture extends Vue {
           messages.name1 = 'Please enter at least one name'
         }
       }
-      if (designationAtEnd && !nameChoices.designation1) {
-        messages.des1 = 'Please choose a designation'
+      if (location === 'BC') {
+        if (designationAtEnd && !nameChoices.designation1) {
+          messages.des1 = 'Please choose a designation'
+        }
       }
       if (messages.name1 || messages.des1) {
         return false
@@ -604,7 +609,7 @@ export default class NamesCapture extends Vue {
   }
   get xproNameWithoutConflict () {
     var name = this.nameChoices.name1
-    if (this.nameChoices.designation1) {
+    if (!this.isAssumedName && this.nameChoices.designation1) {
       name = `${name} ${this.nameChoices.designation1}`
     }
     return name

--- a/client/src/components/common/names-capture.vue
+++ b/client/src/components/common/names-capture.vue
@@ -54,32 +54,61 @@
             {{choicesLabelsAndHints[0].label}}
           </v-col>
           <transition name="fade" mode="out-in">
-            <v-col :key="transitionKey(1)" class="ma-0 pa-0" cols="10"><v-row class="ma-0 pa-0">
-          <v-col :cols="designationAtEnd ? 8 : 12" class="py-0" >
-            <v-text-field :autofocus="autofocusField === 'name1'"
-                          :error-messages="messages.name1"
-                          :hide-details="hide"
-                          :value="nameChoices.name1"
-                          @blur="handleBlur()"
-                          @input="editChoices('name1', $event, true)"
-                          filled
-                          id="choice-1-text-field"
-                          :placeholder="choicesLabelsAndHints[0].hint"/>
-          </v-col>
-          <v-col cols="4" class="py-0" v-if="designationAtEnd">
-            <v-select :autofocus="autofocusField === 'des1'"
-                      :error-messages="des1Message"
-                      :hide-details="hide"
-                      :items="items"
-                      :menu-props="props"
-                      :value="nameChoices.designation1"
-                      @blur="handleBlur(); showDesignationErrors.des1 = true"
-                      @input="editChoices('designation1', $event, true)"
-                      filled
-                      id="designation-1-select"
-                      placeholder="Designation" />
-          </v-col>
-            </v-row></v-col>
+            <v-col :key="transitionKey(1)" class="ma-0 pa-0" cols="10">
+              <v-row class="ma-0 pa-0" v-if="location === 'BC'">
+                <v-col :cols="designationAtEnd ? 8 : 12" class="py-0" >
+                  <v-text-field :autofocus="autofocusField === 'name1'"
+                                :error-messages="messages.name1"
+                                :hide-details="hide"
+                                :value="nameChoices.name1"
+                                @blur="handleBlur()"
+                                @input="editChoices('name1', $event, true)"
+                                filled
+                                id="choice-1-text-field"
+                                :placeholder="choicesLabelsAndHints[0].hint"/>
+                </v-col>
+                <v-col cols="4" class="py-0" v-if="designationAtEnd">
+                  <v-select :autofocus="autofocusField === 'des1'"
+                            :error-messages="des1Message"
+                            :hide-details="hide"
+                            :items="items"
+                            :menu-props="props"
+                            :value="nameChoices.designation1"
+                            @blur="handleBlur(); showDesignationErrors.des1 = true"
+                            @input="editChoices('designation1', $event, true)"
+                            filled
+                            id="designation-1-select"
+                            placeholder="Designation" />
+                </v-col>
+              </v-row>
+              <v-row class="ma-0 pa-0" v-else>
+                <v-col :cols="isAssumedName ? 8 : 12" class="py-0" >
+                  <v-text-field :autofocus="autofocusField === 'name1'"
+                                :error-messages="messages.name1"
+                                :hide-details="hide"
+                                :value="xproNameWithoutConflict"
+                                @blur="handleBlur()"
+                                @input="editChoices('name1', $event, true)"
+                                :filled="isAssumedName"
+                                id="choice-1-text-field"
+                                :placeholder="choicesLabelsAndHints[0].hint"
+                                :disabled="!isAssumedName"/>
+                </v-col>
+                <v-col cols="4" class="py-0" v-if="isAssumedName">
+                  <v-select :autofocus="autofocusField === 'des1'"
+                            :error-messages="des1Message"
+                            :hide-details="hide"
+                            :items="items"
+                            :menu-props="props"
+                            :value="nameChoices.designation1"
+                            @blur="handleBlur(); showDesignationErrors.des1 = true"
+                            @input="editChoices('designation1', $event, true)"
+                            filled
+                            id="designation-1-select"
+                            placeholder="Designation" />
+                </v-col>
+              </v-row>
+            </v-col>
           </transition>
         </v-row>
       <v-row v-if="!editMode" class="my-1 py-0 colour-text mt-5">
@@ -311,36 +340,53 @@ export default class NamesCapture extends Vue {
   }
 
   get choicesLabelsAndHints () {
-    if (this.isAssumedName) {
+    if (this.location === 'BC') {
       return [
         {
-          'label': 'Assumed Name First Choice',
-          'hint': 'Enter your first choice for an assumed name (Optional)'
-        },
-        {
-          'label': 'Assumed Name Second Choice',
-          'hint': 'Enter your second choice for an assumed name (Optional)'
-        },
-        {
-          'label': 'Assumed Name Third Choice',
-          'hint': 'Enter your third choice for an assumed name (Optional)'
-        }
-      ]
-    } else {
-      return [
-        {
-          'label': 'Name in Home Jurisdiction',
+          'label': 'First Choice',
           'hint': ''
         },
         {
-          'label': 'Assumed Name First Choice',
-          'hint': 'Enter your first choice for an assumed name (Optional)'
+          'label': 'Second Choice',
+          'hint': 'Second Alternate Name (Optional)'
         },
         {
-          'label': 'Assumed Name Second Choice',
-          'hint': 'Enter your second choice for an assumed name (Optional)'
+          'label': 'Third Choice',
+          'hint': 'Third Alternate Name (Optional)'
         }
       ]
+    } else {
+      if (this.isAssumedName) {
+        return [
+          {
+            'label': 'Assumed Name First Choice',
+            'hint': 'Enter your first choice for an assumed name'
+          },
+          {
+            'label': 'Assumed Name Second Choice',
+            'hint': 'Enter your second choice for an assumed name (Optional)'
+          },
+          {
+            'label': 'Assumed Name Third Choice',
+            'hint': 'Enter your third choice for an assumed name (Optional)'
+          }
+        ]
+      } else {
+        return [
+          {
+            'label': 'Name in Home Jurisdiction',
+            'hint': ''
+          },
+          {
+            'label': 'Assumed Name First Choice',
+            'hint': 'Enter your first choice for an assumed name (Optional)'
+          },
+          {
+            'label': 'Assumed Name Second Choice',
+            'hint': 'Enter your second choice for an assumed name (Optional)'
+          }
+        ]
+      }
     }
   }
 
@@ -525,14 +571,21 @@ export default class NamesCapture extends Vue {
     return newReqModule.locationOptions
   }
   get mainMessage () {
-    if (this.isAssumedName) {
+    if (this.location !== 'BC') {
+      if (this.isAssumedName) {
+        return `You may provide up to two additional assumed names which will be considered at no further cost, in the
+          order provided, if your first choice cannot be approved. Be sure to follow all 
+          <a href='https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/approval-business-name/how-to-name-business' target='_blank'>guidelines for how to build a name. 
+          </a>`
+      }
       return `You may provide up to two additional assumed names which will be considered at no further cost, in the
-        order provided, if your first choice cannot be approved. Be sure to follow all 
-        <a href='' target='_blank'>guidelines for how to build a name.</a>`
+          order provided, if the name in the home jurisdiction cannot be approved. Be sure to follow all 
+          <a href='https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/approval-business-name/how-to-name-business' target='_blank'>guidelines for how to build a name.
+          </a>`
+    } else {
+      return `You may provide up to two additional names which will be considered at no further cost, in the
+        order provided, only if your First Choice cannot be approved.`
     }
-    return `You may provide up to two additional assumed names which will be considered at no further cost, in the
-        order provided, if the name in the home jurisdiction cannot be approved. Be sure to follow all 
-        <a href='' target='_blank'>guidelines for how to build a name.</a>`
   }
   get name () {
     return newReqModule.name
@@ -548,6 +601,13 @@ export default class NamesCapture extends Vue {
   }
   get requestTypeOptions () {
     return newReqModule.requestTypeOptions
+  }
+  get xproNameWithoutConflict () {
+    var name = this.nameChoices.name1
+    if (this.nameChoices.designation1) {
+      name = `${name} ${this.nameChoices.designation1}`
+    }
+    return name
   }
   set entity_type_cd (type: string) {
     newReqModule.mutateEntityType(type)

--- a/client/src/components/common/names-capture.vue
+++ b/client/src/components/common/names-capture.vue
@@ -113,8 +113,25 @@
         </v-row>
       <v-row v-if="!editMode" class="my-1 py-0 colour-text mt-5">
         <v-col cols="2" class="py-0"></v-col>
-        <v-col cols="10" class="py-0 main-message-style"
-        v-html='mainMessage'>
+        <v-col cols="10" class="py-0 main-message-style">
+          <span v-if="location!=='BC'">
+            <span v-if="isAssumedName">
+              You may provide up to two additional assumed names which will be considered at no further cost,
+              in the order provided, f your first choice cannot be approved. Be sure to follow
+              all <a :href="buildNameURL" target='_blank'>guidelines for how to build a name.</a>
+              <v-icon class="launch-icon">mdi-launch</v-icon>
+            </span>
+            <span v-else>
+              You may provide up to two additional assumed names which will be considered at no further cost,
+              in the order provided, if the name in the home jurisdiction cannot be approved. Be sure to follow
+              all <a :href="buildNameURL" target='_blank'>for how to build a name.</a>
+              <v-icon class="launch-icon">mdi-launch</v-icon>
+            </span>
+          </span>
+          <span v-else>
+            You may provide up to two additional names which will be considered at no further cost, in the
+            order provided, only if your First Choice cannot be approved.`
+          </span>
         </v-col>
       </v-row>
       <v-row class="mt-5">
@@ -575,23 +592,6 @@ export default class NamesCapture extends Vue {
   get locationOptions () {
     return newReqModule.locationOptions
   }
-  get mainMessage () {
-    if (this.location !== 'BC') {
-      if (this.isAssumedName) {
-        return `You may provide up to two additional assumed names which will be considered at no further cost, in the
-          order provided, if your first choice cannot be approved. Be sure to follow all 
-          <a href='https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/approval-business-name/how-to-name-business' target='_blank'>guidelines for how to build a name. 
-          </a>`
-      }
-      return `You may provide up to two additional assumed names which will be considered at no further cost, in the
-          order provided, if the name in the home jurisdiction cannot be approved. Be sure to follow all 
-          <a href='https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/approval-business-name/how-to-name-business' target='_blank'>guidelines for how to build a name.
-          </a>`
-    } else {
-      return `You may provide up to two additional names which will be considered at no further cost, in the
-        order provided, only if your First Choice cannot be approved.`
-    }
-  }
   get name () {
     return newReqModule.name
   }
@@ -613,6 +613,10 @@ export default class NamesCapture extends Vue {
       name = `${name} ${this.nameChoices.designation1}`
     }
     return name
+  }
+  get buildNameURL () {
+    return 'https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/' +
+    'permits-licences/businesses-incorporated-companies/approval-business-name/how-to-name-business'
   }
   set entity_type_cd (type: string) {
     newReqModule.mutateEntityType(type)
@@ -776,15 +780,25 @@ export default class NamesCapture extends Vue {
 }
 </script>
 
-<style scoped lang="sass">
-::v-deep .v-messages__message
-  line-height: 14px !important
+<style lang="scss" scoped>
+@import "@/assets/scss/theme.scss";
 
-.main-message-style
-  font-size: 14px
-  color: #495057
-.label-style
-  font-size: 16px
-  font-weight: bold
-  color: #212529
+::v-deep .v-messages__message {
+  line-height: 14px !important;
+}
+
+.main-message-style {
+  font-size: 14px;
+  color: #495057;
+}
+.label-style {
+  font-size: 16px;
+  font-weight: bold;
+  color: #212529;
+}
+
+.launch-icon {
+  font-size: 1rem;
+  color: $link;
+}
 </style>

--- a/client/src/components/common/names-capture.vue
+++ b/client/src/components/common/names-capture.vue
@@ -799,6 +799,6 @@ export default class NamesCapture extends Vue {
 
 .launch-icon {
   font-size: 1rem;
-  color: $link;
+  color: $app-blue;
 }
 </style>

--- a/client/src/components/new-request/grey-box.vue
+++ b/client/src/components/new-request/grey-box.vue
@@ -195,11 +195,7 @@ export default class GreyBox extends Vue {
     return this.stripAllDesignations(this.originalName)
   }
   get boxIsChecked () {
-    let { type } = this.option
-    // eslint-disable-next-line no-console
-    console.log(type + this.issueIndex)
-    // eslint-disable-next-line no-console
-    console.log(this.requestExaminationOrProvideConsent[this.issueIndex])
+    let { type } = this.option     
     return this.requestExaminationOrProvideConsent[this.issueIndex][type]
   }
   set boxIsChecked (value) {

--- a/client/src/components/new-request/grey-box.vue
+++ b/client/src/components/new-request/grey-box.vue
@@ -88,7 +88,8 @@
             <!-- ASSUMED NAME OPTION BOX -->
             <template v-else-if="option.type === 'assumed_name'">
               <v-col :id="option.type + '-button-checkbox-col'"
-                     class="grey-box-checkbox-button text-center">
+                     class="grey-box-checkbox-button text-center"
+                     v-if="entity_type_cd !== 'XLP' && entity_type_cd !== 'XLL'">
                 <transition name="fade" mode="out-in" >
                   <v-checkbox :error="showError"
                               :key="option.type+'-checkbox'"

--- a/client/src/components/new-request/grey-box.vue
+++ b/client/src/components/new-request/grey-box.vue
@@ -195,7 +195,7 @@ export default class GreyBox extends Vue {
     return this.stripAllDesignations(this.originalName)
   }
   get boxIsChecked () {
-    let { type } = this.option     
+    let { type } = this.option
     return this.requestExaminationOrProvideConsent[this.issueIndex][type]
   }
   set boxIsChecked (value) {

--- a/client/src/components/new-request/grey-box.vue
+++ b/client/src/components/new-request/grey-box.vue
@@ -90,10 +90,19 @@
               <v-col :id="option.type + '-button-checkbox-col'"
                      class="grey-box-checkbox-button text-center">
                 <transition name="fade" mode="out-in" >
+                  <v-checkbox :error="showError"
+                              :key="option.type+'-checkbox'"
+                              :label="checkBoxLabel"
+                              :ripple="false"
+                              :hide-details="true"
+                              class="py-0 my-0"
+                              id="assume-name-checkbox"
+                              v-if="showCheckBoxOrButton === 'checkbox'"
+                              v-model="boxIsChecked" />
                   <ReserveSubmit :key="option.type+'-reserve-submit'"
                                  id="reserve-submit-comp"
                                  setup="assumed"
-                                 v-if="isLastIndex" />
+                                 v-if="isLastIndex && showCheckBoxOrButton === 'button'" />
                 </transition>
               </v-col>
             </template>
@@ -186,6 +195,10 @@ export default class GreyBox extends Vue {
   }
   get boxIsChecked () {
     let { type } = this.option
+    // eslint-disable-next-line no-console
+    console.log(type + this.issueIndex)
+    // eslint-disable-next-line no-console
+    console.log(this.requestExaminationOrProvideConsent[this.issueIndex])
     return this.requestExaminationOrProvideConsent[this.issueIndex][type]
   }
   set boxIsChecked (value) {
@@ -216,7 +229,7 @@ export default class GreyBox extends Vue {
       case 'conflict_self_consent':
         return 'I will submit written consent to the BC Business Registry'
       case 'assumed_name':
-        return 'I want to send my name to be examined as an Assumed Name'
+        return 'I want to assume a name in BC'
       default:
         return ''
     }
@@ -381,22 +394,22 @@ export default class GreyBox extends Vue {
         case 'cancel_to_start':
           return 'button'
         case 'send_to_examiner':
-          if (this.showLastStepButtons.send_to_examiner) {
+          if (this.boxIsChecked) {
             return 'button'
           }
           return 'checkbox'
         case 'obtain_consent':
-          if (this.showLastStepButtons.obtain_consent) {
+          if (this.boxIsChecked) {
             return 'button'
           }
           return 'checkbox'
         case 'conflict_self_consent':
-          if (this.showLastStepButtons.conflict_self_consent) {
+          if (this.boxIsChecked) {
             return 'button'
           }
           return 'checkbox'
         case 'assumed_name':
-          if (this.showLastStepButtons.assumed_name) {
+          if (this.boxIsChecked) {
             return 'button'
           }
           return 'checkbox'

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1165,7 +1165,7 @@ export class NewRequestModule extends VuexModule {
     })
   }
   get isAssumedName () {
-    return !!this.assumedNameOriginal
+    return !!this.assumedNameOriginal || this.request_action_cd === 'ASSUMED'
   }
   get locationOptions () {
     // To save template conditional logic, some locations have duplicate descriptions to align with there request

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1486,7 +1486,7 @@ export class NewRequestModule extends VuexModule {
       while (choiceIdx <= 3) {
         if (nameChoices[`name${choiceIdx}`] as boolean) {
           let combinedName = nameChoices[`name${choiceIdx}`]
-          if (this.location === 'BC' && $designations[this.entity_type_cd].end) {
+          if (($designations[this.entity_type_cd].end)) {
             let des = nameChoices[`designation${choiceIdx}`]
             if (des && !combinedName.endsWith(des)) {
               combinedName = combinedName + ' ' + des

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -744,22 +744,26 @@ export class NewRequestModule extends VuexModule {
     0: {
       send_to_examiner: false,
       obtain_consent: false,
-      conflict_self_consent: false
+      conflict_self_consent: false,
+      assumed_name: false
     },
     1: {
       send_to_examiner: false,
       obtain_consent: false,
-      conflict_self_consent: false
+      conflict_self_consent: false,
+      assumed_name: false
     },
     2: {
       send_to_examiner: false,
       obtain_consent: false,
-      conflict_self_consent: false
+      conflict_self_consent: false,
+      assumed_name: false
     },
     3: {
       send_to_examiner: false,
       obtain_consent: false,
-      conflict_self_consent: false
+      conflict_self_consent: false,
+      assumed_name: false
     }
   }
   requestActions: RequestActionsI[] = [


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5549

*Description of changes:*
Added checkbox for assumed name setup
Toggle functionality for checkboxes ( One checkbox to be active at a time)
Added designation dropdowns for XPRO options
Added the logic to show the designation dropdown + validation for the first name choice only if there is a conflict
Added the read only text box with the user entered value if send to examiner or obtain consent option is selected
Modified the post request to include designations for xpro
Updated the texts and labels in the Name Choices UI based on the location 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
