### PR TITLE
Fixed persisting federal getter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -386,7 +386,7 @@ export default class NewSearch extends Vue {
   }
 
   get isFederal () {
-    return this.jurisdiction === 'FD'
+    return this.location === 'CA' && this.jurisdiction === 'FD'
   }
 
   get isPersonsName () {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7192

*Description of changes:*

* Prevented `Federal` getter from persisting when location was no longer xpro Canada.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
