### PR TITLE
Disable getStats() when FF is set

### DIFF
--- a/client/src/components/new-request/stats.vue
+++ b/client/src/components/new-request/stats.vue
@@ -55,33 +55,37 @@ import { featureFlags } from '@/plugins/featureFlags'
 @Component({})
 export default class Stats extends Vue {
   created (): void {
-    newReqModule.getStats()
+    if (!featureFlags.getFlag('hardcode-wait-times')) {
+      newReqModule.getStats()
+    }
   }
 
   get stats (): StatsI {
     return newReqModule.stats
   }
+
   get autoApprovedCount (): string | number {
-    return (this.stats || {}).auto_approved_count || '0'
+    return (this.stats?.auto_approved_count || '0')
   }
+
   /** The regular wait time, in days. */
   get regularWaitTime (): string | number {
     if (featureFlags.getFlag('hardcode-wait-times')) {
       return 5
     } else {
-      return (this.stats || {}).regular_wait_time || '-'
+      return (this.stats?.regular_wait_time || '-')
     }
   }
+
   /** The priority wait time, in hours. */
   get priorityWaitTime (): string | number {
     if (featureFlags.getFlag('hardcode-wait-times')) {
       return 24
     } else {
-      return (this.stats || {}).priority_wait_time || '-'
+      return (this.stats?.priority_wait_time || '-')
     }
   }
 }
-
 </script>
 
 <style lang="sass" scoped>
@@ -128,5 +132,4 @@ export default class Stats extends Vue {
   padding: 15px 0 0 0 !important
   text-align: center
   max-width: 160px
-
 </style>


### PR DESCRIPTION
*Issue #:* N/A

*Description of changes:* This should prevent some Sentry errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).