### PR TITLE
Allow letters and dashes ( - ) in xpro home juri corp num field

### DIFF
--- a/src/components/new-request/name-input.vue
+++ b/src/components/new-request/name-input.vue
@@ -64,7 +64,7 @@ export default class NameInput extends Vue {
   /** The array of validation rules for the MRAS corp num. */
   private get mrasRules (): Function[] {
     return [
-      v => (/^\d+$/.test(v) || 'A corporate number is required'),
+      v => (/^[0-9a-zA-Z-]+$/.test(v) || 'A corporate number is required'),
       v => (!v || v.length <= 40) || 'Cannot exceed 40 characters' // maximum character count
     ]
   }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5994

*Description of changes:*
Change the text input rule to allow letters and dashes (-) in xpro home juri corp num field

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
