### PR TITLE
6337 - all date formats consistent - full month and no "th" on dates

### DIFF
--- a/client/src/components/existing-request/existing-request-display.vue
+++ b/client/src/components/existing-request/existing-request-display.vue
@@ -284,14 +284,14 @@ export default class ExistingRequestDisplay extends Mixins(
 
   private get consentDate () {
     if (this.nr.consent_dt) {
-      return Moment(this.nr.consent_dt).tz('America/Vancouver').format('MMM Do[,] YYYY')
+      return Moment(this.nr.consent_dt).tz('America/Vancouver').format('MMMM D[,] YYYY')
     }
     return 'Not Yet Received'
   }
 
   private get expiryDate () {
     if (this.nr.expirationDate) {
-      return Moment(this.nr.expirationDate).tz('America/Vancouver').format('MMM Do[,] YYYY')
+      return Moment(this.nr.expirationDate).tz('America/Vancouver').format('MMMM D[,] YYYY')
     }
     return ''
   }
@@ -306,7 +306,7 @@ export default class ExistingRequestDisplay extends Mixins(
       let reviewDate = new Date()
       // add the number of days to the current date to get the review date
       reviewDate.setDate(reviewDate.getDate() + waitingTime)
-      return Moment(reviewDate).tz('America/Vancouver').format("MMM Do[,] YYYY") + " (" + this.nr.waiting_time + " days)"
+      return Moment(reviewDate).tz('America/Vancouver').format("MMMM D[,] YYYY") + " (" + this.nr.waiting_time + " days)"
     }
     return ""
   }
@@ -314,14 +314,14 @@ export default class ExistingRequestDisplay extends Mixins(
   private get queueDate () {
     if (this.nr.oldest_draft) {
       let oldest_draft = Moment(this.nr.oldest_draft)
-      return oldest_draft.tz('America/Vancouver').format("MMM Do[,] YYYY")
+      return oldest_draft.tz('America/Vancouver').format("MMMM D[,] YYYY")
     }
     return ""
   }
 
   private get submittedDate () {
     if (this.nr.submittedDate) {
-      return Moment(this.nr.submittedDate).tz('America/Vancouver').format("MMMM Do[,] YYYY, h:mm a") + " Pacific Time"
+      return Moment(this.nr.submittedDate).tz('America/Vancouver').format("MMMM D[,] YYYY, h:mm a") + " Pacific Time"
     }
     return ""
   }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6337

*Description of changes:*
See feedback on ticket


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
