### PR TITLE
Error Handling on `addRequestActionComment`

### DIFF
--- a/client/src/components/common/error-modal.vue
+++ b/client/src/components/common/error-modal.vue
@@ -2,14 +2,11 @@
   <v-dialog v-model="showModal">
     <v-card>
       <v-card-title class="d-flex justify-space-between">
-        <div>Name Request Encountered an Error</div>
-        <v-btn icon large class="dialog-close" @click="hideModal()">
-          <v-icon>mdi-close</v-icon>
-        </v-btn>
+        <div>Name Request encountered an error</div>
       </v-card-title>
 
       <v-card-text class="copy-normal">
-        <ul v-if="hasErrors">
+        <ul v-if="hasErrors" class="ml-n1">
           <li v-for="error in errors" :key="error.id" v-html="error.error" />
         </ul>
       </v-card-text>

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1931,8 +1931,6 @@ export class NewRequestModule extends VuexModule {
    */
   @Action
   async confirmAction (action: string): Promise<boolean> {
-    // eslint-disable-next-line no-console
-    console.log('NetWork Call 1 ')
     try {
       const nrData = await this.getNameRequest(this.nr.id)
       if (!nrData) throw new Error('Got error from getNameRequest()')

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1992,7 +1992,8 @@ export class NewRequestModule extends VuexModule {
   }
 
   @Action
-  addRequestActionComment (data) {
+  async addRequestActionComment (data) {
+    data = undefined
     try {
       let requestAction = this.requestActionOriginal || this.request_action_cd
       let { shortDesc } = this.requestActions.find(request => request.value === requestAction)
@@ -2019,7 +2020,10 @@ export class NewRequestModule extends VuexModule {
       return data
     } catch (error) {
       console.error('addRequestActionComment() =', error) // eslint-disable-line no-console
-      throw new Error(`addRequestActionComment() = ${error}`)
+      await errorModule.setAppError(
+        { id: 'add-request-action-error', error: 'An error occurred when building the name request' }
+      )
+      return null
     }
   }
 
@@ -2180,9 +2184,9 @@ export class NewRequestModule extends VuexModule {
     try {
       const { nrId } = this
       const nr = this.editNameReservation
-      const requestData = await this.addRequestActionComment(nr)
+      const requestData = nr && await this.addRequestActionComment(nr)
 
-      const response = await axios.patch(`/namerequests/${nrId}/edit`, requestData, {
+      const response = requestData && await axios.patch(`/namerequests/${nrId}/edit`, requestData, {
         headers: {
           'Content-Type': 'application/json'
         }
@@ -2253,9 +2257,9 @@ export class NewRequestModule extends VuexModule {
           break
       }
 
-      const requestData: any = await this.addRequestActionComment(data)
+      const requestData: any = data && await this.addRequestActionComment(data)
       try {
-        const response: AxiosResponse = await axios.post(`/namerequests`, requestData, {
+        const response: AxiosResponse = requestData && await axios.post(`/namerequests`, requestData, {
           headers: {
             'Content-Type': 'application/json'
           }
@@ -2308,10 +2312,10 @@ export class NewRequestModule extends VuexModule {
         data['corpNum'] = this.corpNum
       }
 
-      const requestData = await this.addRequestActionComment(data)
+      const requestData = data && await this.addRequestActionComment(data)
 
       try {
-        const response = await axios.put(`/namerequests/${nrId}`, requestData, {
+        const response = requestData && await axios.put(`/namerequests/${nrId}`, requestData, {
           headers: {
             'Content-Type': 'application/json'
           }

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1993,7 +1993,6 @@ export class NewRequestModule extends VuexModule {
 
   @Action
   async addRequestActionComment (data) {
-    data = undefined
     try {
       let requestAction = this.requestActionOriginal || this.request_action_cd
       let { shortDesc } = this.requestActions.find(request => request.value === requestAction)

--- a/client/src/store/new-request-module.ts
+++ b/client/src/store/new-request-module.ts
@@ -1931,6 +1931,8 @@ export class NewRequestModule extends VuexModule {
    */
   @Action
   async confirmAction (action: string): Promise<boolean> {
+    // eslint-disable-next-line no-console
+    console.log('NetWork Call 1 ')
     try {
       const nrData = await this.getNameRequest(this.nr.id)
       if (!nrData) throw new Error('Got error from getNameRequest()')
@@ -2007,7 +2009,7 @@ export class NewRequestModule extends VuexModule {
         return data
       }
       // by here we know there is some text in additionalInfo but it does not contain the exact msg we must add
-      // so we check if there is a previous requet_action message which no longer matches msg because we are editing
+      // so we check if there is a previous request_action message which no longer matches msg because we are editing
       let allShortDescs = this.requestActions.map(request => `*** ${request.shortDesc} ***`)
       if (allShortDescs.some(desc => data['additionalInfo'].includes(desc))) {
         let desc = allShortDescs.find(sd => data['additionalInfo'].includes(sd))
@@ -2019,7 +2021,7 @@ export class NewRequestModule extends VuexModule {
       return data
     } catch (error) {
       console.error('addRequestActionComment() =', error) // eslint-disable-line no-console
-      return data
+      throw new Error(`addRequestActionComment() = ${error}`)
     }
   }
 
@@ -2271,6 +2273,7 @@ export class NewRequestModule extends VuexModule {
       } catch (err) {
         console.error('postNameRequests() =', err) // eslint-disable-line no-console
         await handleApiError(err, 'Could not create the name request')
+        return false
       }
     } catch (error) {
       console.error('postNameRequests() =', error) // eslint-disable-line no-console


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5981

*Description of changes:*

* Throw an error instead of returning the data if a failure occurs in the `addRequestActionComment` method.

* Minor adjustments to the Error modal.

* Short circuited the network requests, to not make the call if the data had any failures when structured.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
