### PR TITLE
16634 Fixed clickable and hover areas + fixed items with same value + fixed blurbs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/corp-type-module": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -14,6 +14,7 @@
           label="Select an Action"
           :error-messages="getErrors.includes('request_action_cd') ? 'Please select an action' : ''"
           :items="requestActions"
+          item-value="[group,value]"
           :menu-props="{ bottom: true, offsetY: true, maxHeight: 423 }"
           @change="clearErrors()"
         >

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -18,24 +18,27 @@
           @change="clearErrors()"
         >
           <template v-slot:item="{ item }">
-            <v-list-item-title
+            <v-list-item-content
               v-if="item.isHeader"
-              class="group-header d-flex justify-space-between align-center"
+              class="group-header px-4 py-5"
               @click.stop="toggleActionGroup(item.group)"
             >
-              <div class="app-blue mr-4">{{ item.text }}</div>
-              <v-icon color="primary">
-                {{ item.group === activeActionGroup ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
-              </v-icon>
-            </v-list-item-title>
-            <v-list-item-title
+              <div class="d-flex justify-space-between align-center">
+                <p class="mb-0 mr-4" :class="{'app-blue': item.group === activeActionGroup}">{{ item.text }}</p>
+                <v-icon color="primary">
+                  {{ item.group === activeActionGroup ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
+                </v-icon>
+              </div>
+            </v-list-item-content>
+
+            <v-list-item-content
               v-else
-              class="group-item ml-2 colour-text"
+              class="group-item pl-8 pr-4 py-4"
               @click="request_action_cd = item.value"
             >
               <div class="font-weight-bold">{{ item.text }}</div>
               <div>{{ item.subtext }}</div>
-            </v-list-item-title>
+            </v-list-item-content>
           </template>
         </v-select>
       </v-col>
@@ -553,13 +556,13 @@ export default class NewSearch extends Mixins(CommonMixin) {
 <style lang="scss" scoped>
 @import '@/assets/styles/theme.scss';
 
-// set min height of request action groups and items only
+// remove v-list-item clickable padding
 ::v-deep .v-list-item:has(.group-header),
 ::v-deep .v-list-item:has(.group-item) {
-  min-height: 60px;
+  padding: 0;
 }
 
-// set border at top of group headers only
+// set border at top of group headers
 ::v-deep .v-list-item:has(.group-header) {
   border-top: 1px solid $gray3;
 }
@@ -575,9 +578,14 @@ export default class NewSearch extends Mixins(CommonMixin) {
   border-top: 1px solid $gray3;
   padding: 20px 8px !important;
 }
+
+// set content colour when hovering over list items
+
+.v-list-item:hover .v-list-item__content,
 .list-item:hover {
-  color: $app-blue;
+  color: $app-blue !important;
 }
+
 .disabled-custom {
   opacity: 0.4;
   pointer-events: none;

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -75,7 +75,7 @@
                       <div v-for="(blurb, index) in item.blurbs "
                            :key="`Location-Blurb-${index}`">
                         <span v-if="request_action_cd === request_action_enum[index]">
-                          {{ item }}
+                          {{ blurb }}
                         </span>
                       </div>
                   </v-tooltip>
@@ -124,7 +124,7 @@
                     <div v-for="(blurb, index) in entityBlurbs(item.value)"
                          :key="`Blurb-${index}`">
                       <span :class="{ 'tooltip-bullet': index !== 0}">
-                        {{ item }}
+                        {{ blurb }}
                       </span>
                     </div>
                   </v-tooltip>


### PR DESCRIPTION
*Issue #:* bcgov/entity#16634

*Description of changes:*

Commit 1:
    - app version = 5.0.5
    - updated v-select item components to fix clickable areas and hover areas
    - removed unneeded text colour class

Commit 2:
    - used combined group+value for v-select to distinguish between items with the same value

Commit 3:
    - fixed location blurb (tooltip)
    - fixed entity type blurb (tooltip)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).