### PR TITLE
7018 - Modal for the refund request response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.3.13",
+  "version": "2.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.3.13",
+  "version": "2.3.14",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/dialogs/refund.vue
+++ b/src/components/dialogs/refund.vue
@@ -45,23 +45,23 @@
 
         <v-card-title class="d-flex justify-space-between">
           <div>Cancel and Refund</div>
-          <v-btn icon large class="dialog-close" @click="closeResponseModal()">
+          <v-btn icon large class="dialog-close" @click="hideResponseModal()">
             <v-icon>mdi-close</v-icon>
           </v-btn>
         </v-card-title>
 
         <v-card-text class="text-body-1">
-          <span v-html="refundParams.refundMessageText1"></span>
+          <span v-html="getRefundParams.refundMessageText1"></span>
         </v-card-text>
 
         <v-card-text
-          v-if="refundParams.refundMessageText2"
+          v-if="getRefundParams.refundMessageText2"
           class="text-body-1">
-          <span v-html="refundParams.refundMessageText2"></span>
+          <span v-html="getRefundParams.refundMessageText2"></span>
         </v-card-text>
 
         <v-card-text
-          v-if="refundParams.showStaffContact"
+          v-if="getRefundParams.showStaffContact"
           class="text-body-2">
           <contact-info
             id="tooltip-contact-info"
@@ -72,7 +72,7 @@
           <v-btn
             class="px-6 button-normal"
             id="keep-nr-btn"
-            @click="closeResponseModal()">OK</v-btn>
+            @click="hideResponseModal()">OK</v-btn>
         </v-card-actions>
 
       </v-card>
@@ -89,7 +89,6 @@ import ContactInfo from '@/components/common/contact-info.vue'
 import { REFUND_MODAL_IS_VISIBLE } from '@/modules/payment/store/types'
 import { NrAction } from '@/enums'
 import { PaymentMixin, PaymentSessionMixin } from '@/mixins'
-import { sleep } from '@/plugins'
 import { ActionBindingIF } from '@/interfaces/store-interfaces'
 import NamexServices from '@/services/namex.services'
 
@@ -165,8 +164,8 @@ export default class RefundDialog extends Mixins(PaymentMixin, PaymentSessionMix
     }
   }
 
-  /** Closes the response modal */
-  private closeResponseModal (): void {
+  /** Hides the response modal */
+  private hideResponseModal (): void {
     this.isResponseModalVisible = false
   }
 

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -59,7 +59,7 @@
                           </span>
                         </template>
                         <div v-html="getRefundParams.refundMessageText1" />
-                        <br/>
+                        <br v-if="getRefundParams.refundMessageText2" />
                         <div v-if="getRefundParams.refundMessageText2"
                           v-html="getRefundParams.refundMessageText2" />
                         <div v-if="getRefundParams.showStaffContact">

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -58,7 +58,10 @@
                             </v-icon>
                           </span>
                         </template>
-                        <div v-html="refundParams.refundMessage"></div>
+                        <div v-html="refundParams.refundMessageText1" />
+                        <br/>
+                        <div v-if="refundParams.refundMessageText2"
+                          v-html="refundParams.refundMessageText2" />
                         <div v-if="refundParams.showStaffContact">
                           <br/>
                           <contact-info
@@ -197,7 +200,6 @@ import {
   NrAction,
   NrState,
   PaymentStatus,
-  PaymentMethod,
   SbcPaymentStatus,
   PaymentAction,
   Furnished
@@ -229,7 +231,6 @@ export default class ExistingRequestDisplay extends Mixins(
   // Global getters
   @Getter getDisplayedComponent!: string
   @Getter getIsAuthenticated!: boolean
-  @Getter getNr!: Partial<NameRequestI>
   @Getter getNrId!: number
   @Getter getNrState!: NrState
 
@@ -260,14 +261,6 @@ export default class ExistingRequestDisplay extends Mixins(
 
   /** The pending payment, if any. See mounted(). */
   private pendingPayment = null
-
-  /** Params used to format refund message (tooltip and modal). */
-  private refundParams: RefundParamsIF = {
-    refundMessage: '',
-    refundLabel: '',
-    showStaffContact: false,
-    showAlertIcon: false
-  }
 
   /** The actions list, with some buttons forced to the bottom. */
   private get actions (): NrAction[] {
@@ -782,105 +775,6 @@ export default class ExistingRequestDisplay extends Mixins(
 
       // hide spinner
       this.$root.$emit('showSpinner', false)
-    }
-  }
-
-  /**
-   * Check if NR State is 'REFUND_REQUESTED'
-   * If so, call buildRefundParams method.
-  */
-  private get isRefundRequested (): boolean {
-    if (this.nr.state === NrState.REFUND_REQUESTED) {
-      this.buildRefundParams()
-      return true
-    }
-    return false
-  }
-
-  /**
-   * Build refund params to be used to display information about the refund request.
-   */
-  private buildRefundParams () {
-    if (this.nr.state === NrState.REFUND_REQUESTED) {
-      if (!this.isThereMoreThanOnePaymentMethod) {
-        const paymentMethod = this.payments[0]?.sbcPayment?.paymentMethod
-        if (paymentMethod === PaymentMethod.PAD) {
-          // Premium Account
-          if (!this.isNoRefund) {
-            this.refundParams.refundLabel = 'Refund Request Processed'
-            this.refundParams.refundMessage =
-              'Your Name Request has been cancelled and a refund request is being processed.<br/><br/>' +
-              'A credit will be applied to your BC Registries account.<br/>There may be a one day delay before the ' +
-              'credit will show on your transactions / statetements.'
-            this.refundParams.showStaffContact = false
-            this.refundParams.showAlertIcon = false
-          } else {
-            // May happen when a PAD is not processed yet.
-            // It usually takes a day to be processed.
-            this.refundParams.refundLabel = 'Refund Not Processed'
-            this.refundParams.refundMessage =
-              'Your Name Request has been cancelled.<br/><br/>' +
-              'Pre-authorized debit transactions are handled at the end of each day, therefore, your bank will ' +
-              'not be charged the initial payment amount.'
-            this.refundParams.showStaffContact = false
-            this.refundParams.showAlertIcon = true
-          }
-        } else if (paymentMethod === PaymentMethod.INTERNAL) {
-          // INTERNAL is a Staff payment. It can be 'Routing Slip' or 'No Fee' payments.
-          if (this.isNoFeePayment) {
-            // No Fee payment
-            this.refundParams.refundLabel = 'Refund Not Processed'
-            this.refundParams.refundMessage = 'Your Name Request has been cancelled.<br/><br/>' +
-              'Since there was no charge for this transaction, a refund will not be issued. Please contact BC' +
-              'Registry if you require further assistance.'
-            this.refundParams.showStaffContact = true
-            this.refundParams.showAlertIcon = true
-          } else {
-            // Routing Slip
-            this.refundParams.refundLabel = 'Refund Not Processed'
-            this.refundParams.refundMessage =
-              'Your Name Request has been cancelled, but you will not receive an automatic refund. Please contact BC ' +
-              'Registries in order to request a refund.'
-            this.refundParams.showStaffContact = true
-            this.refundParams.showAlertIcon = true
-          }
-        } else if ([PaymentMethod.DIRECT_PAY, PaymentMethod.DRAWDOWN].includes(paymentMethod)) {
-          // Credit Card or BCOL
-          if (!this.isNoFeePayment) {
-            this.refundParams.refundLabel = 'Refund Request Processed'
-            this.refundParams.refundMessage =
-              'Your Name Request has been cancelled and a refund request has been submitted.<br/><br/>' +
-              'The refund will be applied to you original payment method and the request name will not be ' +
-              'examined for use. An email confirming the cancellation and refund of this Name Request will be ' +
-              `sent to ${this.nr.applicants.emailAddress}.`
-            this.refundParams.showStaffContact = false
-            this.refundParams.showAlertIcon = false
-          } else {
-            this.refundParams.refundLabel = 'Refund Not Processed'
-            this.refundParams.refundMessage = 'Your Name Request has been cancelled, but we were unable to process ' +
-              'your full refund. Please contact BC Registry.'
-            this.refundParams.showStaffContact = true
-            this.refundParams.showAlertIcon = true
-          }
-        }
-      } else if (!this.isNoRefund) {
-        // Multi-transaction scenario returns success
-        this.refundParams.refundLabel = 'Refund Request Processed'
-        this.refundParams.refundMessage =
-          'Your Name Request has been cancelled and a refund request has been submitted.<br/><br/>' +
-          'The refund will be applied to you original payment method and the request name will not be ' +
-          'examined for use. An email confirming the cancellation and refund of this Name Request will be ' +
-          `sent to ${this.nr.applicants.emailAddress}.`
-        this.refundParams.showStaffContact = false
-        this.refundParams.showAlertIcon = false
-      } else {
-        // This should not happen
-        this.refundParams.refundLabel = 'Refund Not Processed'
-        this.refundParams.refundMessage = 'Your Name Request has been cancelled, but we were unable to process ' +
-          'your full refund. Please contact BC Registry.'
-        this.refundParams.showStaffContact = true
-        this.refundParams.showAlertIcon = true
-      }
     }
   }
 }

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -52,17 +52,17 @@
                         top nudge-top min-width="24rem">
                         <template v-slot:activator="{ on, attrs }">
                           <span v-bind="attrs" v-on="on">
-                            <span  class="refund-label">{{ refundParams.refundLabel }}</span>
-                            <v-icon v-if="refundParams.showAlertIcon" icon color="error">
+                            <span  class="refund-label">{{ getRefundParams.refundLabel }}</span>
+                            <v-icon v-if="getRefundParams.showAlertIcon" icon color="error">
                               mdi-alert
                             </v-icon>
                           </span>
                         </template>
-                        <div v-html="refundParams.refundMessageText1" />
+                        <div v-html="getRefundParams.refundMessageText1" />
                         <br/>
-                        <div v-if="refundParams.refundMessageText2"
-                          v-html="refundParams.refundMessageText2" />
-                        <div v-if="refundParams.showStaffContact">
+                        <div v-if="getRefundParams.refundMessageText2"
+                          v-html="getRefundParams.refundMessageText2" />
+                        <div v-if="getRefundParams.showStaffContact">
                           <br/>
                           <contact-info
                             id="tooltip-contact-info"
@@ -447,7 +447,7 @@ export default class ExistingRequestDisplay extends Mixins(
   /** The display text for Request Status. */
   private get requestStatusText (): string {
     if (this.nr.state === NrState.REFUND_REQUESTED) {
-      return 'Cancelled, ' // this label will be composed with 'refundParams.refundLabel'
+      return 'Cancelled, ' // this label will be composed with 'getRefundParams.refundLabel'
     } else if (this.isNotPaid) {
       return 'Payment Incomplete'
     } else if (this.isPaymentProcessing) {

--- a/src/interfaces/refund-params-interface.ts
+++ b/src/interfaces/refund-params-interface.ts
@@ -1,6 +1,6 @@
 export interface RefundParamsIF {
     refundMessageText1: string
-    refundMessageText2: string
+    refundMessageText2?: string
     refundLabel: string
     showStaffContact: boolean
     showAlertIcon: boolean

--- a/src/interfaces/refund-params-interface.ts
+++ b/src/interfaces/refund-params-interface.ts
@@ -1,5 +1,6 @@
 export interface RefundParamsIF {
-    refundMessage: string
+    refundMessageText1: string
+    refundMessageText2: string
     refundLabel: string
     showStaffContact: boolean
     showAlertIcon: boolean

--- a/src/interfaces/state-interface.ts
+++ b/src/interfaces/state-interface.ts
@@ -1,5 +1,5 @@
 import { NewRequestIF } from '@/interfaces/new-request-interface'
-import { NameCheckModelIF, StaffPaymentIF } from '@/interfaces'
+import { NameCheckModelIF, StaffPaymentIF, RefundParamsIF } from '@/interfaces'
 
 export interface StateIF {
   stateModel: StateModelIF
@@ -15,4 +15,5 @@ export interface StateModelIF {
   errorModel?: {}
   paymentModel?: {}
   nameCheckModel: NameCheckModelIF
+  refundParams: RefundParamsIF
 }

--- a/src/mixins/payment-mixin.ts
+++ b/src/mixins/payment-mixin.ts
@@ -208,8 +208,8 @@ export class PaymentMixin extends Mixins(ActionMixin) {
               refundMessageText1:
               'Your Name Request has been cancelled.',
               refundMessageText2:
-              'Since there was no charge for this transaction, a refund will not be issued. Please contact BC' +
-              'Registry if you require further assistance.',
+              'Since there was no charge for this transaction, a refund will not be issued. Please contact BC ' +
+              'Registries if you require further assistance.',
               showStaffContact: true,
               showAlertIcon: true
             }
@@ -247,7 +247,7 @@ export class PaymentMixin extends Mixins(ActionMixin) {
               refundLabel: 'Refund Not Processed',
               refundMessageText1:
               'Your Name Request has been cancelled, but we were unable to process ' +
-              'your full refund. Please contact BC Registry.',
+              'your full refund. Please contact BC Registries.',
               refundMessageText2: '',
               showStaffContact: true,
               showAlertIcon: true
@@ -274,7 +274,7 @@ export class PaymentMixin extends Mixins(ActionMixin) {
           refundLabel: 'Refund Not Processed',
           refundMessageText1:
           'Your Name Request has been cancelled, but we were unable to process ' +
-          'your full refund. Please contact BC Registry.',
+          'your full refund. Please contact BC Registries.',
           showStaffContact: true,
           showAlertIcon: true
         }

--- a/src/mixins/payment-mixin.ts
+++ b/src/mixins/payment-mixin.ts
@@ -23,21 +23,14 @@ export class PaymentMixin extends Mixins(ActionMixin) {
   @Action setPaymentReceipt!: ActionBindingIF
   @Action setPaymentRequest!: ActionBindingIF
   @Action setSbcPayment!: ActionBindingIF
+  @Action setRefundParams!: ActionBindingIF
 
   // Global getter
   @Getter getCurrentJsDate!: Date
   @Getter getStaffPayment!: StaffPaymentIF
   @Getter getFolioNumber!: string
   @Getter getNr!: Partial<NameRequestI>
-
-  /** Params used to format refund message (tooltip and modal). */
-  refundParams: RefundParamsIF = {
-    refundMessageText1: '',
-    refundMessageText2: '',
-    refundLabel: '',
-    showStaffContact: false,
-    showAlertIcon: false
-  }
+  @Getter getRefundParams: RefundParamsIF
 
   get sbcPayment () {
     return this.$store.getters[paymentTypes.GET_SBC_PAYMENT]
@@ -180,88 +173,112 @@ export class PaymentMixin extends Mixins(ActionMixin) {
         if (paymentMethod === PaymentMethod.PAD) {
           // Premium Account
           if (!this.isNoRefund) {
-            this.refundParams.refundLabel = 'Refund Request Processed'
-            this.refundParams.refundMessageText1 =
-              'Your Name Request has been cancelled and a refund request is being processed.'
-            this.refundParams.refundMessageText2 =
+            const refundParams = {
+              refundLabel: 'Refund Request Processed',
+              refundMessageText1:
+              'Your Name Request has been cancelled and a refund request is being processed.',
+              refundMessageText2:
               'A credit will be applied to your BC Registries account.<br/>There may be a one day delay before the ' +
-              'credit will show on your transactions / statetements.'
-            this.refundParams.showStaffContact = false
-            this.refundParams.showAlertIcon = false
+              'credit will show on your transactions / statetements.',
+              showStaffContact: false,
+              showAlertIcon: false
+            }
+            this.setRefundParams(refundParams)
           } else {
             // May happen when a PAD is not processed yet.
             // It usually takes a day to be processed.
-            this.refundParams.refundLabel = 'Refund Not Processed'
-            this.refundParams.refundMessageText1 =
-              'Your Name Request has been cancelled.'
-            this.refundParams.refundMessageText2 =
+            const refundParams = {
+              refundLabel: 'Refund Not Processed',
+              refundMessageText1:
+              'Your Name Request has been cancelled.',
+              refundMessageText2:
               'Pre-authorized debit transactions are handled at the end of each day, therefore, your bank will ' +
-              'not be charged the initial payment amount.'
-            this.refundParams.showStaffContact = false
-            this.refundParams.showAlertIcon = true
+              'not be charged the initial payment amount.',
+              showStaffContact: false,
+              showAlertIcon: true
+            }
+            this.setRefundParams(refundParams)
           }
         } else if (paymentMethod === PaymentMethod.INTERNAL) {
           // INTERNAL is a Staff payment. It can be 'Routing Slip' or 'No Fee' payments.
           if (this.isNoFeePayment) {
             // No Fee payment
-            this.refundParams.refundLabel = 'Refund Not Processed'
-            this.refundParams.refundMessageText1 =
-              'Your Name Request has been cancelled.'
-            this.refundParams.refundMessageText2 =
+            const refundParams = {
+              refundLabel: 'Refund Not Processed',
+              refundMessageText1:
+              'Your Name Request has been cancelled.',
+              refundMessageText2:
               'Since there was no charge for this transaction, a refund will not be issued. Please contact BC' +
-              'Registry if you require further assistance.'
-            this.refundParams.showStaffContact = true
-            this.refundParams.showAlertIcon = true
+              'Registry if you require further assistance.',
+              showStaffContact: true,
+              showAlertIcon: true
+            }
+            this.setRefundParams(refundParams)
           } else {
             // Routing Slip
-            this.refundParams.refundLabel = 'Refund Not Processed'
-            this.refundParams.refundMessageText1 =
+            const refundParams = {
+              refundLabel: 'Refund Not Processed',
+              refundMessageText1:
               'Your Name Request has been cancelled, but you will not receive an automatic refund. Please contact BC ' +
-              'Registries in order to request a refund.'
-            this.refundParams.refundMessageText2 = ''
-            this.refundParams.showStaffContact = true
-            this.refundParams.showAlertIcon = true
+              'Registries in order to request a refund.',
+              refundMessageText2: '',
+              showStaffContact: true,
+              showAlertIcon: true
+            }
+            this.setRefundParams(refundParams)
           }
         } else if ([PaymentMethod.DIRECT_PAY, PaymentMethod.DRAWDOWN].includes(paymentMethod)) {
           // Credit Card or BCOL
           if (!this.isNoFeePayment) {
-            this.refundParams.refundLabel = 'Refund Request Processed'
-            this.refundParams.refundMessageText1 =
-              'Your Name Request has been cancelled and a refund request has been submitted.'
-            this.refundParams.refundMessageText2 =
+            const refundParams = {
+              refundLabel: 'Refund Request Processed',
+              refundMessageText1:
+              'Your Name Request has been cancelled and a refund request has been submitted.',
+              refundMessageText2:
               'The refund will be applied to you original payment method and the request name will not be ' +
               'examined for use. An email confirming the cancellation and refund of this Name Request will be ' +
-              `sent to ${this.getNr.applicants.emailAddress}.`
-            this.refundParams.showStaffContact = false
-            this.refundParams.showAlertIcon = false
+              `sent to ${this.getNr.applicants.emailAddress}.`,
+              showStaffContact: false,
+              showAlertIcon: false
+            }
+            this.setRefundParams(refundParams)
           } else {
-            this.refundParams.refundLabel = 'Refund Not Processed'
-            this.refundParams.refundMessageText1 =
+            const refundParams = {
+              refundLabel: 'Refund Not Processed',
+              refundMessageText1:
               'Your Name Request has been cancelled, but we were unable to process ' +
-              'your full refund. Please contact BC Registry.'
-            this.refundParams.refundMessageText2 = ''
-            this.refundParams.showStaffContact = true
-            this.refundParams.showAlertIcon = true
+              'your full refund. Please contact BC Registry.',
+              refundMessageText2: '',
+              showStaffContact: true,
+              showAlertIcon: true
+            }
+            this.setRefundParams(refundParams)
           }
         }
       } else if (!this.isNoRefund) {
         // Multi-transaction scenario returns success
-        this.refundParams.refundLabel = 'Refund Request Processed'
-        this.refundParams.refundMessageText1 =
+        const refundParams = {
+          refundLabel: 'Refund Request Processed',
+          refundMessageText1:
           'Your Name Request has been cancelled and a refund request has been submitted.<br/><br/>' +
           'The refund will be applied to you original payment method and the request name will not be ' +
           'examined for use. An email confirming the cancellation and refund of this Name Request will be ' +
-          `sent to ${this.getNr.applicants.emailAddress}.`
-        this.refundParams.showStaffContact = false
-        this.refundParams.showAlertIcon = false
+          `sent to ${this.getNr.applicants.emailAddress}.`,
+          showStaffContact: false,
+          showAlertIcon: false
+        }
+        this.setRefundParams(refundParams)
       } else {
         // This should not happen
-        this.refundParams.refundLabel = 'Refund Not Processed'
-        this.refundParams.refundMessageText1 =
+        const refundParams = {
+          refundLabel: 'Refund Not Processed',
+          refundMessageText1:
           'Your Name Request has been cancelled, but we were unable to process ' +
-          'your full refund. Please contact BC Registry.'
-        this.refundParams.showStaffContact = true
-        this.refundParams.showAlertIcon = true
+          'your full refund. Please contact BC Registry.',
+          showStaffContact: true,
+          showAlertIcon: true
+        }
+        this.setRefundParams(refundParams)
       }
     }
   }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -35,7 +35,8 @@ import {
   StaffPaymentIF,
   QuickSearchParamsI,
   QuickSearchParsedRespI,
-  ConflictListItemI
+  ConflictListItemI,
+  RefundParamsIF
 } from '@/interfaces'
 import { ActionIF } from '@/interfaces/store-interfaces'
 
@@ -1186,4 +1187,8 @@ export const startQuickSearch = async ({ commit, getters }, checks: QuickSearchP
       commit('mutateAnalyzeConflictsPending', false)
     }
   }
+}
+
+export const setRefundParams: ActionIF = ({ commit }, refundParams: RefundParamsIF): void => {
+  commit('mutateRefundParams', refundParams)
 }

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -13,6 +13,7 @@ import {
   NameChoicesIF,
   NameDesignationI,
   NameRequestI,
+  RefundParamsIF,
   RequestActionMappingI,
   RequestActionsI,
   RequestNameI,
@@ -1142,4 +1143,8 @@ export const isMissingDesignation = (state: StateIF): boolean => {
 
 export const isMissingDistinctive = (state: StateIF): boolean => {
   return state.stateModel.nameCheckModel.missingDistinctive
+}
+
+export const getRefundParams = (state: StateIF): RefundParamsIF => {
+  return state.stateModel.refundParams
 }

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -5,6 +5,7 @@ import {
   ConditionalInstructionI,
   ConversionTypesI,
   NameRequestI,
+  RefundParamsIF,
   SelectOptionsI,
   StaffPaymentIF,
   StateIF,
@@ -535,4 +536,8 @@ export const mutateNameCheckErrorClear = (state: StateIF, key: NameCheckErrorTyp
 
 export const mutateFolioNumber = (state: StateIF, folioNumber: string) => {
   state.stateModel.newRequestModel.folioNumber = folioNumber
+}
+
+export const mutateRefundParams = (state: StateIF, refundParams: RefundParamsIF) => {
+  state.stateModel.refundParams = refundParams
 }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,4 +1,4 @@
-import { NameRequestI, StateModelIF } from '@/interfaces'
+import { NameRequestI, StateModelIF, RefundParamsIF } from '@/interfaces'
 import { EntityType, Location, NameCheckErrorType, StaffPaymentOptions } from '@/enums'
 
 export const stateModel: StateModelIF = {
@@ -180,6 +180,12 @@ export const stateModel: StateModelIF = {
     missingDistinctive: false,
     numbersCheckUse: [],
     specialCharacters: []
+  },
+  refundParams: {
+    refundMessageText1: '',
+    refundMessageText2: '',
+    refundLabel: '',
+    showStaffContact: false,
+    showAlertIcon: false
   }
-
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7018

*Description of changes:*

- Added modal to show a response for the refund request; 
- moved some methods from `existing-request-display.vue` to `payment-mixin.ts`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
