### PR TITLE
Updated Proxy KC Url

### DIFF
--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -37,7 +37,7 @@ module.exports = {
     proxy: {
       // this is needed to prevent a CORS error when running locally
       '/local-keycloak-config-url/*': {
-        target: 'https://namerequest-dev.pathfinder.gov.bc.ca/namerequest/keycloak/',
+        target: 'https://dev.bcregistry.ca/namerequest/config/kc/',
         pathRewrite: {
           '/local-keycloak-config-url': ''
         }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5866

*Description of changes:*

* Updated Proxy KC Url

* Verified logout after account switching. Although after changing account, you are left on the Business Registries page when routing back to Name Request, logout will succeed.

* (Verified Locally ONLY, as Auth is disabled in DEV)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
