### PR TITLE
6566 - Save homeJurisNum for international jurisdiction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/name-input.vue
+++ b/src/components/new-request/name-input.vue
@@ -73,7 +73,8 @@ export default class NameInput extends Vue {
   /** The array of validation rules for the MRAS corp num. */
   private get mrasRules (): Function[] {
     return [
-      v => (/^\d+$/.test(v) || 'A corporate number is required')
+      v => (/^\d+$/.test(v) || 'A corporate number is required'),
+      v => (!v || v.length <= 40) || 'Cannot exceed 40 characters' // maximum character count
     ]
   }
 

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -197,7 +197,7 @@
     </v-row>
 
     <!-- Corporate number checkbox, only for XPro Canadian Locations -->
-    <v-row v-else-if="!isFederal" no-gutters>
+    <v-row v-else-if="!isFederal && !isInternational" no-gutters>
       <v-col class="d-flex justify-end">
         <v-tooltip top min-width="390" content-class="top-tooltip" transition="fade-transition">
           <template v-slot:activator="{ on }">
@@ -391,6 +391,10 @@ export default class NewSearch extends Vue {
     return this.location === 'CA' && this.jurisdiction === 'FD'
   }
 
+  get isInternational () {
+    return this.location === 'IN'
+  }
+
   get isPersonsName () {
     return this.getIsPersonsName
   }
@@ -480,6 +484,7 @@ export default class NewSearch extends Vue {
   watchLocation () {
     this.setName('')
     this.setCorpSearch('')
+    this.setNoCorpNum(false)
   }
 
   @Watch('request_action_cd')

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -437,6 +437,7 @@ export const startAnalyzeName: ActionIF = async ({ commit, getters }) => {
   commit('mutateNameOriginal', name) // Set original name for reset baseline
   if (getters.getIsXproMras) {
     commit('mutateNRData', { key: 'xproJurisdiction', value: getters.getJurisdictionText })
+    commit('mutateNRData', { key: 'homeJurisNum', value: getters.getCorpSearch })
     if (!getters.getHasNoCorpNum) {
       const profile: any = await fetchMRASProfile({ commit, getters })
       if (profile) {
@@ -445,7 +446,6 @@ export const startAnalyzeName: ActionIF = async ({ commit, getters }) => {
           ? sanitizeName(profile?.LegalEntity?.names[0]?.legalName)
           : sanitizeName(profile?.LegalEntity?.names?.legalName)
         commit('mutateName', name)
-        commit('mutateNRData', { key: 'homeJurisNum', value: getters.getCorpSearch })
       } else {
         commit('mutateNoCorpNum', true)
         return


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6566

*Description of changes:*

- Fixed saving homeJurisNum for international jurisdiction; 
- Added validation for the home jurisdiction number <= 40;
- Removed option for the user not enter a home jurisdiction number for international jurisdiction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
