### PR TITLE
Fixed Duplicate Designations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.2.15",
+  "version": "2.2.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.2.15",
+  "version": "2.2.16",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/request-details.vue
+++ b/src/components/common/request-details.vue
@@ -3,7 +3,7 @@
     <section>
       <h4>Requested Name <span v-if="nameChoices.name2">Choices</span></h4>
       <ul class="pl-0">
-        <li v-if="name && !nameChoices.name2">{{name}} {{nameChoices.designation1}}</li>
+        <li v-if="name && !nameChoices.name2">{{nameChoices.name1}} {{nameChoices.designation1}}</li>
         <template v-else>
           <li v-if="nameChoices.name1">1. {{nameChoices.name1}} {{nameChoices.designation1}}</li>
           <li v-if="nameChoices.name2">2. {{nameChoices.name2}} {{nameChoices.designation2}}</li>

--- a/src/components/common/request-details.vue
+++ b/src/components/common/request-details.vue
@@ -3,7 +3,7 @@
     <section>
       <h4>Requested Name <span v-if="nameChoices.name2">Choices</span></h4>
       <ul class="pl-0">
-        <li v-if="name && !nameChoices.name2">{{nameChoices.name1}} {{nameChoices.designation1}}</li>
+        <li v-if="!nameChoices.name2">{{nameChoices.name1}} {{nameChoices.designation1}}</li>
         <template v-else>
           <li v-if="nameChoices.name1">1. {{nameChoices.name1}} {{nameChoices.designation1}}</li>
           <li v-if="nameChoices.name2">2. {{nameChoices.name2}} {{nameChoices.designation2}}</li>
@@ -76,9 +76,6 @@ export default class RequestDetails extends Vue {
 
   @Prop(Object)
   readonly nameChoices: NameChoicesIF
-
-  @Prop(String)
-  readonly name: string
 
   @Getter getNameChoices!: NameChoicesIF
   @Getter getFolioNumber!: string


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7351

*Description of changes:*
* Changed which property is displayed in Review/Confirm, previous was writing duplicate Designations when a user entered it manually. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
