### PR TITLE
12529 Namerequest UI get account id from CURRENT_ACCOUNT#12529

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "3.0.18",
+      "version": "3.0.19",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/enums": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/plugins/getConfig.ts
+++ b/src/plugins/getConfig.ts
@@ -12,7 +12,7 @@ export async function getConfig (): Promise<EnvConfigI> {
   }
 
   // get and store account id, if present
-  const accountId = new URLSearchParams(windowLocationSearch).get('accountid')
+  const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
   if (accountId) {
     sessionStorage.setItem('ACCOUNT_ID', accountId)
   }

--- a/src/plugins/getConfig.ts
+++ b/src/plugins/getConfig.ts
@@ -5,7 +5,6 @@ export async function getConfig (): Promise<EnvConfigI> {
   // get config from environment
   const windowLocationOrigin = window.location.origin
   const processEnvBaseUrl = process.env.BASE_URL
-  const windowLocationSearch = window.location.search // eg, ?accountid=2288
 
   if (!processEnvBaseUrl || !windowLocationOrigin) {
     return Promise.reject(new Error('Missing environment variables'))

--- a/src/plugins/getConfig.ts
+++ b/src/plugins/getConfig.ts
@@ -11,12 +11,6 @@ export async function getConfig (): Promise<EnvConfigI> {
     return Promise.reject(new Error('Missing environment variables'))
   }
 
-  // get and store account id, if present
-  const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
-  if (accountId) {
-    sessionStorage.setItem('ACCOUNT_ID', accountId)
-  }
-
   // fetch config from server
   const url = `${windowLocationOrigin}${processEnvBaseUrl}config/configuration.json`
   const headers = {

--- a/src/plugins/navigate.ts
+++ b/src/plugins/navigate.ts
@@ -5,7 +5,7 @@
 export function navigate (url: string): boolean {
   try {
     // get account id and set in params
-    const accountId = sessionStorage.getItem('ACCOUNT_ID')
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     if (accountId) {
       if (url.includes('?')) {
         url += `&accountid=${accountId}`

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -1,0 +1,122 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+import Vuetify from 'vuetify'
+import VueRouter from 'vue-router'
+import { getVuexStore } from '@/store'
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import App from '@/App.vue'
+import ChatPopup from '@/components/common/chat-popup.vue'
+import {
+  AffiliationErrorDialog, CancelDialog, ConditionsDialog, ErrorDialog, ExitDialog, HelpMeChooseDialog,
+  LocationInfoDialog, MrasSearchInfoDialog, NrNotRequiredDialog, ConfirmNrDialog, PaymentCompleteDialog,
+  PickEntityOrConversionDialog, PickRequestTypeDialog, RenewDialog, ReceiptsDialog, RefundDialog, ResubmitDialog,
+  RetryDialog, StaffPaymentErrorDialog, UpgradeDialog, ExitIncompletePaymentDialog
+} from '@/components/dialogs'
+import PaySystemAlert from 'sbc-common-components/src/components/PaySystemAlert.vue'
+import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
+import SbcFooter from 'sbc-common-components/src/components/SbcFooter.vue'
+// import mockRouter from './MockRouter'
+
+Vue.use(Vuetify)
+
+const vuetify = new Vuetify({})
+const store = new Vuex.Store<any>({
+  getters: {
+    isMobile (): any {},
+    getIncorporateLoginModalVisible (): any {}
+  },
+  state: {
+    stateModel: {
+      newRequestModel: {
+        incorporateLoginModalVisible: false
+      }
+    }
+  }
+})
+
+const KEYCLOAK_TOKEN = 'eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJUbWdtZUk0MnVsdUZ0N3' +
+  'FQbmUtcTEzdDUwa0JDbjF3bHF6dHN0UGdUM1dFIn0.eyJqdGkiOiIzZDQ3YjgwYy01MTAzLTRjMTYtOGNhZC0yMjU4NDMwZGYwZTciLCJle' +
+  'HAiOjE1Njg0ODk1NTksIm5iZiI6MCwiaWF0IjoxNTY4NDAzMTYwLCJpc3MiOiJodHRwczovL3Nzby1kZXYucGF0aGZpbmRlci5nb3YuYmMuY2' +
+  'EvYXV0aC9yZWFsbXMvZmNmMGtwcXIiLCJhdWQiOlsic2JjLWF1dGgtd2ViIiwicmVhbG0tbWFuYWdlbWVudCIsImJyb2tlciIsImFjY291bnQ' +
+  'iXSwic3ViIjoiZDRjNTBiZTAtYWM2OC00MDIyLTkxMGQtMzE2NzQ4NGFkOWU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoic2JjLWF1dGgtd2Vi' +
+  'Iiwibm9uY2UiOiJkMjljZTZlNS0xNzZhLTRkMTUtODUzZS05NWUzZmUwZmYwZjgiLCJhdXRoX3RpbWUiOjE1Njg0MDMxNTksInNlc3Npb25fc' +
+  '3RhdGUiOiJiOTEwMzQxZi0xNzVjLTRkMTktYWI1Yy1iM2QxNTBiYjk0NjYiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly' +
+  '8xOTIuMTY4LjAuMTM6ODA4MC8iLCIxOTIuMTY4LjAuMTMiLCIqIiwiaHR0cDovLzE5Mi4xNjguMC4xMzo4MDgwIl0sInJlYWxtX2FjY2VzcyI' +
+  '6eyJyb2xlcyI6WyJ2aWV3IiwiZWRpdCIsIm9mZmxpbmVfYWNjZXNzIiwic3RhZmYiLCJ1bWFfYXV0aG9yaXphdGlvbiIsImJhc2ljIl19LCJy' +
+  'ZXNvdXJjZV9hY2Nlc3MiOnsicmVhbG0tbWFuYWdlbWVudCI6eyJyb2xlcyI6WyJ2aWV3LWlkZW50aXR5LXByb3ZpZGVycyIsInZpZXctcmVhb' +
+  'G0iLCJtYW5hZ2UtaWRlbnRpdHktcHJvdmlkZXJzIiwiaW1wZXJzb25hdGlvbiIsInJlYWxtLWFkbWluIiwiY3JlYXRlLWNsaWVudCIsIm1hbm' +
+  'FnZS11c2VycyIsInF1ZXJ5LXJlYWxtcyIsInZpZXctYXV0aG9yaXphdGlvbiIsInF1ZXJ5LWNsaWVudHMiLCJxdWVyeS11c2VycyIsIm1hbmF' +
+  'nZS1ldmVudHMiLCJtYW5hZ2UtcmVhbG0iLCJ2aWV3LWV2ZW50cyIsInZpZXctdXNlcnMiLCJ2aWV3LWNsaWVudHMiLCJtYW5hZ2UtYXV0aG9y' +
+  'aXphdGlvbiIsIm1hbmFnZS1jbGllbnRzIiwicXVlcnktZ3JvdXBzIl19LCJicm9rZXIiOnsicm9sZXMiOlsicmVhZC10b2tlbiJdfSwiYWNjb' +
+  '3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOi' +
+  'JvcGVuaWQiLCJmaXJzdG5hbWUiOiJTdW1lc2giLCJyb2xlcyI6WyJ2aWV3IiwiZWRpdCIsIm9mZmxpbmVfYWNjZXNzIiwic3RhZmYiLCJ1bWF' +
+  'fYXV0aG9yaXphdGlvbiIsImJhc2ljIl0sIm5hbWUiOiJTdW1lc2ggS2FyaXlpbCIsInByZWZlcnJlZF91c2VybmFtZSI6InNrYXJpeWlsQGlk' +
+  'aXIiLCJlbWFpbCI6InN1bWVzaC5wLmthcml5aWxAZ292LmJjLmNhIiwibGFzdG5hbWUiOiJLYXJpeWlsIiwidXNlcm5hbWUiOiJza2FyaXlpb' +
+  'EBpZGlyIn0.MSPSakOnCUia4qd-fUpvP2PB3k977Eyhjxn-ykjadsUTEK4f2R3c8vozxaIIMH0-qUwduyQmdZCl3tQnXYQ9Ttf1PE9eMLS4sX' +
+  'JiIUlDmKZ2ow7GmmDabic8igHnEDYD6sI7OFYnCJhRdgVEHN-_4KUk2YsAVl5XUr6blJKMuYDPeMyNreGTXU7foE4AT-93FwlyTyFzQGddrDv' +
+  'c6kkQr7mgJNTtgg87DdYbVGbEtIetyVfvwEF0rU8JH2N-j36XIebo33FU3-gJ5Y5S69EHPqQ37R9H4d8WUrHO-4QzJQih3Yaea820XBplJeo0' +
+  'DO3hQoVtPD42j0p3aIy10cnW2g'
+
+describe('App component', () => {
+  let wrapper: any
+
+  beforeEach(async () => {
+    sessionStorage.clear()
+    sessionStorage.setItem('KEYCLOAK_TOKEN', KEYCLOAK_TOKEN)
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": 668 }')
+
+    // create a Local Vue and install router on it
+    const localVue = createLocalVue()
+    localVue.use(VueRouter)
+    wrapper = shallowMount(App, { localVue, store, vuetify, stubs: { Affix: true } })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('renders dialogs properly', () => {
+    expect(wrapper.findComponent(AffiliationErrorDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(CancelDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(ConditionsDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(ConfirmNrDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(ErrorDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(ExitDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(ExitIncompletePaymentDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(HelpMeChooseDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(LocationInfoDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(MrasSearchInfoDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(NrNotRequiredDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(PaymentCompleteDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(PickEntityOrConversionDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(PickRequestTypeDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(RenewDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(ReceiptsDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(RefundDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(ResubmitDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(RetryDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(StaffPaymentErrorDialog).exists()).toBe(true)
+    expect(wrapper.findComponent(UpgradeDialog).exists()).toBe(true)
+  })
+
+  it('renders the sub-components properly', () => {
+    expect(wrapper.findComponent(SbcHeader).exists()).toBe(true)
+    expect(wrapper.findComponent(ChatPopup).exists()).toBe(true)
+    expect(wrapper.findComponent(SbcHeader).exists()).toBe(true)
+    expect(wrapper.findComponent(PaySystemAlert).exists()).toBe(true)
+    expect(wrapper.findComponent(SbcFooter).exists()).toBe(true)
+  })
+
+  it('initializes the local properties properly', () => {
+    const vm: any = wrapper.vm
+    expect(vm.staffPaymentErrorDialog).toBe(false)
+    expect(vm.saveErrors).toEqual([])
+    expect(vm.saveWarnings).toEqual([])
+  })
+
+  it('redirects to dashboard if exiting after saving changes', async () => {
+    // verify sessionStorage items
+    expect(sessionStorage.getItem('KEYCLOAK_TOKEN')).toBe(KEYCLOAK_TOKEN)
+    expect(JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT')).id).toBe(668)
+  })
+})


### PR DESCRIPTION
*Issue #:* [/bcgov/entity#12529](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/12529)

*Description of changes:*
- get account id from CURRENT_ACCOUNT
  - navigate.ts
- removed ACCOUNT_ID from getConfig.ts
- added unit test file: App.spec.ts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
