### PR TITLE
Updated Corp Num Implementation

### DIFF
--- a/client/src/store/list-data/request-action-mapping.ts
+++ b/client/src/store/list-data/request-action-mapping.ts
@@ -19,4 +19,6 @@ export const xproMapping: RequestActionMappingI = {
   AML: ['XCR', 'XCP']
 }
 
-export const $colinRequestActions = ['CHG', 'REN']
+export const $colinRequestActions = ['AML', 'CHG', 'CNV', 'REH']
+export const $colinRequestTypes = ['BC', 'CC', 'CR', 'UL']
+export const $xproColinRequestTypes = ['XCR', 'XUL']

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -26,7 +26,8 @@ import {
 } from '@/models'
 
 import store from '@/store'
-import { bcMapping, xproMapping, $colinRequestActions } from '@/store/list-data/request-action-mapping'
+import { bcMapping, xproMapping, $colinRequestActions, $colinRequestTypes, $xproColinRequestTypes }
+  from '@/store/list-data/request-action-mapping'
 import $canJurisdictions, { $mrasJurisdictions } from './list-data/canada-jurisdictions'
 import $designations from './list-data/designations'
 import $intJurisdictions from './list-data/intl-jurisdictions'
@@ -832,11 +833,11 @@ export class NewRequestModule extends VuexModule {
     return (!this.editMode && this.nrState === 'DRAFT') || (!this.editMode && this.submissionType === 'examination')
   }
   get showCorpNum (): 'colin' | 'mras' | false {
-    if (($colinRequestActions.includes(this.request_action_cd) && this.location === 'BC') ||
+    if (($colinRequestActions.includes(this.request_action_cd) && $colinRequestTypes.includes(this.entity_type_cd)) ||
       this.entity_type_cd === 'DBA') {
       return 'colin'
     }
-    if (this.location === 'BC' && this.request_action_cd === 'CNV') {
+    if ($colinRequestActions.includes(this.request_action_cd) && $xproColinRequestTypes.includes(this.entity_type_cd)) {
       return 'colin'
     }
     let mrasEntities = ['XCR', 'XLP', 'UL', 'CR', 'CP', 'BC', 'CC']
@@ -2544,7 +2545,9 @@ export class NewRequestModule extends VuexModule {
   }
   @Action
   checkCOLIN (corpNum: string) {
-    let url = `colin/${corpNum}`
+    // Remove BC prefix as Colin only supports base number with no prefix for BC's
+    const cleanedCorpNum = corpNum.replace(/^BC+/i, '')
+    let url = `colin/${cleanedCorpNum}`
     return axios.post(url, {})
   }
   @Action


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5904 /bcgov/entity#5804 

*DRAFT: Until i can validate with BA's that there is no other request/entity type combinations required here.*

*Description of changes:*

* For BC corp num validation searches, we strip out any BC pre-fixes due to the formatting of BC corp nums in COLIN.

* Re- enable the bc corp num field for the specified requests and entities listed in the ticket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
