### PR TITLE
sentry errors related to keycloak calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "3.3.12",
+      "version": "3.3.13",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/enums": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/update-user-mixin.ts
+++ b/src/mixins/update-user-mixin.ts
@@ -8,7 +8,9 @@ export class UpdateUserMixin extends Vue {
   async updateUser (): Promise<any> {
     try {
       const userInfo = await AuthServices.fetchUserInfo()
-      await this.updateLaunchDarkly(userInfo)
+      if (userInfo !== undefined) {
+        await this.updateLaunchDarkly(userInfo)
+      }
     } catch (err) {
       // just log the error -- no need to halt app
       console.log('Launch Darkly update error =', err) // eslint-disable-line no-console

--- a/src/mixins/update-user-mixin.ts
+++ b/src/mixins/update-user-mixin.ts
@@ -8,7 +8,7 @@ export class UpdateUserMixin extends Vue {
   async updateUser (): Promise<any> {
     try {
       const userInfo = await AuthServices.fetchUserInfo()
-      if (userInfo !== undefined) {
+      if (userInfo) {
         await this.updateLaunchDarkly(userInfo)
       }
     } catch (err) {

--- a/src/services/auth.services.ts
+++ b/src/services/auth.services.ts
@@ -54,12 +54,19 @@ export default class AuthServices {
    */
   static async fetchUserInfo (): Promise<any> {
     const url = `${this.authApiUrl}/users/@me`
-
-    return axios.get(url)
-      .then(response => {
-        if (response?.data) return response.data
-        throw new Error('Invalid user info')
-      })
+    if (!sessionStorage.getItem('PREVENT_STORAGE_SYNC')) {
+      const token = sessionStorage.getItem('KEYCLOAK_TOKEN')
+      if (token) {
+        const headers = {
+          Authorization: `Bearer ${token}`
+        }
+        return axios.get(url, { headers: headers })
+          .then(response => {
+            if (response?.data) return response.data
+            throw new Error('Invalid user info')
+          })
+      }
+    }
   }
 
   /**

--- a/src/services/auth.services.ts
+++ b/src/services/auth.services.ts
@@ -53,19 +53,23 @@ export default class AuthServices {
    * Throws on error.
    */
   static async fetchUserInfo (): Promise<any> {
+    // PREVENT_STORAGE_SYNC flag is set during signout in sbc common components
+    // when session is state cleared, as a mechanism to prevent returning async
+    // functions to set tokens
+    if (sessionStorage.getItem('PREVENT_STORAGE_SYNC')) return null
     const url = `${this.authApiUrl}/users/@me`
-    if (!sessionStorage.getItem('PREVENT_STORAGE_SYNC')) {
-      const token = sessionStorage.getItem('KEYCLOAK_TOKEN')
-      if (token) {
-        const headers = {
-          Authorization: `Bearer ${token}`
-        }
-        return axios.get(url, { headers: headers })
-          .then(response => {
-            if (response?.data) return response.data
-            throw new Error('Invalid user info')
-          })
+    const token = sessionStorage.getItem('KEYCLOAK_TOKEN')
+    if (token) {
+      const headers = {
+        Authorization: `Bearer ${token}`
       }
+      return axios.get(url, { headers: headers })
+        .then(response => {
+          if (response?.data) return response.data
+          throw new Error('Invalid user info')
+        })
+    } else {
+      return null
     }
   }
 


### PR DESCRIPTION
*Issue: /bcgov/entity/issues/6970

*Description of changes:
The main loop in the vue app tries to sync the token every time changes are detected, i.e. before we are redirected to /signin and after we are redirected to /signout the path is /namerequest and we call initializeToken.  Majority of still relevant sentry errors take place during logout (i.e. at https://www.bcregistry.ca/namerequest/signout -  see full list of errors here https://registries.sentry.io/issues/2098686855/events/?project=5433955&referrer=issue-stream&statsPeriod=14d). The errors take place right after the session is cleared and PREVENT_STORAGE_SYNC flag is set during the logout. Checking for PREVENT_STORAGE_SYNC the flag should prevent us from fetching userInfo when we don’t have the token, as auth-api returns 401 error if auth token is not provided in /users/@me calls (authorization_header_missing errors can be observed in the developer tools console)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
