### PR TITLE
5739 - Remove Federal option from applicant info province dropdown

### DIFF
--- a/src/components/common/applicant-info-1.vue
+++ b/src/components/common/applicant-info-1.vue
@@ -540,7 +540,8 @@ export default class ApplicantInfo1 extends Mixins(ActionMixin) {
   }
 
   get provinceOptions () {
-    return CanJurisdictions.map(jurisdiction => ({ value: jurisdiction.value, text: jurisdiction.text }))
+    return CanJurisdictions.filter(jurisdiction => jurisdiction.value !== Location.FD)
+      .map(jurisdiction => ({ value: jurisdiction.value, text: jurisdiction.text }))
   }
 
   get showAllFields (): boolean {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5739

*Description of changes:*

Remove "Federal" option from applicant info province dropdown
