### PR TITLE
Imported latest codes + added ULCB and ULBE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "name-request",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.0.8",
+      "version": "5.0.9",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
-        "@bcrs-shared-components/breadcrumb": "2.1.21",
+        "@bcrs-shared-components/breadcrumb": "2.1.24",
         "@bcrs-shared-components/corp-type-module": "1.0.13",
-        "@bcrs-shared-components/enums": "1.0.41",
+        "@bcrs-shared-components/enums": "1.0.43",
         "@bcrs-shared-components/genesys-web-message": "1.0.0",
-        "@bcrs-shared-components/interfaces": "1.0.65",
+        "@bcrs-shared-components/interfaces": "1.0.67",
         "@bcrs-shared-components/staff-payment": "1.0.29",
         "@bcrs-shared-components/web-chat": "2.0.0",
         "@mdi/font": "^4.5.95",
@@ -1959,12 +1959,88 @@
       }
     },
     "node_modules/@bcrs-shared-components/breadcrumb": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/breadcrumb/-/breadcrumb-2.1.21.tgz",
-      "integrity": "sha512-kthYdjytGIFpwLEDwHmzk+bEnsiZK7N14VE9zWZrKrNsa11nDFosOxYRRkb7Kd9Ht119OcEKnihpoI9AWeeXHw==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/breadcrumb/-/breadcrumb-2.1.24.tgz",
+      "integrity": "sha512-E1UJlz55hkK0TRIGr3/irPtV+SQuvtxOzRz+rmZ1BJ5aeHH0Mvo7X/FME55Ln225aggyifQOCholp0oZK66WzA==",
       "dependencies": {
-        "@bcrs-shared-components/interfaces": "^1.0.64",
-        "vue-property-decorator": "^9.1.2"
+        "@bcrs-shared-components/interfaces": "^1.0.67",
+        "vue": "^2.7.14"
+      }
+    },
+    "node_modules/@bcrs-shared-components/breadcrumb/node_modules/@vue/compiler-sfc": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+      "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
+      "dependencies": {
+        "@babel/parser": "^7.18.4",
+        "postcss": "^8.4.14",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@bcrs-shared-components/breadcrumb/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/@bcrs-shared-components/breadcrumb/node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
+    "node_modules/@bcrs-shared-components/breadcrumb/node_modules/postcss": {
+      "version": "8.4.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/@bcrs-shared-components/breadcrumb/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@bcrs-shared-components/breadcrumb/node_modules/vue": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+      "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+      "dependencies": {
+        "@vue/compiler-sfc": "2.7.14",
+        "csstype": "^3.1.0"
       }
     },
     "node_modules/@bcrs-shared-components/corp-type-module": {
@@ -1973,9 +2049,9 @@
       "integrity": "sha512-Wa8H/bxo8GAlcG7YdiP4zl1wzqxewiCO0TC+pBaYUc4+eufuInlS3yYFa9MFg8+vIL/pDfamRtXqdg1I6C6QYA=="
     },
     "node_modules/@bcrs-shared-components/enums": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.0.41.tgz",
-      "integrity": "sha512-7ZtLveqV5o8fAvoxA2uvDABgIvJmXM7uILAOO3KdVYtU6yY5/99Rp4rNM3FVdm6p+zc3TrRXIQNDpnGUB0eeSQ==",
+      "version": "1.0.43",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.0.43.tgz",
+      "integrity": "sha512-n1Mrhc57p9kuc1nqtujH18s4818u/gHQKHj+/dxAIT6LMnpSaDcgf+Jfu4b9QqgjL6vSgje+p1d8sIFZo/n31A==",
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": "^1.0.13"
       }
@@ -2009,20 +2085,88 @@
       }
     },
     "node_modules/@bcrs-shared-components/interfaces": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/interfaces/-/interfaces-1.0.65.tgz",
-      "integrity": "sha512-EnqM7WrneOPHDYJ27PusBmzEMKrKrmpDrQFV2o+fyk0vkCQrgNliUnflbt+GYtBW9dZ8eAL+RFuDUk22nTT1zA==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/interfaces/-/interfaces-1.0.67.tgz",
+      "integrity": "sha512-v6VwL2rO++6FqzTCoZlgk3z94Ia6TTAslB+XAD6psQg7nYhSmwj3f1s6JBEyfUqKucxAgUJMxIpNDmaai2zjPw==",
       "dependencies": {
-        "@bcrs-shared-components/enums": "^1.0.41",
-        "vue": "^2.7.10"
+        "@bcrs-shared-components/enums": "^1.0.43",
+        "vue": "^2.7.14"
       }
     },
-    "node_modules/@bcrs-shared-components/interfaces/node_modules/@bcrs-shared-components/enums": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.0.41.tgz",
-      "integrity": "sha512-7ZtLveqV5o8fAvoxA2uvDABgIvJmXM7uILAOO3KdVYtU6yY5/99Rp4rNM3FVdm6p+zc3TrRXIQNDpnGUB0eeSQ==",
+    "node_modules/@bcrs-shared-components/interfaces/node_modules/@vue/compiler-sfc": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+      "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
       "dependencies": {
-        "@bcrs-shared-components/corp-type-module": "^1.0.13"
+        "@babel/parser": "^7.18.4",
+        "postcss": "^8.4.14",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@bcrs-shared-components/interfaces/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/@bcrs-shared-components/interfaces/node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
+    "node_modules/@bcrs-shared-components/interfaces/node_modules/postcss": {
+      "version": "8.4.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/@bcrs-shared-components/interfaces/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@bcrs-shared-components/interfaces/node_modules/vue": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+      "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+      "dependencies": {
+        "@vue/compiler-sfc": "2.7.14",
+        "csstype": "^3.1.0"
       }
     },
     "node_modules/@bcrs-shared-components/staff-payment": {
@@ -27156,12 +27300,58 @@
       }
     },
     "@bcrs-shared-components/breadcrumb": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/breadcrumb/-/breadcrumb-2.1.21.tgz",
-      "integrity": "sha512-kthYdjytGIFpwLEDwHmzk+bEnsiZK7N14VE9zWZrKrNsa11nDFosOxYRRkb7Kd9Ht119OcEKnihpoI9AWeeXHw==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/breadcrumb/-/breadcrumb-2.1.24.tgz",
+      "integrity": "sha512-E1UJlz55hkK0TRIGr3/irPtV+SQuvtxOzRz+rmZ1BJ5aeHH0Mvo7X/FME55Ln225aggyifQOCholp0oZK66WzA==",
       "requires": {
-        "@bcrs-shared-components/interfaces": "^1.0.64",
-        "vue-property-decorator": "^9.1.2"
+        "@bcrs-shared-components/interfaces": "^1.0.67",
+        "vue": "^2.7.14"
+      },
+      "dependencies": {
+        "@vue/compiler-sfc": {
+          "version": "2.7.14",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+          "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
+          "requires": {
+            "@babel/parser": "^7.18.4",
+            "postcss": "^8.4.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "nanoid": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+        },
+        "picocolors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+        },
+        "postcss": {
+          "version": "8.4.27",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+          "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+          "requires": {
+            "nanoid": "^3.3.6",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "vue": {
+          "version": "2.7.14",
+          "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+          "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+          "requires": {
+            "@vue/compiler-sfc": "2.7.14",
+            "csstype": "^3.1.0"
+          }
+        }
       }
     },
     "@bcrs-shared-components/corp-type-module": {
@@ -27170,9 +27360,9 @@
       "integrity": "sha512-Wa8H/bxo8GAlcG7YdiP4zl1wzqxewiCO0TC+pBaYUc4+eufuInlS3yYFa9MFg8+vIL/pDfamRtXqdg1I6C6QYA=="
     },
     "@bcrs-shared-components/enums": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.0.41.tgz",
-      "integrity": "sha512-7ZtLveqV5o8fAvoxA2uvDABgIvJmXM7uILAOO3KdVYtU6yY5/99Rp4rNM3FVdm6p+zc3TrRXIQNDpnGUB0eeSQ==",
+      "version": "1.0.43",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.0.43.tgz",
+      "integrity": "sha512-n1Mrhc57p9kuc1nqtujH18s4818u/gHQKHj+/dxAIT6LMnpSaDcgf+Jfu4b9QqgjL6vSgje+p1d8sIFZo/n31A==",
       "requires": {
         "@bcrs-shared-components/corp-type-module": "^1.0.13"
       }
@@ -27205,20 +27395,56 @@
       }
     },
     "@bcrs-shared-components/interfaces": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/interfaces/-/interfaces-1.0.65.tgz",
-      "integrity": "sha512-EnqM7WrneOPHDYJ27PusBmzEMKrKrmpDrQFV2o+fyk0vkCQrgNliUnflbt+GYtBW9dZ8eAL+RFuDUk22nTT1zA==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/interfaces/-/interfaces-1.0.67.tgz",
+      "integrity": "sha512-v6VwL2rO++6FqzTCoZlgk3z94Ia6TTAslB+XAD6psQg7nYhSmwj3f1s6JBEyfUqKucxAgUJMxIpNDmaai2zjPw==",
       "requires": {
-        "@bcrs-shared-components/enums": "^1.0.41",
-        "vue": "^2.7.10"
+        "@bcrs-shared-components/enums": "^1.0.43",
+        "vue": "^2.7.14"
       },
       "dependencies": {
-        "@bcrs-shared-components/enums": {
-          "version": "1.0.41",
-          "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.0.41.tgz",
-          "integrity": "sha512-7ZtLveqV5o8fAvoxA2uvDABgIvJmXM7uILAOO3KdVYtU6yY5/99Rp4rNM3FVdm6p+zc3TrRXIQNDpnGUB0eeSQ==",
+        "@vue/compiler-sfc": {
+          "version": "2.7.14",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+          "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
           "requires": {
-            "@bcrs-shared-components/corp-type-module": "^1.0.13"
+            "@babel/parser": "^7.18.4",
+            "postcss": "^8.4.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "nanoid": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+        },
+        "picocolors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+        },
+        "postcss": {
+          "version": "8.4.27",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+          "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+          "requires": {
+            "nanoid": "^3.3.6",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "vue": {
+          "version": "2.7.14",
+          "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
+          "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+          "requires": {
+            "@vue/compiler-sfc": "2.7.14",
+            "csstype": "^3.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",
@@ -15,10 +15,10 @@
   "dependencies": {
     "@babel/compat-data": "^7.12.13",
     "@bcrs-shared-components/corp-type-module": "1.0.13",
-    "@bcrs-shared-components/enums": "1.0.41",
-    "@bcrs-shared-components/breadcrumb": "2.1.21",
+    "@bcrs-shared-components/enums": "1.0.43",
+    "@bcrs-shared-components/breadcrumb": "2.1.24",
     "@bcrs-shared-components/genesys-web-message": "1.0.0",
-    "@bcrs-shared-components/interfaces": "1.0.65",
+    "@bcrs-shared-components/interfaces": "1.0.67",
     "@bcrs-shared-components/staff-payment": "1.0.29",
     "@bcrs-shared-components/web-chat": "2.0.0",
     "@mdi/font": "^4.5.95",

--- a/src/list-data/conversion-types.ts
+++ b/src/list-data/conversion-types.ts
@@ -45,21 +45,21 @@ export const ConversionTypes: ConversionTypesI[] = [
     shortlist: false
   },
   {
-    desc: 'Unlimited Liability Company to a limited Company',
-    text: 'Unlimited Liability Company to a limited Company',
+    desc: 'Unlimited liability company to a limited company',
+    text: 'Unlimited liability company to a limited company',
     entity_type_cd: EntityType.CR,
     blurbs: [
-      'Alter business type from an unlimited Liability Company to a limited Company.'
+      'Alter business type from an unlimited liability company to a limited company.'
     ],
     value: NrRequestTypeCodes.CONVERT_ULCB,
     shortlist: false
   },
   {
-    desc: 'Unlimited Liability Company to a Benefit Company',
-    text: 'Unlimited Liability Company to a Benefit Company',
+    desc: 'Unlimited liability company to a benefit company',
+    text: 'Unlimited liability company to a benefit company',
     entity_type_cd: EntityType.BC,
     blurbs: [
-      'Alter business type from an ULC to a Benefit Company.'
+      'Alter business type from an unlimited liability company to a benefit company.'
     ],
     value: NrRequestTypeCodes.CONVERT_ULBE,
     shortlist: false

--- a/src/list-data/conversion-types.ts
+++ b/src/list-data/conversion-types.ts
@@ -43,5 +43,25 @@ export const ConversionTypes: ConversionTypesI[] = [
     ],
     value: NrRequestTypeCodes.CONVERT_CORP,
     shortlist: false
+  },
+  {
+    desc: 'Unlimited Liability Company to a limited Company',
+    text: 'Unlimited Liability Company to a limited Company',
+    entity_type_cd: EntityType.CR,
+    blurbs: [
+      'Alter business type from an unlimited Liability Company to a limited Company.'
+    ],
+    value: NrRequestTypeCodes.CONVERT_ULCB,
+    shortlist: false
+  },
+  {
+    desc: 'Unlimited Liability Company to a Benefit Company',
+    text: 'Unlimited Liability Company to a Benefit Company',
+    entity_type_cd: EntityType.BC,
+    blurbs: [
+      'Alter business type from an ULC to a Benefit Company.'
+    ],
+    value: NrRequestTypeCodes.CONVERT_ULBE,
+    shortlist: false
   }
 ]


### PR DESCRIPTION
*Issue #:* None

The reason for this change is to restore a couple of conversion records that were deleted (and also use the latest NR codes enum).

*Description of changes:*
- app version = 5.0.9
- imported latest shared enums
- added conversion types ULCB and ULBE from main branch
- fixed conversion desc and text capitalizations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).