### PR TITLE
Prevent cache on the Search Pending

### DIFF
--- a/client/src/views/landing.vue
+++ b/client/src/views/landing.vue
@@ -33,7 +33,7 @@
         </v-col>
         <div class="main-container-style mt-3">
           <transition name="fade" mode="out-in" :duration="{ enter: 100, leave: 100 }">
-            <keep-alive :include="['Tabs', 'AnalyzePending']">
+            <keep-alive :include="['Tabs']">
               <component :is="displayedComponent" :key="displayedComponent" transition="fade-transition" />
             </keep-alive>
           </transition>


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*

* fix to hopefully prevent persistent tooltips from the Analyze Pending component during a quick transition.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
