### PR TITLE
Updated defensive coding when conflict date or id are missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/analyze-results.vue
+++ b/src/components/new-request/analyze-results.vue
@@ -82,12 +82,13 @@
                 <v-col cols="auto">
                   <div v-for="(corp, n) in conflicts" :key="'conflict-' + n">
                     <b>{{ corp.name }}</b><br>
-                    <span v-if="conflictDate && conflictId.startsWith('NR ')">
-                      <b>Submitted Date:</b> {{ conflictDate + ', ' }}</span>
-                    <span v-if="conflictDate && !conflictId.startsWith('NR ')">
-                      <b>Incorporation Date:</b> {{ conflictDate + ', ' }}</span>
-                    <span v-if="conflictId && !conflictId.startsWith('NR ')">
-                      <b>Corporation No.:</b> {{ conflictId }}</span>
+                    <template v-if="conflictId.startsWith('NR ')">
+                      <span><b>Submitted Date:</b> {{ conflictDate }}</span>
+                    </template>
+                    <template v-if="!conflictId.startsWith('NR ')">
+                      <span><b>Incorporation Date:</b> {{ conflictDate + ', ' }}</span>
+                      <span><b>Corporation No.:</b> {{ conflictId }}</span>
+                    </template>
                   </div>
                 </v-col>
               </v-row>
@@ -367,14 +368,14 @@ export default class AnalyzeResults extends Mixins(DateMixin) {
         console.error('start date is invalid, conflict = ', this.issue.conflicts[0])
       }
     }
-    return null
+    return 'Unknown'
   }
 
   get conflictId () {
     if (Array.isArray(this.issue.conflicts) && this.issue.conflicts.length >= 1) {
       return this.issue.conflicts[0].id
     }
-    return null
+    return 'Unknown'
   }
 
   get conflicts () {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6992

*Description of changes:*
- display "Unknown" if conflict date is null
- display "Unknown" if conflict id is null
- cleaned up logic
- updated app version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).