### PR TITLE
13304 - delete obsolete NameRequest feature flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/enums": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -424,7 +424,7 @@ export default class ExistingRequestDisplay extends Mixins(
 
   /** True if the Register button should be shown. */
   get showRegisterButton (): boolean {
-    return this.isFirm(this.nr) && !!getFeatureFlag('enable-sp-gp-dba')
+    return this.isFirm(this.nr)
   }
 
   /** True if the Check Status gray box should be shown. */

--- a/src/plugins/featureFlags.ts
+++ b/src/plugins/featureFlags.ts
@@ -8,7 +8,6 @@ declare const window: any
  * Uses "namerequest" project (per LD client id in config).
  */
 const defaultFlagSet: LDFlagSet = {
-  'enable-sp-gp-dba': false, // by default, don't show firm Register button
   'enable-priority-checkbox': false, // by default, priority is disabled
   'disable-analysis': true, // by default, analysis is disabled
   'hardcoded_regular_wait_time': 0, // by default, use actual wait time


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13304

*Description of changes:*
- removed  "enable-sp-gp-dba", which should always be TRUE

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
