### PR TITLE
fix the typo in cancel/refund message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "3.0.17",
+      "version": "3.0.18",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/enums": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/payment-mixin.ts
+++ b/src/mixins/payment-mixin.ts
@@ -248,7 +248,7 @@ export class PaymentMixin extends Mixins(ActionMixin) {
               refundMessageText1:
               'Your Name Request has been cancelled and a refund request has been submitted.',
               refundMessageText2:
-              'The refund will be applied to you original payment method and the requested name will not be ' +
+              'The refund will be applied to your original payment method and the requested name will not be ' +
               'examined for use. An email confirming the cancellation and refund of this Name Request will be ' +
               `sent to ${this.getNr.applicants.emailAddress}.`,
               showStaffContact: false,
@@ -274,7 +274,7 @@ export class PaymentMixin extends Mixins(ActionMixin) {
           refundLabel: 'Refund Request Processed',
           refundMessageText1:
           'Your Name Request has been cancelled and a refund request has been submitted.<br/><br/>' +
-          'The refund will be applied to you original payment method and the requested name will not be ' +
+          'The refund will be applied to your original payment method and the requested name will not be ' +
           'examined for use. An email confirming the cancellation and refund of this Name Request will be ' +
           `sent to ${this.getNr.applicants.emailAddress}.`,
           showStaffContact: false,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12204

*Description of changes:*
fix the typo in cancel/refund message

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
