### PR TITLE
8907 8918 Abort when resubmit payment fails + set renew priority request false in model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.3.19",
+  "version": "2.3.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "2.3.19",
+  "version": "2.3.20",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/advanced-search/advanced-search-retrieve.vue
+++ b/src/components/advanced-search/advanced-search-retrieve.vue
@@ -74,7 +74,6 @@ export default class AdvancedSearchRetrieve extends Vue {
   @Getter getNr!: Partial<NameRequestI>
 
   // Global setters
-  @Action findNameRequest!: ActionBindingIF
   @Action setExistingRequestSearch!: ActionBindingIF
   @Action setNameRequest!: ActionBindingIF
   @Action setDisplayedComponent!: ActionBindingIF

--- a/src/components/dialogs/renew.vue
+++ b/src/components/dialogs/renew.vue
@@ -108,9 +108,11 @@ export default class RenewDialog extends Mixins(
   // Global getters
   @Getter getName!: string
   @Getter isRoleStaff!: boolean
+  @Getter getPriorityRequest!: boolean
 
   // Global action
   @Action toggleRenewModal!: ActionBindingIF
+  @Action setPriorityRequest!: ActionBindingIF
 
   /** Whether staff payment is valid. */
   private isStaffPaymentValid = false
@@ -142,10 +144,14 @@ export default class RenewDialog extends Mixins(
       // reset tab id
       this.currentTab = this.TAB_RENEW_NAME_REQUEST
 
+      // update new request model
+      this.setPriorityRequest(false) // no priority on renew
+
+      // fetch fees
       const params: FetchFeesParams = {
         filingType: FilingTypes.NM620,
         jurisdiction: Jurisdictions.BC,
-        priorityRequest: false // no priority on renew
+        priorityRequest: this.getPriorityRequest
       }
 
       // only make visible on success, otherwise hide it
@@ -207,7 +213,7 @@ export default class RenewDialog extends Mixins(
       action: PaymentAction.RENEW,
       nrId: this.getNrId,
       filingType: FilingTypes.NM620,
-      priorityRequest: false // no priority on renew
+      priorityRequest: this.getPriorityRequest
     } as CreatePaymentParams, onSuccess)
 
     // on error, close this modal so error modal is visible

--- a/src/components/dialogs/resubmit.vue
+++ b/src/components/dialogs/resubmit.vue
@@ -88,10 +88,11 @@ import StaffPayment from '@/components/payment/staff-payment.vue'
 import { CreatePaymentParams, FetchFeesParams } from '@/modules/payment/models'
 import { RESUBMIT_MODAL_IS_VISIBLE } from '@/modules/payment/store/types'
 import { FilingTypes } from '@/modules/payment/filing-types'
-import { Jurisdictions, PaymentAction } from '@/enums'
+import { Jurisdictions, NrAction, PaymentAction } from '@/enums'
 import { PaymentMixin, PaymentSessionMixin, DisplayedComponentMixin } from '@/mixins'
 import { getBaseUrl } from '@/components/payment/payment-utils'
 import { ActionBindingIF } from '@/interfaces/store-interfaces'
+import NamexServices from '@/services/namex.services'
 
 @Component({
   components: {
@@ -116,11 +117,13 @@ export default class ResubmitDialog extends Mixins(
 
   // Global getters
   @Getter isRoleStaff!: boolean
+  @Getter getNrNum!: string
 
   // Global action
   @Action toggleResubmitModal!: ActionBindingIF
   @Action resubmit!: ActionBindingIF
   @Action setPriorityRequest!: ActionBindingIF
+  @Action loadExistingNameRequest!: ActionBindingIF
 
   /** Whether staff payment is valid. */
   private isStaffPaymentValid = false
@@ -211,6 +214,9 @@ export default class ResubmitDialog extends Mixins(
 
     this.isLoadingPayment = true
 
+    // save original NR number
+    const nrNum = this.getNrNum
+
     // first resubmit the NR
     let success: boolean = await this.resubmit(null)
 
@@ -238,9 +244,20 @@ export default class ResubmitDialog extends Mixins(
       priorityRequest: this.isPriorityRequest
     } as CreatePaymentParams, onSuccess)
 
-    // on error, close this modal so error modal is visible
     if (!success) {
+      // close this modal so error modal is visible
       await this.hideModal()
+
+      // reset session data
+      sessionStorage.setItem('BCREG-NRL', null)
+      sessionStorage.setItem('BCREG-nrNum', nrNum)
+
+      // try to delete the new (resubmitted) NR
+      await NamexServices.patchNameRequestsByAction(this.getNrId, NrAction.CANCEL).catch(() => {})
+
+      // try to reload the original NR
+      const nrData = await NamexServices.getNameRequest(false)
+      if (nrData) this.loadExistingNameRequest(nrData)
     }
   }
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8907 /bcgov/entity#8918

*Description of changes:*
- if resubmit payment creation fails then reset session data, try to delete the new NR, and try to reload the original NR
- set renew priority request false in model
- app version: 2.3.20

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).