### PR TITLE
17322-alter logic to show numbered options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.0.17",
+  "version": "5.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.0.17",
+      "version": "5.0.18",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.0.17",
+  "version": "5.0.18",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -349,6 +349,7 @@ export default class Search extends Mixins(CommonMixin) {
   @Getter getLocationText!: string
   @Getter getRequestActionCd!: NrRequestActionCodes
   @Getter isMobile!: boolean
+  @Getter isBcCcCrUl!: boolean
 
   // Global actions
   @Action setConversionType!: ActionBindingIF
@@ -554,10 +555,7 @@ export default class Search extends Mixins(CommonMixin) {
   }
 
   get showCompanyRadioBtn (): boolean {
-    if (this.getEntityTypeCd === EntityType.CP) {
-      this.selectedCompanyType = CompanyType.NAMED_COMPANY
-    }
-    return this.getEntityTypeCd !== EntityType.CP
+    return this.isBcCcCrUl
   }
 
   get jurisdictionOptions () {

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -1188,3 +1188,13 @@ export const getIncorporateNowErrorStatus = (state: StateIF): boolean => {
 export const getBusinessLookup = (state: StateIF): BusinessLookupResultIF => {
   return state.stateModel.newRequestModel.businessLookup
 }
+
+/** Check if BC company, CCC, Corporation or ULC  */
+export const isBcCcCrUl = (state: StateIF): boolean => {
+  return (
+    getEntityTypeCd(state) === EntityType.BC ||
+    getEntityTypeCd(state) === EntityType.CC ||
+    getEntityTypeCd(state) === EntityType.CR ||
+    getEntityTypeCd(state) === EntityType.UL
+  )
+}


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17322

*Description of changes:*

Alter logic to INCLUDE the 4 entity types (BC company, CCC, Corporation or ULC) to show Numbered option.

Below are some screenshots as examples. Here is the temporary URL to check other: https://namerequest-dev--pr-646-9rfvoqsw.web.app/

Limited Company (same for CCC, ULC):

![image](https://github.com/bcgov/namerequest/assets/116035339/0fd6d826-d653-4d49-ab6c-aee00ac31112)

BEN:

![image](https://github.com/bcgov/namerequest/assets/116035339/f57efb89-9ae4-4d6f-bff6-b7c6c525d45d)

SP:

![image](https://github.com/bcgov/namerequest/assets/116035339/f1a57b41-d258-4ee7-b3a2-933c6236f0bb)

DBA:

![image](https://github.com/bcgov/namerequest/assets/116035339/f55bc6a6-41cd-47c4-aa41-a244821e75e6)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
