### PR TITLE
Add the conditions to show Business Register button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/enums": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -427,10 +427,10 @@ export default class ExistingRequestDisplay extends Mixins(
     return this.isFirm(this.nr) &&
            this.nr.request_action_cd !== RequestCode.CHG &&
            (NrState.APPROVED === this.nr.state ||
-            !this.isConcentRequired)
+            !this.isConsentRequired)
   }
 
-  get isConcentRequired (): boolean {
+  get isConsentRequired (): boolean {
     return NrState.CONDITIONAL === this.nr.state &&
             this.nr.consentFlag &&
             this.nr.consentFlag === 'Y'

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -425,15 +425,17 @@ export default class ExistingRequestDisplay extends Mixins(
   /** True if the Register button should be shown. */
   get showRegisterButton (): boolean {
     return this.isFirm(this.nr) &&
-           this.nr.request_action_cd !== RequestCode.CHG &&
+           this.nr.request_action_cd &&
+           this.nr.request_action_cd === RequestCode.NEW &&
            (NrState.APPROVED === this.nr.state ||
-            !this.isConsentRequired)
+            this.isConsentUnRequired)
   }
 
-  get isConsentRequired (): boolean {
+  get isConsentUnRequired (): boolean {
     return NrState.CONDITIONAL === this.nr.state &&
-            this.nr.consentFlag &&
-            this.nr.consentFlag === 'Y'
+            (this.nr.consentFlag === null ||
+              this.nr.consentFlag === 'R' ||
+              this.nr.consentFlag === 'N')
   }
 
   /** True if the Check Status gray box should be shown. */

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -226,7 +226,7 @@ import NamesGrayBox from './names-gray-box.vue'
 import CheckStatusGrayBox from './check-status-gray-box.vue'
 import NrApprovedGrayBox from './nr-approved-gray-box.vue'
 import NrNotApprovedGrayBox from './nr-not-approved-gray-box.vue'
-import { NameState, NrAction, NrState, PaymentStatus, SbcPaymentStatus, PaymentAction, Furnished }
+import { NameState, NrAction, NrState, PaymentStatus, SbcPaymentStatus, PaymentAction, Furnished, RequestCode }
   from '@/enums'
 import { sleep, getFeatureFlag, navigate } from '@/plugins'
 import NamexServices from '@/services/namex.services'
@@ -424,7 +424,16 @@ export default class ExistingRequestDisplay extends Mixins(
 
   /** True if the Register button should be shown. */
   get showRegisterButton (): boolean {
-    return this.isFirm(this.nr)
+    return this.isFirm(this.nr) &&
+           this.nr.request_action_cd !== RequestCode.CHG &&
+           (NrState.APPROVED === this.nr.state ||
+            !this.isConcentRequired)
+  }
+
+  get isConcentRequired (): boolean {
+    return NrState.CONDITIONAL === this.nr.state &&
+            this.nr.consentFlag &&
+            this.nr.consentFlag === 'Y'
   }
 
   /** True if the Check Status gray box should be shown. */


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14366 and /bcgov/entity#14465

*Description of changes:*
Add the conditions to show Business Register button in existing NR page:
1. the NR should not be used for name change
2. the NR request status 
    a.  is Approved OR
    b.  is Conditional and consent status is
             - null (not required)
             - R (received)
             - N (waived)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
