### PR TITLE
Additional Comments in namex + disabling manage addresses option in text fields

### DIFF
--- a/client/src/components/common/applicant-info-1.vue
+++ b/client/src/components/common/applicant-info-1.vue
@@ -20,7 +20,8 @@
                             hide-details="auto"
                             id="lastname"
                             :name="Math.random()"
-                            placeholder="Last Name" />
+                            autocomplete="chrome-off"
+                            label="Last Name" />
             </v-col>
             <v-col cols="4" class="pt-0">
               <label for="firstname" class="hidden">First Name</label>
@@ -36,7 +37,8 @@
                             hide-details="auto"
                             id="firstname"
                             :name="Math.random()"
-                            placeholder="First Name" />
+                            autocomplete="chrome-off"
+                            label="First Name" />
             </v-col>
             <v-col cols="4" class="pt-0">
               <label for="middlename" class="hidden">Middle Name (Optional)</label>
@@ -51,7 +53,8 @@
                             hide-details="auto"
                             id="middlename"
                             :name="Math.random()"
-                            placeholder="Middle Name (Optional)" />
+                            autocomplete="chrome-off"
+                            label="Middle Name (Optional)" />
             </v-col>
           </v-row>
 
@@ -72,7 +75,6 @@
                                 :value="applicant.addrLine1"
                                 @blur="blurAddress1"
                                 @input="updateApplicant('addrLine1', $event)"
-                                autocomplete="off"
                                 class="pa-0"
                                 dense
                                 filled
@@ -80,6 +82,7 @@
                                 hide-details="auto"
                                 id="line1"
                                 :name="Math.random()"
+                                autocomplete="chrome-off"
                                 placeholder="Start typing an address here..."
                                 ref="Line1"
                                 single-line />
@@ -150,7 +153,8 @@
                             hide-details="auto"
                             id="1ine2"
                             :name="Math.random()"
-                            placeholder="Additional Street Address (Optional)"
+                            autocomplete="chrome-off"
+                            label="Additional Street Address (Optional)"
                             ref="Line2" />
             </v-col>
           </v-row>
@@ -169,7 +173,8 @@
                             hide-details="auto"
                             id="line3"
                             :name="Math.random()"
-                            placeholder="Additional Street Address (Optional)"
+                            autocomplete="chrome-off"
+                            label="Additional Street Address (Optional)"
                             ref="Line3" />
             </v-col>
           </v-row>
@@ -189,7 +194,8 @@
                             hide-details="auto"
                             id="city"
                             :name="Math.random()"
-                            placeholder="City"
+                            autocomplete="chrome-off"
+                            label="City"
                             ref="City"
               />
             </v-col>
@@ -208,7 +214,8 @@
                         hide-details="auto"
                         id="province"
                         :name="Math.random()"
-                        placeholder="Province"
+                        autocomplete="chrome-off"
+                        label="Province"
                         ref="Province" />
             </v-col>
             <v-col cols="6" class="py-0 my-0" v-else-if="applicant.countryTypeCd === 'US'">
@@ -243,7 +250,8 @@
                             hide-details="auto"
                             id="state"
                             :name="Math.random()"
-                            placeholder="Province/State (Optional, 2 letters max)"
+                            autocomplete="chrome-off"
+                            label="Province/State (Optional, 2 letters max)"
                             ref="state" />
             </v-col>
           </v-row>
@@ -281,7 +289,8 @@
                             hide-details="auto"
                             id="postalcode"
                             :name="Math.random()"
-                            placeholder="Postal/Zip Code" />
+                            autocomplete="chrome-off"
+                            label="Postal/Zip Code" />
             </v-col>
           </v-row>
 

--- a/client/src/components/common/applicant-info-2.vue
+++ b/client/src/components/common/applicant-info-2.vue
@@ -11,9 +11,10 @@
                         @blur="messages = {}"
                         @input="mutateApplicant('emailAddress', $event)"
                         id="emailAddress"
-                        name="emailAddress"
                         filled
                         hide-details="auto"
+                        :name="Math.random()"
+                        autocomplete="chrome-off"
                         label="Email Address (for notifications)" />
         </v-col>
         <v-col cols="5" class="py-0" />
@@ -28,7 +29,8 @@
                         @blur="messages = {}"
                         @input="mutateApplicant('phoneNumber', $event)"
                         id="phoneNumber"
-                        name="phoneNumber"
+                        :name="Math.random()"
+                        autocomplete="chrome-off"
                         filled
                         hide-details="auto"
                         label="Phone Number (Optional)" />
@@ -40,7 +42,8 @@
                         @blur="messages = {}"
                         @input="mutateApplicant('faxNumber', $event)"
                         id="faxNumber"
-                        name="faxNumber"
+                        :name="Math.random()"
+                        autocomplete="chrome-off"
                         filled
                         hide-details="auto"
                         label="Fax Number (Optional)" />
@@ -87,7 +90,8 @@
                         @blur="messages = {}; isEditingCorpNum = false"
                         @focus="messages['corpNum'] = 'Incorporation Number (required)'; isEditingCorpNum = true"
                         id="corpNum"
-                        name="corpNum"
+                        :name="Math.random()"
+                        autocomplete="chrome-off"
                         filled
                         label="Incorporation Number (required)"
                         v-model="corpNum"
@@ -106,7 +110,8 @@
                         @blur="messages = {}"
                         @input="mutateNRData('tradeMark', $event)"
                         id="tradeMark"
-                        name="tradeMark"
+                        :name="Math.random()"
+                        autocomplete="chrome-off"
                         filled
                         hide-details="auto"
                         label="Registered Trademark (Optional)" />

--- a/client/src/components/new-request/name-input.vue
+++ b/client/src/components/new-request/name-input.vue
@@ -3,7 +3,7 @@
     <v-text-field :error-messages="message"
                   @input="clearErrors()"
                   @keydown.enter="handleSubmit"
-                  autocomplete="off"
+                  autocomplete="chrome-off"
                   filled
                   id="name-input-text-field"
                   ref="nameInput"

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1445,6 +1445,32 @@ export class NewRequestModule extends VuexModule {
         data['additionalInfo'] += ' ' + notice
       }
     }
+    for (let step in this.requestExaminationOrProvideConsent) {
+      if (this.requestExaminationOrProvideConsent[step].obtain_consent ||
+        this.requestExaminationOrProvideConsent[step].conflict_self_consent) {
+        if (!data['additionalInfo']) {
+          data['additionalInfo'] = ''
+        }
+        if (!data['additionalInfo'].includes('*** Consent will be supplied')) {
+          data['additionalInfo'] += '\n\n'
+          let notice = `*** Consent will be supplied ***`
+          data['additionalInfo'] += ' ' + notice
+        }
+      }
+      if (this.location !== 'BC') {
+        if (this.requestExaminationOrProvideConsent[step].obtain_consent ||
+          this.requestExaminationOrProvideConsent[step].send_to_examiner) {
+          if (!data['additionalInfo']) {
+            data['additionalInfo'] = ''
+          }
+          if (!data['additionalInfo'].includes('*** Legal Name:')) {
+            data['additionalInfo'] += '\n\n'
+            let notice = `*** Legal Name: ${this.nameChoices.name1} ***`
+            data['additionalInfo'] += ' ' + notice
+          }
+        }
+      }
+    }
     return data
   }
   get editNameReservation () {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5922, /bcgov/entity#5508

*Description of changes:*
Additional info for specific  flows
Disabled Manage Addresses option in text fields in different screens(This is different from the cached value showing up as a list) 
Changed place holders to labels in applicant info 1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
