### PR TITLE
show Payment Incomplete status in UI only when nr.state='DRAFT'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "3.3.4",
+      "version": "3.3.5",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/enums": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -532,7 +532,8 @@ export default class ExistingRequestDisplay extends Mixins(
   }
 
   get isNotPaid () {
-    return (this.pendingPayment?.sbcPayment?.statusCode === PaymentStatus.CREATED)
+    return (this.pendingPayment?.sbcPayment?.statusCode === PaymentStatus.CREATED) &&
+            NrState.DRAFT === this.nr.state
   }
 
   get isPaymentProcessing () {

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -533,7 +533,7 @@ export default class ExistingRequestDisplay extends Mixins(
 
   get isNotPaid () {
     return (this.pendingPayment?.sbcPayment?.statusCode === PaymentStatus.CREATED) &&
-            NrState.DRAFT === this.nr.state
+            ([NrState.DRAFT, NrState.PENDING_PAYMENT].includes(this.nr.state))
   }
 
   get isPaymentProcessing () {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14774

*Description of changes:*
Add condition nr.state='DRAFT' when Payment Incomplete state to be show

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
