### PR TITLE
Fixed Names can proceed to Review

### DIFF
--- a/client/src/components/new-request/analyze-results.vue
+++ b/client/src/components/new-request/analyze-results.vue
@@ -756,6 +756,7 @@ export default class AnalyzeResults extends Vue {
       (this.quill as any).setContents([
         { insert: text }
       ])
+      this.handleSubmit(event)
     } catch {
       return
     }

--- a/client/src/components/new-request/analyze-results.vue
+++ b/client/src/components/new-request/analyze-results.vue
@@ -5,6 +5,7 @@
         You are searching for a name for a
         {{ entityText === ' BC Corporation' && location.text === ' BC' ? '' : ' ' + location.text }}
         {{ entityText }}
+        {{json.status}}
       </v-col>
     </template>
     <template v-slot:content>
@@ -277,6 +278,10 @@ export default class AnalyzeResults extends Vue {
     if (newVal) {
       this.finalName = this.name
       this.showActualInput = true
+
+      // Once the name is fixed, inform the UI that no further analysis is required
+      this.json.status = 'Available'
+      this.json.issues = []
     }
   }
 
@@ -485,7 +490,7 @@ export default class AnalyzeResults extends Vue {
     return false
   }
   get headerProps () {
-    if (this.json.status === 'Available') {
+    if (this.isApproved) {
       return {
         class: 'approved',
         icon: 'mdi-check-circle',
@@ -756,7 +761,6 @@ export default class AnalyzeResults extends Vue {
       (this.quill as any).setContents([
         { insert: text }
       ])
-      this.handleSubmit(event)
     } catch {
       return
     }

--- a/client/src/components/new-request/analyze-results.vue
+++ b/client/src/components/new-request/analyze-results.vue
@@ -5,7 +5,6 @@
         You are searching for a name for a
         {{ entityText === ' BC Corporation' && location.text === ' BC' ? '' : ' ' + location.text }}
         {{ entityText }}
-        {{json.status}}
       </v-col>
     </template>
     <template v-slot:content>

--- a/client/tests/unit/analyze-results.spec.ts
+++ b/client/tests/unit/analyze-results.spec.ts
@@ -27,6 +27,7 @@ describe('AnalyzeResults', () => {
   for (let iTestData = 0; iTestData < lengthTestData; iTestData++) {
     let data = testData[iTestData]
     let { name } = data
+    let { corrected } = data
     let lengthIssues = data.analysisJSON.issues.length
 
     describe(`Testing name-analysis with location=BC, request_action=NEW, and entity_type=CR`, () => {
@@ -91,16 +92,20 @@ describe('AnalyzeResults', () => {
           await wrapper.vm.$nextTick()
           done()
         })
-        test('Further Action required message to be displayed', async () => {
-          expect(wrapper.text()).toContain('Further Action Required')
+        // These tests only check conditions after correcting all the Issues..
+        test('Name Ready for review after resoling all issues', async () => {
+          expect(wrapper.text()).toContain('Name Ready for Review')
         })
         test(`this.name === ${data.corrected}`, () => {
           expect(wrapper.vm.name).toBe(data.corrected)
         })
-        test('Altering the name causes the component to resist submission', async () => {
+        test('Cannot alter the name once issues are corrected', async () => {
+          expect(wrapper.find('#name-search-bar').text()).toBe(`${corrected}`)
           wrapper.vm.name = 'ALTERED NAME'
+
           await wrapper.vm.$nextTick()
-          expect(wrapper.text()).toContain('Further Action Required')
+          expect(wrapper.find('#name-search-bar').text()).toBe(`${corrected}`)
+          expect(wrapper.text()).toContain('Name Ready for Review')
         })
       })
     })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5877

*Description of changes:*

* Once names have been corrected(fixed) inform the UI the name is approved, clear issues and proceed to review

* This prevents the UI from sitting in limbo after selecting the recommendations, but waiting for a user to manually search the name again. There is NOT another analysis.

*Notes:*

After a discussion with Kaine and Lorna, we confirmed that it is SAFE for the UI to assume the name is now ready for review once we have handled the designation Issues, as the designation issues are the LAST ones to tackle.

That being said, i will re-work this commit to now indicate the user the name analysis has been corrected and successful from the UI, and to proceed to review.

*QA NOTES:*

* Since the UI is now informing ITSELF when the name has been fixed, it's critical during QA to ensure we don't have any false positive results. Ie.. results that would FAIL analysis but are being sent to examination due to some error in the UI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
