### PR TITLE
13314 Added ability to disable Upgrade Priority action button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/enums": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/dialogs/resubmit.vue
+++ b/src/components/dialogs/resubmit.vue
@@ -58,7 +58,7 @@
                 :disabled="isMobile || enablePriorityCheckbox"
               >
                 <template v-slot:activator="{ on }">
-                  <div v-on="on" style="width:fit-content">
+                  <div v-on="on" class="width-fit-content">
                     <v-checkbox
                       hide-details
                       v-model="isPriorityRequest"
@@ -311,6 +311,10 @@ export default class ResubmitDialog extends Mixins(
 </script>
 
 <style lang="scss" scoped>
+.width-fit-content {
+  width: fit-content;
+}
+
 // hide tabs bar
 ::v-deep .v-tabs > .v-tabs-bar {
   display: none;

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -157,13 +157,24 @@
                   <!-- incorporate action is a distinct button below -->
                   <template v-if="action !== NrAction.INCORPORATE">
                     <v-col cols="12" :key="action+'-button'">
-                      <v-btn block
-                        class="button"
-                        :id="action+'-btn'"
-                        :class="isRedButton(action) ? 'button-red' : 'button-blue'"
-                        :disabled="disableUnfurnished && (action !== NrAction.RECEIPT)"
-                        @click="handleButtonClick(action)"
-                      >{{ actionText(action) }}</v-btn>
+                      <v-tooltip top
+                        content-class="top-tooltip"
+                        transition="fade-transition"
+                        :disabled="isMobile || !actionTooltip(action)"
+                      >
+                        <template v-slot:activator="{ on }">
+                          <div v-on="on" class="width-fit-content">
+                            <v-btn block
+                              class="button"
+                              :id="action+'-btn'"
+                              :class="isRedButton(action) ? 'button-red' : 'button-blue'"
+                              :disabled="isDisabledButton(action)"
+                              @click="handleButtonClick(action)"
+                            >{{ actionText(action) }}</v-btn>
+                          </div>
+                        </template>
+                        <span>{{ actionTooltip(action) }}</span>
+                      </v-tooltip>
                     </v-col>
                   </template>
                 </template>
@@ -525,12 +536,33 @@ export default class ExistingRequestDisplay extends Mixins(
     return ''
   }
 
+  /** Whether Upgrade Priority button should be enabled. */
+  get enableUpgradeButton (): boolean {
+    return getFeatureFlag('enable-priority-checkbox')
+  }
+
+  /** Returns True if the specified action button should be disabled. */
+  protected isDisabledButton (action: NrAction): boolean {
+    if (action === NrAction.UPGRADE && !this.enableUpgradeButton) return true
+    if (this.disableUnfurnished && action !== NrAction.RECEIPTS) return true
+    return false
+  }
+
+  /** Returns tooltip (or '') for the specified action button. */
+  protected actionTooltip (action: NrAction): string {
+    if (action === NrAction.UPGRADE && !this.enableUpgradeButton) {
+      return 'Due to the on-going labour dispute between the government and its employees, ' +
+        'priority filings are temporarily disabled.'
+    }
+    return ''
+  }
+
   /** Returns True if the specified action should display a red button. */
   protected isRedButton (action: NrAction): boolean {
     return [NrAction.REQUEST_REFUND, NrAction.CANCEL].includes(action)
   }
 
-  /** Returns display text for the specified action code. */
+  /** Returns display text for the specified action button. */
   protected actionText (action: NrAction): string {
     switch (action) {
       case NrAction.CANCEL: return 'Cancel Name Request'


### PR DESCRIPTION
*Issue #:* bcgov/entity#13314

*Description of changes:*
- disable Upgrade Priority action depending on FF
- display action tooltip as needed
- app version = 3.1.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).