### PR TITLE
17045 Fix back button on Breadcrumb shared component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.0.15",
+  "version": "5.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.0.15",
+      "version": "5.0.16",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.0.15",
+  "version": "5.0.16",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -360,10 +360,6 @@ export default class App extends Mixins(
 }
 
 .namerequest-sbc-breadcrumb {
-  .container {
-    max-width: 1360px; // should match auth-web, etc
-  }
-
   .v-btn {
     width: 28px;
     height: 28px !important;

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,6 +46,7 @@
 
       <!-- Breadcrumb -->
       <Breadcrumb
+        class="namerequest-sbc-breadcrumb"
         :breadcrumbs="breadcrumbs"
       />
 
@@ -355,6 +356,18 @@ export default class App extends Mixins(
     font-weight: normal !important;
     letter-spacing: normal !important;
     font-size: .875rem !important;
+  }
+}
+
+.namerequest-sbc-breadcrumb {
+  .container {
+    max-width: 1360px; // should match auth-web, etc
+  }
+
+  .v-btn {
+    width: 28px;
+    height: 28px !important;
+    background-color: white !important;
   }
 }
 

--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -19,16 +19,6 @@
   padding-right: 0 !important;
 }
 
-#breadcrumb > .container {
-  max-width: 1360px; // should match auth-web, etc
-}
-
-#breadcrumb-back-btn {
-  width: 28px;
-  height: 28px !important;
-  background-color: white !important;
-}
-
 @media only screen and (max-width: 925px) {
   html, body {
     max-width: 100%;

--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -19,6 +19,10 @@
   padding-right: 0 !important;
 }
 
+.container {
+  max-width: 1360px; // should match auth-web, etc
+}
+
 @media only screen and (max-width: 925px) {
   html, body {
     max-width: 100%;


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17045

*Notes:*
The override causing the visual bug for the breadcrumb component comes from [overrides.scss](https://github.com/bcgov/namerequest/blob/feature-way-of-navigating/src/assets/styles/overrides.scss#L101), which overrides the `height` and `background-colour` of `v-btn`s. I am hesitant to remove the `!important` directives here since it is a global override and I am not sure what downstream effects that could have. Rather, I am moving the quick fix I had implemented for this bug in #618 (ticket [16633](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/gh/bcgov/entity/16633)) to a more appropriate spot. Also, instead of targeting it using the sbc component id, I am using a custom class on the component to prevent any issues if the sbc id changes.

*Description of changes:*
- Move the custom breadcrumb button stylings into App.vue


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
