### PR TITLE
Cancel the payment modal timer

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/client/src/components/payment/payment-modal.vue
+++ b/client/src/components/payment/payment-modal.vue
@@ -74,6 +74,10 @@ import { getBaseUrl } from './payment-utils'
     onCancel: {
       type: Function,
       default: async () => {}
+    },
+    stopTimer: {
+      type: Function,
+      default: async () => undefined
     }
   }
 })
@@ -103,6 +107,11 @@ export default class PaymentModal extends Mixins(
 
   /** Clears store property to hide this modal. */
   async hideModal () {
+    // stop timer because we don't need it any more
+    const { stopTimer } = this.$props
+    if (typeof stopTimer === 'function') {
+      stopTimer()
+    }
     this.isLoadingPayment = false
     await PaymentModule.togglePaymentModal(false)
   }
@@ -135,8 +144,16 @@ export default class PaymentModal extends Mixins(
 
   /** Called when user clicks "Continue to Payment" button. */
   private async confirmPayment () {
+    // stop timer now so delays in creating payment don't
+    // inadvertently cause timer expiry and app reset
+    const { stopTimer } = this.$props
+    if (typeof stopTimer === 'function') {
+      stopTimer()
+    }
+
     this.isLoadingPayment = true
     const { nrId, priorityRequest } = this
+
     const onSuccess = (paymentResponse) => {
       const { paymentId, paymentToken } = this
       // Save response to session

--- a/client/src/modules/vx-timer/store/actions.ts
+++ b/client/src/modules/vx-timer/store/actions.ts
@@ -5,9 +5,9 @@ export const createAndStartTimer = ({ commit }, opts: TimerOptions) => {
   commit(types.CREATE_AND_START_TIMER, opts)
 }
 
-export const createPromiseTimer = ({ commit }, opts: TimerOptions) => {
-  commit(types.CREATE_PROMISE_TIMER, opts)
-}
+// export const createPromiseTimer = ({ commit }, opts: TimerOptions) => {
+//   commit(types.CREATE_PROMISE_TIMER, opts)
+// }
 
 export const restartTimer = ({ commit }, opts: TimerOptions) => {
   commit(types.RESTART_TIMER, opts)

--- a/client/src/modules/vx-timer/store/mutations.ts
+++ b/client/src/modules/vx-timer/store/mutations.ts
@@ -1,12 +1,12 @@
-import * as types from './types'
 import { Timer, TimerOptions } from '../timer'
+
 // TODO: Do something to correct IDE param detection... maybe we can curry these or something.
 export default {
   createAndStartTimer: (state, opts: TimerOptions): Timer | undefined => {
     const { id } = opts
     const { timers } = state
     if (!id) throw new Error(`[Error] Timer needs an ID, none provided`)
-
+    // console.info('Creating and starting timer =', id) // eslint-disable-line no-console
     const timer = new Timer(opts)
     // Add the timer to state
     timers[id] = timer
@@ -14,41 +14,42 @@ export default {
     state.timers = timers
     return timer
   },
-  createPromiseTimer: (state, opts: TimerOptions): Promise<Timer | any> => {
-    const { id, timeoutMs } = opts
-    const { timers } = state
-    if (!id) throw new Error(`[Error] Timer needs an ID, none provided`)
-    if (timers.hasOwnProperty(id)) {
-      // eslint-disable-next-line no-console
-      console.warn(`[Warning] Timer [${id}] already exists`)
-      return
-    }
-
-    const promiseTimer = new Promise((resolve) => {
-      const timer = new Timer({
-        id: `promiseTimer:${id}`,
-        timeoutMs: timeoutMs,
-        expirationFn: () => {
-          // eslint-disable-next-line no-debugger
-          // alert('Promise expired')
-          resolve()
-        },
-        pollRate: 100 // Check every 100 milliseconds
-      })
-      // Add the timer to state
-      timers[id] = timer
-      timer.start()
-      state.timers = timers
-    })
-
-    return promiseTimer
-  },
+  // NOT USED
+  // createPromiseTimer: (state, opts: TimerOptions): Promise<Timer | any> => {
+  //   const { id, timeoutMs } = opts
+  //   const { timers } = state
+  //   if (!id) throw new Error(`[Error] Timer needs an ID, none provided`)
+  //   if (timers.hasOwnProperty(id)) {
+  //     // eslint-disable-next-line no-console
+  //     console.warn(`[Warning] Timer [${id}] already exists`)
+  //     return
+  //   }
+  //   const promiseTimer = new Promise((resolve) => {
+  //     const timer = new Timer({
+  //       id: `promiseTimer:${id}`,
+  //       timeoutMs: timeoutMs,
+  //       expirationFn: () => {
+  //         // eslint-disable-next-line no-debugger
+  //         // alert('Promise expired')
+  //         resolve(null)
+  //       },
+  //       pollRate: 100 // Check every 100 milliseconds
+  //     })
+  //     // Add the timer to state
+  //     timers[id] = timer
+  //     timer.start()
+  //     state.timers = timers
+  //   })
+  //   return promiseTimer
+  // },
   restartTimer: (state, opts: TimerOptions): void => {
     const { id } = opts
     const { timers } = state
     if (!id) throw new Error(`[Error] Timer ID was not provided`)
     if (!timers.hasOwnProperty(id)) throw new Error(`[Error] Timer with ID [${id}] does not exist`)
+    // console.info('Restarting timer =', id) // eslint-disable-line no-console
     const timer = timers[id]
+    // Update the timer in state
     timers[id] = timer
     state.timers = timers
   },
@@ -57,13 +58,13 @@ export default {
     const { timers } = state
     if (!id) throw new Error(`[Error] Timer ID was not provided`)
     if (!timers.hasOwnProperty(id)) throw new Error(`[Error] Timer with ID [${id}] does not exist`)
+    // console.info('Refreshing timer =', id) // eslint-disable-line no-console
     const timer = timers[id]
-
     timer.refresh()
     if (timeoutMs) {
       timer.timeoutMs = timeoutMs
     }
-
+    // Update the timer in state
     timers[id] = timer
     state.timers = timers
   },
@@ -73,7 +74,9 @@ export default {
     if (!id) throw new Error(`[Error] Timer ID was not provided`)
     const timer = timers[id]
     if (timer) {
+      // console.info('Stopping timer =', id) // eslint-disable-line no-console
       timer.stop()
+      // Remove the timer from state
       delete timers[id]
       state.timers = timers
     }

--- a/client/src/modules/vx-timer/store/types.ts
+++ b/client/src/modules/vx-timer/store/types.ts
@@ -1,6 +1,6 @@
 export const GET_TIMER = 'getTimer'
 export const CREATE_AND_START_TIMER = 'createAndStartTimer'
-export const CREATE_PROMISE_TIMER = 'createPromiseTimer'
+// export const CREATE_PROMISE_TIMER = 'createPromiseTimer'
 export const RESTART_TIMER = 'restartTimer'
 export const REFRESH_TIMER = 'refreshTimer'
 export const STOP_TIMER = 'stopTimer'

--- a/client/tests/unit/analyze-results.spec.ts
+++ b/client/tests/unit/analyze-results.spec.ts
@@ -52,7 +52,7 @@ describe('AnalyzeResults', () => {
                 // eslint-disable-next-line
                 let checkbox = wrapper.find('#provide-consent-checkbox')
                 await checkbox.setChecked()
-                return new Promise(resolve => { resolve() })
+                return new Promise(resolve => { resolve(null) })
 
               case 'designation_non_existent':
               case 'designation_mismatch':
@@ -60,13 +60,13 @@ describe('AnalyzeResults', () => {
                 // eslint-disable-next-line
                 let designation = wrapper.find('#designation-btn-0')
                 await designation.trigger('click')
-                return new Promise(resolve => { resolve() })
+                return new Promise(resolve => { resolve(null) })
 
               case 'designation_misplaced':
                 // eslint-disable-next-line
                 let move = wrapper.find('#move-designation-btn')
                 await move.trigger('click')
-                return new Promise(resolve => { resolve() })
+                return new Promise(resolve => { resolve(null) })
             }
           }
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6025

*Description of changes:*

This is a necessary first part of the subject ticket. My plan is to get this into Prod and then see what errors remain.

- updated app version to 0.2.5
- stop payment completion timer when modal is hidden
- stop payment completion timer when modal is confirmed
- commented out unused method, etc (may be reinstated later)
- commented out timer debugging (may be useful later)
- fixed some resolve warnings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).