### PR TITLE
Fetch and prepopulate submitting party info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/advanced-search/advanced-search-dates.vue
+++ b/src/components/advanced-search/advanced-search-dates.vue
@@ -38,7 +38,6 @@
 
 <script lang='ts'>
 import { Component, Emit, Prop, Mixins } from 'vue-property-decorator'
-import { Getter } from 'vuex-class'
 
 // Mixins
 import { DateMixin } from '@/mixins'
@@ -50,9 +49,6 @@ import { StartEndDatesI } from '@/interfaces/models'
 export default class AdvancedSearchDates extends Mixins(DateMixin) {
   /** Prop to display the dialog. */
   @Prop() readonly dialog: boolean
-
-  // Global getters
-  @Getter getCurrentJsDate: Date
 
   private startDateText = ''
   private endDateText = ''

--- a/src/components/common/applicant-info-1.vue
+++ b/src/components/common/applicant-info-1.vue
@@ -383,7 +383,6 @@
 <script lang="ts">
 import { Component, Vue, Watch, Mixins } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
-import KeycloakService from 'sbc-common-components/src/services/keycloak.services'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import ApplicantInfoNav from '@/components/common/applicant-info-nav.vue'
 import { Location, NrState } from '@/enums'
@@ -415,6 +414,8 @@ export default class ApplicantInfo1 extends Mixins(ActionMixin) {
   @Getter getNrState!: string
   @Getter getSubmissionTabNumber!: number
   @Getter getShowXproJurisdiction!: boolean
+  @Getter getKeycloakRoles!: string[]
+  @Getter isRoleStaff!: boolean
 
   // Global actions
   @Action setActingOnOwnBehalf!: ActionBindingIF
@@ -447,9 +448,8 @@ export default class ApplicantInfo1 extends Mixins(ActionMixin) {
     // eg, when user continues to send for review
     this.$el.addEventListener('keydown', this.handleKeydown)
 
-    // proceed only if we have a login token
-    const keycloakToken = sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)
-    if (keycloakToken) {
+    // proceed only if we have any roles (ie, logged in), and not staff
+    if (this.getKeycloakRoles.length > 0 && !this.isRoleStaff) {
       // pre-populate submitting party name
       const userInfo = await AuthServices.fetchUserInfo().catch(e => null)
       if (userInfo) {

--- a/src/components/common/applicant-info-3.vue
+++ b/src/components/common/applicant-info-3.vue
@@ -7,7 +7,7 @@
           <v-text-field :messages="messages['contact']"
                         :value="applicant.contact"
                         @blur="messages = {}"
-                        @input="mutateApplicant('contact', $event)"
+                        @input="updateApplicant('contact', $event)"
                         filled
                         hide-details="auto"
                         label="Contact Name (Optional)" />
@@ -17,7 +17,7 @@
                         :rules="emailRules"
                         :value="applicant.emailAddress"
                         @blur="messages = {}"
-                        @input="mutateApplicant('emailAddress', $event)"
+                        @input="updateApplicant('emailAddress', $event)"
                         filled
                         hide-details="auto"
                         label="Email Address (for notifications)" />
@@ -31,7 +31,7 @@
                         :value="applicant.phoneNumber"
                         :rules="phoneRules"
                         @blur="messages = {}"
-                        @input="mutateApplicant('phoneNumber', $event)"
+                        @input="updateApplicant('phoneNumber', $event)"
                         filled
                         hide-details="auto"
                         label="Phone Number" />
@@ -41,7 +41,7 @@
                         :value="applicant.faxNumber"
                         :rules="faxRules"
                         @blur="messages = {}"
-                        @input="mutateApplicant('faxNumber', $event)"
+                        @input="updateApplicant('faxNumber', $event)"
                         filled
                         hide-details="auto"
                         label="Fax Number (Optional)" />
@@ -54,7 +54,7 @@
           <v-text-field :messages="messages['clientFirst']"
                         :value="applicant.clientFirstName"
                         @blur="messages = {}"
-                        @input="mutateApplicant('clientFirstName', $event)"
+                        @input="updateApplicant('clientFirstName', $event)"
                         filled
                         hide-details="auto"
                         label="First Name (Optional)" />
@@ -63,7 +63,7 @@
           <v-text-field :messages="messages['clientLast']"
                         :value="applicant.clientLastName"
                         @blur="messages = {}"
-                        @input="mutateApplicant('clientLastName', $event)"
+                        @input="updateApplicant('clientLastName', $event)"
                         filled
                         hide-details="auto"
                         label="Last Name (Optional)" />
@@ -395,15 +395,18 @@ export default class ApplicantInfo3 extends Vue {
     }
   }
 
-  mutateApplicant (key, value) {
+  updateApplicant (key, value) {
     this.setApplicantDetails({ key, value })
   }
+
   mutateNRData (key, value) {
     this.setNRData({ key, value })
   }
+
   setError (error) {
     this.error = error
   }
+
   validate () {
     if (this.hideCorpNum !== 'auto') {
       this.hideCorpNum = 'auto'

--- a/src/services/auth.services.ts
+++ b/src/services/auth.services.ts
@@ -20,13 +20,23 @@ export default class AuthServices {
     return axios.delete(url)
   }
 
-  /** Fetches current user info. */
+  /** Fetches current user's info. */
   static async fetchUserInfo (): Promise<any> {
     const url = `${this.authApiUrl}/users/@me`
     return axios.get(url)
       .then(response => {
         if (response?.data) return response.data
-        else throw new Error('Invalid user info')
+        throw new Error('Invalid user info')
+      })
+  }
+
+  /** Fetches specified org's info. */
+  static async fetchOrgInfo (orgId: number): Promise<any> {
+    const url = `${this.authApiUrl}/orgs/${orgId}`
+    return axios.get(url)
+      .then(response => {
+        if (response?.data) return response.data
+        throw new Error('Invalid org info')
       })
   }
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -549,10 +549,6 @@ export const setActingOnOwnBehalf: ActionIF = ({ commit }, isActingOnOwn: boolea
   commit('mutateActingOnOwnBehalf', isActingOnOwn)
 }
 
-export const setApplicant: ActionIF = ({ commit }, applicant: any): void => {
-  commit('mutateApplicant', applicant)
-}
-
 export const setNRData: ActionIF = ({ commit }, nrData: any): void => {
   commit('mutateNRData', nrData)
 }

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -1043,6 +1043,11 @@ export const getConditionalNameReservation = (state: StateIF): ConditionalReqI =
   return data
 }
 
+/** The user's keycloak roles. */
+export const getKeycloakRoles = (state: StateIF): Array<string> => {
+  return state.stateModel.common.keycloakRoles
+}
+
 /** Whether the user has "staff" keycloak role. */
 export const isRoleStaff = (state: StateIF): boolean => {
   return state.stateModel.common.keycloakRoles.includes('staff')

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -35,8 +35,8 @@ export const mutateAnalysisJSON = (state: StateIF, analysisJSON: AnalysisJSONI) 
 
 export const mutateApplicant = (state: StateIF, appKV: any) => {
   if (Array.isArray(appKV)) {
-    for (let address of appKV) {
-      state.stateModel.newRequestModel.applicant[address.name] = address.value
+    for (let element of appKV) {
+      state.stateModel.newRequestModel.applicant[element.name] = element.value
     }
   }
   if (appKV.key === 'postalCd') {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8126

*Description of changes:*
- added Fetch Org Info method
- deleted unused action method
- deleted unneeded getter (already imported in mixin)
- get user info from auth
- get account info from auth
- prepopulate submitting party details accordingly
- misc cleanup
- updated app version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).