### PR TITLE
added 3 more settings

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -14,6 +14,9 @@ http {
   fastcgi_temp_path     /tmp/fastcgi_temp;
   uwsgi_temp_path       /tmp/uwsgi_temp;
   scgi_temp_path        /tmp/scgi_temp;
+  default_type  application/octet-stream;
+  server_tokens off;
+  underscores_in_headers on;
 
   server {
     # Enable HTTP Strict Transport Security (HSTS) to force clients to always


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10195

*Description of changes:*


After careful review there were three more http settings that Service BC had in their nginx file, that we did not add to our nginx.conf file.  i am adding them now to see if underscores_in_headers fixes the following messages.

2022/01/10 16:56:49 [info] 22#22: *314035 client sent invalid header line: "sm_transactionid: 0000000000000000000000008e223ffc-2e82-61dc6551-0015-863a6d52" while reading client request headers, client: 10.97.6.1, server: _, request: "HEAD /namerequest/ HTTP/1.1", referrer: "https://test.bcregistry.ca/namerequest/"
2022/01/10 16:56:49 [info] 22#22: *314035 client sent invalid header line: "sm_sdomain: .bcregistry.ca" while reading client request headers, client: 10.97.6.1, server: _, request: "HEAD /namerequest/ HTTP/1.1", referrer: "https://test.bcregistry.ca/namerequest/"
2022/01/10 16:56:49 [info] 22#22: *314035 client sent invalid header line: "sm_authtype: Not Protected" while reading client request headers, client: 10.97.6.1, server: _, request: "HEAD /namerequest/ HTTP/1.1", referrer: "https://test.bcregistry.ca/namerequest/"
2022/01/10 16:56:49 [info] 22#22: *314035 client sent invalid header line: "sm_user: " while reading client request headers, client: 10.97.6.1, server: _, request: "HEAD /namerequest/ HTTP/1.1", referrer: "https://test.bcregistry.ca/namerequest/"
2022/01/10 16:56:49 [info] 22#22: *314035 client sent invalid header line: "sm_userdn: " while reading client request headers, client: 10.97.6.1, server: _, request: "HEAD /namerequest/ HTTP/1.1", referrer: "https://test.bcregistry.ca/namerequest/"
