### PR TITLE
8221 - Adjustments for RESUBMIT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/services/namex.services.ts
+++ b/src/services/namex.services.ts
@@ -428,7 +428,7 @@ export default class NamexServices {
       sessionStorage.setItem('BCREG-emailAddress', null)
       sessionStorage.setItem('BCREG-phoneNumber', null)
 
-      const requestData: any = data && addComment && await this.addRequestActionComment(requestActionCd, data)
+      const requestData: any = addComment ? await this.addRequestActionComment(requestActionCd, data) : data
       if (addComment && !requestData) throw new Error('postNameRequests() - invalid request data') // safety check
 
       // eslint-disable-next-line no-console

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -485,6 +485,11 @@ export const resubmit: any = async ({ commit, getters }): Promise<boolean> => {
   // override request action code
   nrTypeData['request_action_cd'] = RequestCode.RESUBMIT
 
+  // override applicants partyIds
+  for (let [key, value] of Object.entries(nrTypeData['applicants'])) {
+    value['partyId'] = ''
+  }
+
   // post new NR (without adding comment)
   const request = await NamexServices.postNameRequests(getters.getRequestActionCd, nrTypeData, false)
   if (request) {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8221

*Description of changes:*

- Cleared partyIds to make the BE create new applicant records; 
- Changed logic for addComment that was failing for resubmit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
