### PR TITLE
#9009 Renew/Upgrade payment: remove previous incomplete payment after a new payment created

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/payment-mixin.ts
+++ b/src/mixins/payment-mixin.ts
@@ -4,7 +4,7 @@ import { AxiosRequestConfig } from 'axios'
 import { ACCEPTED, CREATED, NO_CONTENT, OK, PAYMENT_REQUIRED } from 'http-status-codes'
 
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
-import { PaymentStatus, StaffPaymentOptions, NrState, PaymentMethod } from '@/enums'
+import { PaymentStatus, StaffPaymentOptions, NrState, PaymentMethod, SbcPaymentStatus } from '@/enums'
 import { ActionMixin } from '@/mixins'
 import * as paymentTypes from '@/modules/payment/store/types'
 import { CreatePaymentParams, FetchFeesParams, NameRequestPaymentResponse } from '@/modules/payment/models'
@@ -338,6 +338,20 @@ export class PaymentMixin extends Mixins(ActionMixin) {
       await this.setPayment(payment)
       // await paymentModule.setPaymentReceipt(sbcPayment.receipts[0]) // FUTURE: verify that new code === old code
       await this.setPaymentRequest(data)
+
+      // delete previous incomplete payments after the new payment record created
+      const allPayments = await this.getNameRequestPayments(nrId, {})
+      if (allPayments) {
+        for (let i = 0; i < allPayments.length; i++) {
+          if (
+            allPayments[i].payment.id !== payment.id &&
+            allPayments[i].payment.payment_action === action &&
+            allPayments[i].sbcPayment.statusCode === SbcPaymentStatus.CREATED
+          ) {
+            await NamexServices.cancelPayment(nrId, allPayments[i].sbcPayment.id)
+          }
+        }
+      }
 
       if (onSuccess) {
         // Execute callback

--- a/src/mixins/payment-mixin.ts
+++ b/src/mixins/payment-mixin.ts
@@ -344,9 +344,9 @@ export class PaymentMixin extends Mixins(ActionMixin) {
       if (allPayments) {
         for (let i = 0; i < allPayments.length; i++) {
           if (
-            allPayments[i].payment.id !== payment.id &&
-            allPayments[i].payment.payment_action === action &&
-            allPayments[i].sbcPayment.statusCode === SbcPaymentStatus.CREATED
+            allPayments[i].payment?.id !== payment.id &&
+            allPayments[i].payment?.payment_action === action &&
+            allPayments[i].sbcPayment?.statusCode === SbcPaymentStatus.CREATED
           ) {
             await NamexServices.cancelPayment(nrId, allPayments[i].sbcPayment.id)
           }


### PR DESCRIPTION
Delete the all the incomplete payments after a new payment records created for Renew/Upgrade payments.

*Issue #:* /bcgov/entity#9009

*Description of changes:*
After a new renew or upgrade payment record created, delete all the previous incomplete payment records.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
