### PR TITLE
#8901 name choice should not have designation added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/names-capture.vue
+++ b/src/components/common/names-capture.vue
@@ -757,6 +757,8 @@ export default class NamesCapture extends Mixins(CommonMixin) {
       let { choice } = name
       if (name.designation) {
         this.setNameChoices({ key: `designation${choice}`, value: name.designation })
+      } else {
+        this.setNameChoices({ key: `designation${choice}`, value: '' })
       }
       this.setNameChoices({ key: `name${choice}`, value: name.name })
     }
@@ -787,7 +789,8 @@ export default class NamesCapture extends Mixins(CommonMixin) {
               this.setNameChoices({ key: `name${choice}`, value: name })
             }
           } else {
-            this.setNameChoices({ key: `name${choice}`, value: name })
+            let value = nameChoices[`name${choice}`].replace(nameChoices[`designation${choice}`], '').trim()
+            this.setNameChoices({ key: `name${choice}`, value: value })
           }
         }
         if (this.designationAtEnd) {
@@ -796,11 +799,6 @@ export default class NamesCapture extends Mixins(CommonMixin) {
               let newName = nameChoices[`name${choice}`].replace(nameChoices[`designation${choice}`], '').trim()
               this.setNameChoices({ key: `name${choice}`, value: newName })
             }
-          }
-        } else if (this.designationAtEnd && nameChoices[`designation${choice}`]) {
-          if (!nameChoices[`name${choice}`].endsWith(nameChoices[`designation${choice}`])) {
-            let newName = nameChoices[`name${choice}`] + ' ' + nameChoices[`designation${choice}`]
-            this.setNameChoices({ key: `name${choice}`, value: newName })
           }
         }
       }


### PR DESCRIPTION
Name choice should not have designation added

*Issue #:* /bcgov/entity#8901

*Description of changes:*
1. If a designation has NOT been setup before editing the name, the designation is NOT in the name when no designation input available.
2. If the designation has been setup before editing the name, the designation goes with the name when no designation input available.
3. Removed a piece of the code which never reachable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
