### PR TITLE
Disable cache of index.html.

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -26,13 +26,19 @@ http {
 
     location /namerequest {
       alias /app;
-      try_files $uri /index.html;
+      try_files $uri @index;
       gzip on;
       gzip_vary on;
       gzip_min_length 10240;
       gzip_proxied any;
       gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml;
       gzip_disable "MSIE [1-6]\.";
+    }
+
+    location @index {
+      add_header Cache-Control no-cache;
+      expires 0;
+      try_files /index.html;
     }
 
     # For status of ngnix service, OpenShift is configured to call this


### PR DESCRIPTION
*Issue 6716: https://github.com/bcgov/entity/issues/6716

*Description of changes:*
1. add "no cache" header to index.html through nginx  config;

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
