### PR TITLE
Implemented optional fields length rules

### DIFF
--- a/client/src/components/common/applicant-info-2.vue
+++ b/client/src/components/common/applicant-info-2.vue
@@ -26,6 +26,7 @@
           <label for="faxNumber" class="hidden">Phone Number (Optional)</label>
           <v-text-field :messages="messages['phone']"
                         :value="applicant.phoneNumber"
+                        :rules="phoneFaxRules"
                         @blur="messages = {}"
                         @input="mutateApplicant('phoneNumber', $event)"
                         id="phoneNumber"
@@ -39,6 +40,7 @@
           <label for="faxNumber" class="hidden">Fax Number (Optional)</label>
           <v-text-field :messages="messages['fax']"
                         :value="applicant.faxNumber"
+                        :rules="phoneFaxRules"
                         @blur="messages = {}"
                         @input="mutateApplicant('faxNumber', $event)"
                         id="faxNumber"
@@ -70,6 +72,7 @@
           <label for="additionalInfo" class="hidden">Additional Business Info (Optional)</label>
           <v-textarea :messages="messages['additional']"
                       :value="nrData.additionalInfo"
+                      :rules="additionalInfoRules"
                       @blur="messages = {}"
                       @input="mutateNRData('additionalInfo', $event)"
                       id="additionalInfo"
@@ -107,6 +110,7 @@
           <label for="tradeMark" class="hidden">Registered Trademark (Optional)</label>
           <v-text-field :messages="messages['tradeMark']"
                         :value="nrData.tradeMark"
+                        :rules="trademarkRules"
                         @blur="messages = {}"
                         @input="mutateNRData('tradeMark', $event)"
                         id="tradeMark"
@@ -162,6 +166,15 @@ export default class ApplicantInfo2 extends Vue {
   emailRules = [
     v => !!v || 'Required field',
     v => /.+@.+\..+/.test(v) || 'Not a valid email'
+  ]
+  additionalInfoRules = [
+    v => (!v || v.length <= 120) || 'Cannot exceed 120 characters'
+  ]
+  phoneFaxRules = [
+    v => (!v || v.length <= 30) || 'Cannot exceed 30 characters'
+  ]
+  trademarkRules = [
+    v => (!v || v.length <= 100) || 'Cannot exceed 100 characters'
   ]
   error: boolean = false
   isEditingCorpNum: boolean = false

--- a/client/src/components/common/applicant-info-3.vue
+++ b/client/src/components/common/applicant-info-3.vue
@@ -31,6 +31,7 @@
         <v-col cols="5">
           <v-text-field :messages="messages['phone']"
                         :value="applicant.phoneNumber"
+                        :rules="phoneFaxRules"
                         @blur="messages = {}"
                         @focus="messages['phone'] = 'Phone Number (Optional)'"
                         @input="mutateApplicant('phoneNumber', $event)"
@@ -41,6 +42,7 @@
         <v-col cols="5">
           <v-text-field :messages="messages['fax']"
                         :value="applicant.faxNumber"
+                        :rules="phoneFaxRules"
                         @blur="messages = {}"
                         @focus="messages['fax'] = 'Fax Number (Optional)'"
                         @input="mutateApplicant('faxNumber', $event)"
@@ -91,6 +93,7 @@
         <v-col cols="5" align-self="start">
           <v-textarea :messages="messages['additional']"
                       :value="nrData.additionalInfo"
+                      :rules="additionalInfoRules"
                       @blur="messages = {}"
                       @focus="messages['additional'] = 'Additional Info'"
                       @input="mutateNRData('additionalInfo', $event)"
@@ -126,6 +129,7 @@
         <v-col cols="5">
           <v-text-field :messages="messages['tradeMark']"
                         :value="nrData.tradeMark"
+                        :rules="trademarkRules"
                         @blur="messages = {}"
                         @focus="messages['tradeMark'] = 'Registered Trademark (Optional)'"
                         @input="mutateNRData('tradeMark', $event)"
@@ -176,6 +180,15 @@ export default class ApplicantInfo3 extends Vue {
   emailRules = [
     v => !!v || 'Required field',
     v => /.+@.+\..+/.test(v) || 'Not a valid email'
+  ]
+  additionalInfoRules = [
+    v => (!v || v.length <= 120) || 'Cannot exceed 120 characters'
+  ]
+  phoneFaxRules = [
+    v => (!v || v.length <= 30) || 'Cannot exceed 30 characters'
+  ]
+  trademarkRules = [
+    v => (!v || v.length <= 100) || 'Cannot exceed 100 characters'
   ]
   error: boolean = false
   isValid: boolean = false


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5991

*Description of changes:*

* Applied Vue form rules to all the optional fields in the applicant info 1 & 2 components.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
