### PR TITLE
Show Prioprity fee in Cancel and Refund confirmation window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/enums": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/payment/refund-summary.vue
+++ b/src/components/payment/refund-summary.vue
@@ -13,6 +13,10 @@
             <div class="fee-list__item-name">{{item.description}}</div>
             <div class="fee-list__item-value">${{item.filingFees.toFixed(2)}}</div>
           </li>
+          <li class="fee-list__item text-body-1" v-if="item.priorityFees > 0">
+            <div class="fee-list__item-name">Priority fee</div>
+            <div class="fee-list__item-value">${{item.priorityFees.toFixed(2)}}</div>
+          </li>
           <li class="fee-list__item text-body-1" v-if="item.serviceFees > 0">
             <div class="fee-list__item-name">Service fee</div>
             <div class="fee-list__item-value">${{item.serviceFees.toFixed(2)}}</div>
@@ -39,6 +43,7 @@ export default class RefundSummary extends Vue {
 
   /** The array of line items in all completed SBC payments. */
   private get lineItems (): any[] {
+    debugger
     const arrays = this.payments.map(p => (p.sbcPayment.statusCode === 'COMPLETED') ? p.sbcPayment.lineItems : [])
     const lineItems = [].concat(...arrays)
     return lineItems

--- a/src/components/payment/refund-summary.vue
+++ b/src/components/payment/refund-summary.vue
@@ -43,7 +43,6 @@ export default class RefundSummary extends Vue {
 
   /** The array of line items in all completed SBC payments. */
   private get lineItems (): any[] {
-    debugger
     const arrays = this.payments.map(p => (p.sbcPayment.statusCode === 'COMPLETED') ? p.sbcPayment.lineItems : [])
     const lineItems = [].concat(...arrays)
     return lineItems


### PR DESCRIPTION
*Issue #:* [/bcgov/entity#7342](https://github.com/bcgov/entity/issues/7342)

*Description of changes:*
Add code to display Priority fees from payments object in Cancel and Refund confirmation window

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
