### PR TITLE
Updated Virgin Islands and Puerto Rico

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 .vscode
 configuration.json.*
 keycloak.json.*
+public/config/configuration.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3052,6 +3052,17 @@
             "unique-filename": "^1.1.1"
           }
         },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -3164,6 +3175,18 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
+        },
+        "vue-loader-v16": {
+          "version": "npm:vue-loader@16.8.3",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
+          "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "hash-sum": "^2.0.0",
+            "loader-utils": "^2.0.0"
+          }
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -19383,51 +19406,6 @@
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
             "json5": "^1.0.1"
-          }
-        }
-      }
-    },
-    "vue-loader-v16": {
-      "version": "npm:vue-loader@16.8.1",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.1.tgz",
-      "integrity": "sha512-V53TJbHmzjBhCG5OYI2JWy/aYDspz4oVHKxS43Iy212GjGIG1T3EsB3+GWXFm/1z5VwjdjLmdZUFYM70y77vtQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "hash-sum": "^2.0.0",
-        "loader-utils": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/list-data/intl-jurisdictions.ts
+++ b/src/list-data/intl-jurisdictions.ts
@@ -151,18 +151,13 @@ const Other: JurisdictionI[] = [
     text: 'Viet Nam'
   },
   {
-    value: 'PR',
-    text: 'Puerto Rico',
-    SHORT_DESC: 'Puerto Rico'
-  },
-  {
     value: 'VI',
     text: 'VIRGIN ISLANDS, U.S.',
     SHORT_DESC: 'VIRGIN ISLANDS, U.S.'
   },
   {
     value: 'VG',
-    text: 'VIRGIN ISLANDS, BRITISH Virgin Islands',
+    text: 'VIRGIN ISLANDS, BRITISH',
     SHORT_DESC: 'Virgin Islands, BRITISH'
   },
   {

--- a/src/list-data/intl-jurisdictions.ts
+++ b/src/list-data/intl-jurisdictions.ts
@@ -152,13 +152,13 @@ const Other: JurisdictionI[] = [
   },
   {
     value: 'VI',
-    text: 'VIRGIN ISLANDS, U.S.',
-    SHORT_DESC: 'VIRGIN ISLANDS, U.S.'
+    text: 'Virgin Islands, U.S.',
+    SHORT_DESC: 'Virgin Islands, U.S.'
   },
   {
     value: 'VG',
-    text: 'VIRGIN ISLANDS, BRITISH',
-    SHORT_DESC: 'Virgin Islands, BRITISH'
+    text: 'Virgin Islands, British',
+    SHORT_DESC: 'Virgin Islands, British'
   },
   {
     value: 'WF',

--- a/src/list-data/intl-jurisdictions.ts
+++ b/src/list-data/intl-jurisdictions.ts
@@ -151,9 +151,19 @@ const Other: JurisdictionI[] = [
     text: 'Viet Nam'
   },
   {
+    value: 'PR',
+    text: 'Puerto Rico',
+    SHORT_DESC: 'Puerto Rico'
+  },
+  {
+    value: 'VI',
+    text: 'VIRGIN ISLANDS, U.S.',
+    SHORT_DESC: 'VIRGIN ISLANDS, U.S.'
+  },
+  {
     value: 'VG',
-    text: 'Virgin Islands',
-    SHORT_DESC: 'Virgin Islands'
+    text: 'VIRGIN ISLANDS, BRITISH Virgin Islands',
+    SHORT_DESC: 'Virgin Islands, BRITISH'
   },
   {
     value: 'WF',

--- a/src/list-data/us-states.ts
+++ b/src/list-data/us-states.ts
@@ -197,11 +197,6 @@ export const UsaStateCodes: JurisdictionI[] = [
     value: 'PA'
   },
   {
-    text: 'Puerto Rico',
-    SHORT_DESC: 'Puerto Rico',
-    value: 'PR'
-  },
-  {
     text: 'Rhode Island',
     SHORT_DESC: 'Rhode Island',
     value: 'RI'
@@ -240,11 +235,6 @@ export const UsaStateCodes: JurisdictionI[] = [
     text: 'Virginia',
     SHORT_DESC: 'Virginia',
     value: 'VA'
-  },
-  {
-    text: 'Virgin Islands',
-    SHORT_DESC: 'Virgin Islands',
-    value: 'VI'
   },
   {
     text: 'Washington',

--- a/src/list-data/us-states.ts
+++ b/src/list-data/us-states.ts
@@ -197,6 +197,11 @@ export const UsaStateCodes: JurisdictionI[] = [
     value: 'PA'
   },
   {
+    text: 'Puerto Rico',
+    SHORT_DESC: 'Puerto Rico',
+    value: 'PR'
+  },
+  {
     text: 'Rhode Island',
     SHORT_DESC: 'Rhode Island',
     value: 'RI'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9178

*Description of changes:*
Mapped VI  to VIRGIN ISLANDS, U.S.   in international jurisdiction   and removed from states file
Mapped PR to Puerto Rico                   in international jurisdiction   and removed from states file
updated  VG  (VIRGIN ISLANDS to VIRGIN ISLANDS, BRITISH in international jurisdiction
