### PR TITLE
Updates to chat popup and GET HEAD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/date-mixin.ts
+++ b/src/mixins/date-mixin.ts
@@ -1,14 +1,13 @@
-import { Component, Mixins } from 'vue-property-decorator'
+import { Component, Vue } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 import { isDate } from 'lodash'
-import { CommonMixin } from './common-mixin'
 
 /**
  * Mixin that provides some useful date utilities.
  * Ref: https://github.com/bcgov/business-edit-ui/blob/master/src/mixins/date-mixin.ts
  */
 @Component({})
-export class DateMixin extends Mixins(CommonMixin) {
+export class DateMixin extends Vue {
   readonly MS_IN_A_DAY = (1000 * 60 * 60 * 24)
 
   // Global getter
@@ -24,21 +23,17 @@ export class DateMixin extends Mixins(CommonMixin) {
     const input = `${window.location.origin}${process.env.VUE_APP_PATH}/`
     const init: RequestInit = { cache: 'no-store', method: 'HEAD' }
 
-    // don't call fetch() during Jest tests
-    // because it's not defined
-    if (this.isJestRunning) return new Date()
-
-    const { headers, ok, statusText } = await fetch(input, init)
-
-    if (!ok) {
+    try {
+      const { headers, ok, statusText } = await fetch(input, init)
+      if (!ok) throw new Error(statusText)
+      return new Date(headers.get('Date'))
+    } catch (err) {
       // eslint-disable-next-line no-console
       console.warn('Unable to get server date - using browser date instead')
       // fall back to local date
       // NB: filing  may contain invalid dates/times
       return new Date()
     }
-
-    return new Date(headers.get('Date'))
   }
 
   /**


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*
- cleaned up chat-popup.vue
- don't render chat-popup if no url
- fixed tz in chat-popup
- removed common mixin from date-mixin
- wrapped "fetch head" in try-catch (re: https://sentry.io/organizations/registries/issues/2296940817/?project=5433950)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).