### PR TITLE
16918 Set business lookup visible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.0.13",
+  "version": "5.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.0.13",
+      "version": "5.0.14",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.0.13",
+  "version": "5.0.14",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -184,16 +184,6 @@
         <template>
           <!-- Search for business identifier or name if NR request action is one of [CHG, AML, CNV, REH] -->
           <BusinessLookup v-if="isBusinessLookup" />
-
-          <template v-if="businessIdentifier">
-            <dl>
-              <dt class="font-weight-bold mr-2">Business Name:</dt>
-              <dd>{{businessName}}</dd>
-
-              <dt class="font-weight-bold mr-2">Incorporation Number:</dt>
-              <dd>{{businessIdentifier}}</dd>
-            </dl>
-          </template>
         </template>
       </v-col>
     </v-row>

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -379,8 +379,6 @@ export default class Search extends Mixins(CommonMixin) {
     NrRequestActionCodes.CONVERSION
   ]
   activeActionGroup = NaN
-  businessName = ''
-  businessIdentifier = ''
 
   private mounted () {
     this.$nextTick(() => {

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -182,10 +182,8 @@
     <v-row no-gutters>
       <v-col cols="12">
         <template>
-          <!-- Search for business identifier or name -->
-          <BusinessLookup
-            @business="businessName = $event.name; businessIdentifier = $event.identifier"
-          />
+          <!-- Search for business identifier or name if NR request action is one of [CHG, AML, CNV, REH] -->
+          <BusinessLookup v-if="isBusinessLookup" />
 
           <template v-if="businessIdentifier">
             <dl>
@@ -552,6 +550,16 @@ export default class Search extends Mixins(CommonMixin) {
 
   get entityTextFromValue (): string {
     return this.getEntityTextFromValue || 'specified business type'
+  }
+
+  get isBusinessLookup () {
+    // show BusinessLookup when NR request actions are following these
+    return [
+      NrRequestActionCodes.AMALGAMATE,
+      NrRequestActionCodes.CHANGE_NAME,
+      NrRequestActionCodes.CONVERSION,
+      NrRequestActionCodes.RESTORE
+    ].includes(this.getRequestActionCd)
   }
 
   async handleSubmit (doNameCheck = true) {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16918

*Description of changes:*

Show BusinessLookup for the CHG, AML, CNV, and REH name requests only. That way it won't show for the other flows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
