### PR TITLE
5527 - Changes to send certain BC entity_types to xpro-name-analysis

### DIFF
--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -2509,8 +2509,13 @@ export class NewRequestModule extends VuexModule {
     if (this.location === 'BC') {
       if (this.nameIsEnglish && !this.isPersonsName && !this.doNotAnalyzeEntities.includes(this.entity_type_cd)) {
         if (['NEW', 'DBA', 'CHG'].includes(this.request_action_cd)) {
-          this.getNameAnalysis()
-          return
+          if (['DBA', 'FR', 'GP', 'LLP', 'LP'].includes(this.entity_type_cd)) {
+            this.getNameAnalysisXPRO()
+            return
+          } else {
+            this.getNameAnalysis()
+            return
+          }
         }
       }
       this.mutateSubmissionTabComponent('EntityNotAutoAnalyzed')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5527

*Description of changes:*
- Made changes to send BC entity types 'DBA', 'FR', 'GP', 'LLP' and 'LP' to xpro-name-analysis endpoint instead of name-analysis

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
