### PR TITLE
5401 Ux updates

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -242,6 +242,10 @@ export default class App extends Mixins(SessionTimerMixin) {
   flex-flow: column nowrap
   min-height: 100vh
 
+  .sbc-header
+    .v-btn
+      box-shadow: none !important
+
 .loading-container.grayed-out
   opacity: 0.46
   background-color: rgb(33, 33, 33) // grey darken-4

--- a/client/src/components/common/applicant-info-1.vue
+++ b/client/src/components/common/applicant-info-1.vue
@@ -281,7 +281,7 @@
                             placeholder="Postal/Zip Code" />
             </v-col>
           </v-row>
-          <v-row class="mt-2" v-if="showXproJurisdiction && showAllFields">
+          <v-row class="mt-2" v-if="showXproJurisdiction && showAllFields && editMode">
             <v-col cols="6" class="py-0 my-0">
               <label for="xprojurisdiction" class="hidden">Business Jurisdiction</label>
               <v-select :messages="messages['xproJurisdiction']"

--- a/client/src/components/common/applicant-info-2.vue
+++ b/client/src/components/common/applicant-info-2.vue
@@ -84,7 +84,7 @@
                       rows="3" />
         </v-col>
         <v-col cols="2" />
-        <v-col cols="5" v-if="showCorpNum">
+        <v-col cols="5" v-if="showCorpNum === 'colin'">
           <label for="corpNum" class="hidden">Incorporation Number (required)</label>
           <v-text-field :error-messages="corpNumError"
                         :hide-details="hideCorpNum"

--- a/client/src/components/modals/pick-entity-or-conversion.vue
+++ b/client/src/components/modals/pick-entity-or-conversion.vue
@@ -141,7 +141,7 @@ export default class PickEntityOrConversion extends Vue {
     return `${210 * cols > maxThreshold ? maxThreshold : 210 * cols}px`
   }
   entityBlurbs (entity_type_cd: string) {
-    return newReqModule.entityBlurbs.find(type => type.value === entity_type_cd)?.blurbs
+    return newReqModule.entityBlurbs && newReqModule.entityBlurbs.find(type => type.value === entity_type_cd)?.blurbs
   }
   clearEntitySelection () {
     this.entity_type_cd = 'INFO'

--- a/client/src/components/new-request/name-input.vue
+++ b/client/src/components/new-request/name-input.vue
@@ -46,7 +46,7 @@ export default class NameInput extends Vue {
   /** The array of validation rules for the MRAS corp num. */
   private get mrasRules (): Array<Function> {
     return [
-      v => (/^\d+$/.test(v) || 'A corp num is required')
+      v => (/^\d+$/.test(v) || 'A corporate number is required')
     ]
   }
 

--- a/client/src/components/new-request/search.vue
+++ b/client/src/components/new-request/search.vue
@@ -133,12 +133,15 @@
           </template>
         </v-select>
       </v-col>
-      <v-col :cols="isXproMras ? 7 : 12" :class="{ 'pr-0': isXproMras }">
-        <NameInput :class="inputCompClass"
+      <v-col :cols="isXproMras ? 7 : 12" :class="{ 'pr-0': (isXproMras && !isFederal) }">
+        <NameInput v-if="!isFederal"
+                   :class="inputCompClass"
                    :is-mras-search="(isXproMras && !noCorpNum)"
                    id="name-input-component"
                    class="mb-n7 pa-0"
                    @emit-corp-num-validity="corpNumValid = $event"/>
+        <p v-else class="pl-3 mt-n2 text-body-2">Federally incorporated businesses do not need a Name Request. You may
+          register  your extraprovincial business immediately using its existing name at Corporate Online.</p>
       </v-col>
     </v-row>
     <!-- Person name and english checkboxes, render when location is NOT XPro Canada -->
@@ -192,7 +195,7 @@
       <v-col cols="5"></v-col>
     </v-row>
     <!-- Corporate number checkbox, only for XPro Canadian Locations -->
-    <v-row v-else class="mt-n3" no-gutters>
+    <v-row v-else-if="!isFederal" class="mt-n3" no-gutters>
       <v-col class="d-flex justify-end">
         <v-tooltip top min-width="390" content-class="top-tooltip" transition="fade-transition">
           <template v-slot:activator="{ on }">
@@ -216,10 +219,15 @@
     <v-row>
 
     </v-row>
-    <div class="mt-1 text-center">
+    <div v-if="!isFederal" class="mt-1 text-center">
       <v-btn class="search-name-btn"
              :disabled="!corpNumValid"
               @click="handleSubmit()">{{ isXproMras ? 'Search' : 'Search Name'}}</v-btn>
+    </div>
+    <div v-else class="mt-6 mb-n2 text-center">
+      <v-btn class="goto-corporate-btn" :href="corpOnlineLink" target="_blank">
+        Go to Corporate Online to Register <v-icon small class="ml-1">mdi-open-in-new</v-icon>
+      </v-btn>
     </div>
   </v-container>
 </template>
@@ -237,6 +245,7 @@ import { LocationT } from '@/models'
 export default class NewSearch extends Vue {
   /** Local Properties */
   private corpNumValid: boolean = true
+  private corpOnlineLink = 'https://www.corporateonline.gov.bc.ca/'
 
   @Watch('location')
   watchLocation (newVal, oldVal) {
@@ -279,7 +288,7 @@ export default class NewSearch extends Vue {
   entityBlurbs (entity_type_cd: string) {
     return newReqModule.entityBlurbs.find(type => type.value === entity_type_cd)?.blurbs
   }
-  private get isScreenLg () {
+  get isScreenLg () {
     return this.$vuetify.breakpoint.lgAndUp
   }
   get displayedComponent () {
@@ -329,6 +338,9 @@ export default class NewSearch extends Vue {
   }
   get isConversion () {
     return newReqModule.request_action_cd === 'CNV'
+  }
+  get isFederal () {
+    return this.jurisdiction === 'FD'
   }
   get isPersonsName () {
     return newReqModule.isPersonsName
@@ -425,6 +437,9 @@ export default class NewSearch extends Vue {
   min-height: 45px !important;
   width: 200px !important;
   padding: 0 50px 0 50px !important;
+}
+.goto-corporate-btn {
+  min-height: 45px !important;
 }
 /*Deep Vuetify overrides*/
 ::v-deep {

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -870,7 +870,7 @@ export class NewRequestModule extends VuexModule {
     if (!this.showCorpNum) {
       return {
         corpNum: '',
-        homeJurisNum: ''
+        homeJurisNum: this.nrData.homeJurisNum
       }
     }
     if (this.showCorpNum === 'colin') {
@@ -881,7 +881,7 @@ export class NewRequestModule extends VuexModule {
     }
     return {
       corpNum: this.corpNum,
-      homeJurisNum: this.corpNum
+      homeJurisNum: this.nrData.homeJurisNum
     }
   }
   get currentIssue () {
@@ -1063,13 +1063,13 @@ export class NewRequestModule extends VuexModule {
     return ''
   }
   get locationText () {
-    return this.locationOptions.find(options => options.value === this.location).text
+    return this.locationOptions.find(options => options.value === this.location)?.text
   }
   get isXproMras () {
     return (['CA', 'IN'].includes(this.location) && this.request_action_cd !== 'MVE')
   }
   get requestText () {
-    return this.requestActions.find(options => options.value === this.request_action_cd).text
+    return this.requestActions.find(options => options.value === this.request_action_cd)?.text
   }
   get entityTypeOptions () {
     let bcOptions: SelectOptionsI[] = this.entityTypesBC.filter(x => {
@@ -2476,13 +2476,16 @@ export class NewRequestModule extends VuexModule {
     if (this.errors.length > 0) {
       return
     }
-    // MRAS Profile Search
-    if (this.isXproMras && !this.noCorpNum) {
-      const profile = await this.fetchMRASProfile()
-      if (profile) {
-        name = sanitizeName(profile?.LegalEntity?.names?.legalName)
-        this.mutateName(name)
-      } else return
+    if (this.isXproMras) {
+      this.mutateNRData({ key: 'xproJurisdiction', value: this.request_jurisdiction_cd })
+      if (!this.noCorpNum) {
+        const profile = await this.fetchMRASProfile()
+        if (profile) {
+          name = sanitizeName(profile?.LegalEntity?.names?.legalName)
+          this.mutateName(name)
+          this.mutateNRData({ key: 'homeJurisNum', value: this.corpSearch })
+        } else return
+      }
     }
     let testName = this.name.toUpperCase()
     testName = removeExcessSpaces(testName)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5401

*Description of changes:*

* Implemented some more MRAs UX updates.

* Added a Federal Selection Message

* Updated the applicant info components for XPRO requests, to disable the Jurisdiction Selection and only make the Corp Num field on applicant info 3 viewable for BC locations, as it pertains to BC Corp Nums in COLIN, not Extra provincial Corp Nums.

* Updated the Request payload on the POST for Draft Name Reservations


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
