### PR TITLE
13494 Namerequest UI: missing error handling when clicking Register Your Business button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/enums": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/nr-affiliation-mixin.ts
+++ b/src/mixins/nr-affiliation-mixin.ts
@@ -29,6 +29,10 @@ export class NrAffiliationMixin extends Mixins(CommonMixin) {
 
       // try to affiliate the NR
       const createAffiliationResponse = await AuthServices.createNrAffiliation(accountId, nr)
+      if (!createAffiliationResponse || !createAffiliationResponse.status) {
+        this.setAffiliationErrorModalValue(NrAffiliationErrors.UNABLE_TO_START_REGISTRATION)
+        throw Error('Unable to find existing affiliation')
+      }
 
       // check if affiliation succeeded
       if (createAffiliationResponse.status === CREATED) {


### PR DESCRIPTION
**This is a resubmit (after a revert) of Eve's previous PR, which had package lock file issues.**

*Issue #:* [/bcgov/entity#13494](https://github.com/bcgov/entity/issues/13494)

*Description of changes:*
added the error handling when error retrieving Affiliation info from auth

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).