### PR TITLE
 Incorporate now for named companies after NR is approved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.0.6",
+      "version": "5.0.7",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/bullets-colin-link.vue
+++ b/src/components/common/bullets-colin-link.vue
@@ -58,15 +58,14 @@ import { Getter } from 'vuex-class'
 import { CompanyType, EntityType } from '@/enums'
 import NameInput from '@/components/new-request/name-input.vue'
 import { Navigate } from '@/plugins'
-import { NrAffiliationMixin } from '@/mixins'
-import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
+import { CommonMixin, NrAffiliationMixin } from '@/mixins'
 
 @Component({
   components: {
     NameInput
   }
 })
-export default class BulletsColinLink extends Mixins(NrAffiliationMixin) {
+export default class BulletsColinLink extends Mixins(CommonMixin, NrAffiliationMixin) {
   /** The selected business type. */
   @Prop({ default: '' }) readonly businessType!: EntityType
 
@@ -90,20 +89,6 @@ export default class BulletsColinLink extends Mixins(NrAffiliationMixin) {
 
   // For template
   readonly CompanyType = CompanyType
-
-  /**
-   * The alternate codes for entity types.
-   * Alternate codes are used in Entities UIs.
-   */
-  entityTypeAlternateCode (entityType: EntityType): CorpTypeCd {
-    switch (entityType) {
-      case EntityType.BC: return CorpTypeCd.BENEFIT_COMPANY
-      case EntityType.CC: return CorpTypeCd.BC_CCC
-      case EntityType.CR: return CorpTypeCd.BC_COMPANY
-      case EntityType.UL: return CorpTypeCd.BC_ULC_COMPANY
-      default: return null
-    }
-  }
 
   /** Navigate to the Entity Dashboard. */
   goToEntityDashboard (businessId: string): void {

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -197,8 +197,7 @@
             :showIncorporateNowButton="showIncorporateButton"
             :showRegisterButton="showRegisterButton"
             :disabled="disableUnfurnished"
-            @incorporateYourBusiness="handleButtonClick(NrAction.INCORPORATE)"
-            @registerYourBusiness="registerYourBusiness()"
+            @incorporateRegisterYourBusiness="incorporateRegisterYourBusiness()"
           />
 
           <NrNotApprovedGrayBox
@@ -413,7 +412,6 @@ export default class ExistingRequestDisplay extends Mixins(
   get showIncorporateButton (): boolean {
     return (
       this.isSupportedEntity(this.nr) &&
-      this.nr.request_action_cd &&
       this.nr.request_action_cd === NrRequestActionCodes.NEW_BUSINESS &&
       NrState.APPROVED === this.nr.state
     )
@@ -422,7 +420,6 @@ export default class ExistingRequestDisplay extends Mixins(
   /** True if the Register button should be shown. */
   get showRegisterButton (): boolean {
     return this.isFirm(this.nr) &&
-           this.nr.request_action_cd &&
            this.nr.request_action_cd === NrRequestActionCodes.NEW_BUSINESS &&
            (NrState.APPROVED === this.nr.state ||
             this.isConsentUnRequired)
@@ -685,8 +682,8 @@ export default class ExistingRequestDisplay extends Mixins(
     this.setConditionsModalVisible(true)
   }
 
-  /** Called to register the business. */
-  async registerYourBusiness (): Promise<void> {
+  /** Called to incorporate/register the business. */
+  async incorporateRegisterYourBusiness (): Promise<void> {
     // safety check
     if (!this.isNrApprovedOrConditional) return
 

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -194,8 +194,10 @@
             :nrNum="nr && nr.nrNum"
             :approvedName="approvedName && approvedName.name"
             :emailAddress="nr && nr.applicants && nr.applicants.emailAddress"
+            :showIncorporateNowButton="showIncorporateButton"
             :showRegisterButton="showRegisterButton"
             :disabled="disableUnfurnished"
+            @incorporateYourBusiness="handleButtonClick(NrAction.INCORPORATE)"
             @registerYourBusiness="registerYourBusiness()"
           />
 
@@ -204,13 +206,6 @@
             v-if="showNrNotApprovedGrayBox"
             :nrNum="nr.nrNum"
           />
-
-          <!-- incorporate button -->
-          <div class="mt-5 text-center" v-if="showIncorporateButton">
-            <v-btn id="INCORPORATE-btn" @click="handleButtonClick(NrAction.INCORPORATE)">
-              Incorporate Using This Name Request
-            </v-btn>
-          </div>
         </div>
       </transition>
     </template>
@@ -417,8 +412,10 @@ export default class ExistingRequestDisplay extends Mixins(
    */
   get showIncorporateButton (): boolean {
     return (
-      this.isBenefitCompany(this.nr) &&
-      this.actions.includes(NrAction.INCORPORATE)
+      this.isSupportedEntity(this.nr) &&
+      this.nr.request_action_cd &&
+      this.nr.request_action_cd === NrRequestActionCodes.NEW_BUSINESS &&
+      NrState.APPROVED === this.nr.state
     )
   }
 

--- a/src/components/existing-request/nr-approved-gray-box.vue
+++ b/src/components/existing-request/nr-approved-gray-box.vue
@@ -6,7 +6,7 @@
           class="register-btn"
           min-width="20rem"
           :disabled="disabled"
-          @click="$emit('registerYourBusiness')"
+          @click="$emit('incorporateRegisterYourBusiness')"
         >
           <strong>Register Your Business</strong>
         </v-btn>
@@ -17,7 +17,7 @@
           class="incorporate-now-btn"
           min-width="20rem"
           :disabled="disabled"
-          @click="$emit('incorporateYourBusiness')"
+          @click="$emit('incorporateRegisterYourBusiness')"
         >
           <strong>Incorporate Your Business</strong>
         </v-btn>

--- a/src/components/existing-request/nr-approved-gray-box.vue
+++ b/src/components/existing-request/nr-approved-gray-box.vue
@@ -12,6 +12,17 @@
         </v-btn>
       </div>
 
+      <div v-else-if="showIncorporateNowButton" class="d-flex justify-center my-1 pb-1">
+        <v-btn
+          class="incorporate-now-btn"
+          min-width="20rem"
+          :disabled="disabled"
+          @click="$emit('incorporateYourBusiness')"
+        >
+          <strong>Incorporate Your Business</strong>
+        </v-btn>
+      </div>
+
       <p v-else>
         Your Name Request <strong>{{nrNum}}</strong> for <strong>{{approvedName}}</strong> has been
         approved for use. An email has been sent to <strong>{{emailAddress}}</strong> with instructions
@@ -47,6 +58,9 @@ export default class NrApprovedGrayBox extends Vue {
 
   @Prop({ default: false })
   readonly showRegisterButton: boolean
+
+  @Prop({ default: false })
+  readonly showIncorporateNowButton: boolean
 
   @Prop({ default: false })
   readonly disabled: boolean

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -1,5 +1,7 @@
 import { Component, Vue } from 'vue-property-decorator'
 import { EntityType, PriorityCode, NrRequestActionCodes } from '@/enums'
+import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
+import { GetFeatureFlag } from '@/plugins'
 
 @Component({})
 export class CommonMixin extends Vue {
@@ -52,6 +54,20 @@ export class CommonMixin extends Vue {
   }
 
   /**
+   * The alternate codes for entity types.
+   * Alternate codes are used in Entities UIs.
+   */
+  entityTypeAlternateCode (entityType: EntityType): CorpTypeCd {
+    switch (entityType) {
+      case EntityType.BC: return CorpTypeCd.BENEFIT_COMPANY
+      case EntityType.CC: return CorpTypeCd.BC_CCC
+      case EntityType.CR: return CorpTypeCd.BC_COMPANY
+      case EntityType.UL: return CorpTypeCd.BC_ULC_COMPANY
+      default: return null
+    }
+  }
+
+  /**
    * Returns request action text for the the specified code.
    * See namex -> api/namex/resources/name_requests/report_resource.py::_get_request_action_cd_description()
    */
@@ -80,9 +96,10 @@ export class CommonMixin extends Vue {
     return (nr?.priorityCd === PriorityCode.YES)
   }
 
-  /** Returns true if the specified NR is for a Benefit Company. */
-  isBenefitCompany (nr: any): boolean {
-    return (nr?.entity_type_cd === EntityType.BC)
+  /** Returns true if the specified NR is for a supported Incorporation Entity Type (FF). */
+  isSupportedEntity (nr: any): boolean {
+    const supportedEntites = GetFeatureFlag('supported-incorporation-registration-entities')
+    return supportedEntites.includes(nr?.entity_type_cd)
   }
 
   /** Returns true if the specified NR is for a firm (SP/GP). */

--- a/src/mixins/nr-affiliation-mixin.ts
+++ b/src/mixins/nr-affiliation-mixin.ts
@@ -134,8 +134,8 @@ export class NrAffiliationMixin extends Mixins(CommonMixin) {
 
   /** Returns business request object. */
   private getBusinessRequest (accountId: number, nr: NameRequestI): BusinessRequest {
-    const name = this.isBenefitCompany(nr) ? 'incorporationApplication' : 'registration'
-    const legalType = this.isBenefitCompany(nr) ? 'BEN' : nr.legalType
+    const name = this.isSupportedEntity(nr) ? 'incorporationApplication' : 'registration'
+    const legalType = this.isSupportedEntity(nr) ? this.entityTypeAlternateCode(nr.entity_type_cd) : nr.legalType
     const nrNumber = nr.nrNum
 
     const businessRequest = {

--- a/src/mixins/nr-affiliation-mixin.ts
+++ b/src/mixins/nr-affiliation-mixin.ts
@@ -134,8 +134,12 @@ export class NrAffiliationMixin extends Mixins(CommonMixin) {
 
   /** Returns business request object. */
   private getBusinessRequest (accountId: number, nr: NameRequestI): BusinessRequest {
-    const name = this.isSupportedEntity(nr) ? 'incorporationApplication' : 'registration'
-    const legalType = this.isSupportedEntity(nr) ? this.entityTypeAlternateCode(nr.entity_type_cd) : nr.legalType
+    let name = 'registration'
+    let legalType = nr.legalType
+    if (this.isSupportedEntity(nr)) {
+      name = 'incorporationApplication'
+      legalType = this.entityTypeAlternateCode(nr.entity_type_cd)
+    }
     const nrNumber = nr.nrNum
 
     const businessRequest = {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16942

*Description of changes:*
- Added incorporate now button for named companies after the NR has been approved.

I tested all the possible scenarios (BC, BEN, CC, ULC). I tried implementing the button as clean as possible with minimal code additions by building upon previous work.
UXPin: https://preview.uxpin.com/a86dccdd20ac62828f965c5eea10f81b828a9853#/pages/163136223/simulate/sitemap

### Example for CC:
After NR is Approved:
![NR approved](https://github.com/bcgov/namerequest/assets/122301442/ac3591b5-2f98-4d1d-a91d-78d064db3ac9)

Redirect:
![incorporate with NR](https://github.com/bcgov/namerequest/assets/122301442/30adf098-fd1a-45aa-8a06-9c4adc4375fd)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
