### PR TITLE
14789 Removed corp num from last page + cleaned up misc actions/getters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.0.31",
+  "version": "5.0.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.0.31",
+      "version": "5.0.32",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.0.31",
+  "version": "5.0.32",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/applicant-info-3.vue
+++ b/src/components/common/applicant-info-3.vue
@@ -160,32 +160,6 @@
       <v-row class="mt-0">
         <v-col cols="12" md="2" lg="2" />
 
-        <!--CORP NUMBER-->
-        <v-col cols="12" md="5" lg="5" v-if="getShowCorpNum === CorpNumRequests.COLIN">
-          <v-tooltip top
-            content-class="top-tooltip"
-            transition="fade-transition"
-            :disabled="isMobile"
-          >
-            <template v-slot:activator="{ on }">
-              <div v-on="on">
-                <v-text-field :messages="messages['corpNum']"
-                              :rules="corpNumRules"
-                              :error-messages="corpNumError"
-                              @focus="corpNumError = ''"
-                              :loading="loading"
-                              filled
-                              :label="corpNumFieldLabel"
-                              v-model="corpNum">
-                </v-text-field>
-              </div>
-            </template>
-            <span>
-              Enter the BC incorporation number of your business.
-            </span>
-          </v-tooltip>
-        </v-col>
-
         <!--TRADEMARK-->
         <v-col cols="12" md="5" lg="5">
           <v-tooltip top
@@ -258,7 +232,7 @@ import ApplicantInfoNav from '@/components/common/applicant-info-nav.vue'
 import { FolioNumberInput } from '@bcrs-shared-components/folio-number-input'
 import { ApplicantI } from '@/interfaces'
 import { ActionBindingIF } from '@/interfaces/store-interfaces'
-import { CorpNumRequests, NrRequestActionCodes, NrState } from '@/enums'
+import { NrState } from '@/enums'
 import { GetFeatureFlag } from '@/plugins'
 
 @Component({
@@ -268,45 +242,31 @@ import { GetFeatureFlag } from '@/plugins'
 })
 export default class ApplicantInfo3 extends Vue {
   // Global getters
-  @Getter getCorpNum!: string
   @Getter getApplicant!: ApplicantI
-  @Getter getPriorityRequest!: boolean
   @Getter getEditMode!: boolean
+  @Getter getFolioNumber!: string
   @Getter getNrData!: any
   @Getter getNrState!: string
-  @Getter getRequestActionCd!: NrRequestActionCodes
+  @Getter getPriorityRequest!: boolean
   @Getter getShowPriorityRequest!: boolean
-  @Getter getShowCorpNum!: string
-  @Getter getFolioNumber!: string
   @Getter isRoleStaff!: boolean
   @Getter isMobile!: boolean
 
   // Global actions
   @Action setApplicantDetails!: ActionBindingIF
-  @Action setCorpNum!: ActionBindingIF
+  @Action setFolioNumber!: ActionBindingIF
+  @Action setHotjarUserId!: ActionBindingIF
   @Action setIsLoadingSubmission!: ActionBindingIF
   @Action setNRData!: ActionBindingIF
   @Action setPriorityRequest!: ActionBindingIF
-  @Action fetchCorpNum!: ActionBindingIF
   @Action submit!: ActionBindingIF
-  @Action setFolioNumber!: ActionBindingIF
-  @Action setHotjarUserId!: ActionBindingIF
 
-  // Enum declaration
-  readonly CorpNumRequests = CorpNumRequests
-
-  corpNumError = ''
-  corpNumFieldLabel = 'Incorporation or Registration Number'
   additionalInfoRules = [
     v => (!v || v.length <= 120) || 'Cannot exceed 120 characters'
   ]
   businessNatureRules = [
     v => !!v || 'Required field',
     v => (!v || v.length <= 1000) || 'Cannot exceed 1000 characters'
-  ]
-  corpNumRules = [
-    v => !!v || 'Required field',
-    v => (!v || v.length > 3) || 'Must be at least 4 characters'
   ]
   emailRules = [
     (v: string) => !!v || 'Required field',
@@ -338,16 +298,6 @@ export default class ApplicantInfo3 extends Vue {
     return !!GetFeatureFlag('enable-priority-checkbox')
   }
 
-  mounted () {
-    // Apply optional corpNum validations for Amalgamations as they are NOT a required field but require COLIN lookup.
-    if (this.getRequestActionCd === NrRequestActionCodes.AMALGAMATE) {
-      this.corpNumFieldLabel += ' (Optional)'
-      this.corpNumRules = [
-        v => (!v || v.length > 3) || 'Must be at least 4 characters'
-      ]
-    }
-  }
-
   @Watch('xproJurisdiction')
   async hanldeJurisdiction (newVal, oldVal) {
     if (newVal !== oldVal) {
@@ -358,13 +308,6 @@ export default class ApplicantInfo3 extends Vue {
 
   get applicant () {
     return this.getApplicant
-  }
-
-  get corpNum () {
-    return this.getCorpNum
-  }
-  set corpNum (num) {
-    this.setCorpNum(num)
   }
 
   get priorityRequest (): boolean {
@@ -382,23 +325,6 @@ export default class ApplicantInfo3 extends Vue {
     return (this.getNrData || {}).xproJurisdiction
   }
 
-  async validateCorpNum (num): Promise<boolean> {
-    if (!num || num.length < 4) {
-      return false
-    }
-    this.loading = true
-    try {
-      await this.fetchCorpNum(num)
-      this.corpNumError = ''
-      this.loading = false
-      return true
-    } catch (error) {
-      this.corpNumError = 'Error validating number. Please try again.'
-      this.loading = false
-      return false
-    }
-  }
-
   updateApplicant (key, value) {
     this.setApplicantDetails({ key, value })
   }
@@ -411,10 +337,8 @@ export default class ApplicantInfo3 extends Vue {
     this.error = error
   }
 
-  validate () {
-    if (this.$refs.step3 as any) {
-      (this.$refs.step3 as any).validate()
-    }
+  validate (): boolean {
+    return (this.$refs.step3 && (this.$refs.step3 as any).validate())
   }
 
   @Watch('isValid')
@@ -443,15 +367,7 @@ export default class ApplicantInfo3 extends Vue {
     }
     this.setIsLoadingSubmission(true)
     this.validate()
-    // validate corp num in COLIN
-    if (this.getShowCorpNum === CorpNumRequests.COLIN) {
-      this.$root.$emit('showSpinner', true)
-      await this.validateCorpNum(this.getCorpNum)
-      this.$root.$emit('showSpinner', false)
-    }
-    if (this.isValid && !this.corpNumError) {
-      await this.submit(null)
-    }
+    if (this.isValid) await this.submit(null)
     // hang on to the loading state for a bit
     // to prevent users clicking button again while next component displays
     setTimeout(() => this.setIsLoadingSubmission(false), 1000)

--- a/src/components/new-request/business-fetch.vue
+++ b/src/components/new-request/business-fetch.vue
@@ -27,7 +27,7 @@
 import Vue from 'vue'
 import { Component, Emit } from 'vue-property-decorator'
 import { Action } from 'vuex-class'
-import { BusinessFetchIF } from '@/interfaces'
+import { BusinessSearchIF } from '@/interfaces'
 
 enum States {
   INITIAL = 'initial',
@@ -44,7 +44,7 @@ export default class BusinessFetch extends Vue {
   readonly States = States
 
   // Store action
-  @Action fetchCorpNum!: (corpNum: string) => Promise<BusinessFetchIF>
+  @Action searchBusiness!: (corpNum: string) => Promise<BusinessSearchIF>
 
   /** V-model for search field. */
   searchField = ''
@@ -73,9 +73,9 @@ export default class BusinessFetch extends Vue {
     this.state = States.INITIAL
   }
 
-  /** Searches for business and emits business fetch object. Called by various events. */
+  /** Searches for business and emits business search object. Called by various events. */
   @Emit('business')
-  async search (): Promise<BusinessFetchIF> {
+  async search (): Promise<BusinessSearchIF> {
     // safety check
     if (this.state !== States.INITIAL) return
 
@@ -85,7 +85,7 @@ export default class BusinessFetch extends Vue {
 
     // perform search
     this.state = States.SEARCHING
-    const result = await this.fetchCorpNum(this.searchField).catch(e => null)
+    const result = await this.searchBusiness(this.searchField).catch(e => null)
 
     // return result
     if (result) {

--- a/src/components/new-request/business-lookup.vue
+++ b/src/components/new-request/business-lookup.vue
@@ -48,7 +48,7 @@
 import Vue from 'vue'
 import { Component, Emit, Watch } from 'vue-property-decorator'
 import { debounce } from 'lodash'
-import { BusinessFetchIF, BusinessLookupResultIF } from '@/interfaces'
+import { BusinessLookupResultIF, BusinessSearchIF } from '@/interfaces'
 import BusinessLookupServices from '@/services/business-lookup-services'
 import { EntityType } from '@/enums'
 
@@ -99,9 +99,9 @@ export default class BusinessLookup extends Vue {
     }
   }, 600)
 
-  /** When an item has been selected, emits event with business fetch object. */
+  /** When an item has been selected, emits business search object. */
   @Emit('business')
-  onItemSelected (input: BusinessLookupResultIF): BusinessFetchIF {
+  onItemSelected (input: BusinessLookupResultIF): BusinessSearchIF {
     // safety check
     if (input) {
       // change to summary state

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -283,7 +283,7 @@ import BusinessLookup from '@/components/new-request/business-lookup.vue'
 import BusinessFetch from '@/components/new-request/business-fetch.vue'
 
 // Interfaces / Enums / List Data
-import { BusinessFetchIF, ConversionTypesI, EntityI, FormType, RequestActionsI } from '@/interfaces'
+import { BusinessSearchIF, ConversionTypesI, EntityI, FormType, RequestActionsI } from '@/interfaces'
 import { ActionBindingIF } from '@/interfaces/store-interfaces'
 import { AccountType, CompanyType, EntityType, Location, NrRequestActionCodes, NrRequestTypeCodes } from '@/enums'
 import { CommonMixin, NrAffiliationMixin } from '@/mixins'
@@ -334,7 +334,7 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin) {
   @Getter isInternational!: boolean
   @Getter isMobile!: boolean
   @Getter isMrasJurisdiction!: boolean
-  @Getter isNumberedRequestType!: boolean
+  @Getter isNumberedEntityType!: boolean
   @Getter isRestoration!: boolean
 
   // Store actions
@@ -364,7 +364,7 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin) {
   readonly EntityType = EntityType
   activeActionGroup = NaN
   showRequestActionTooltip = false
-  business = null as BusinessFetchIF
+  business = null as BusinessSearchIF
 
   private mounted () {
     this.$nextTick(() => {
@@ -430,7 +430,7 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin) {
   get companyRadioBtnApplicable (): boolean {
     const isSociety = (this.isSocietyEnabled() && this.getEntityTypeCd === EntityType.SO)
     // check if numbered is not allowed or society NR name is required
-    if (!this.isNumberedRequestType || isSociety) {
+    if (!this.isNumberedEntityType || isSociety) {
       this.selectedCompanyType = CompanyType.NAMED_COMPANY
       return false
     }
@@ -562,7 +562,7 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin) {
   }
 
   /** Event handled for business lookup/fetch. */
-  onBusiness (business: BusinessFetchIF): void {
+  onBusiness (business: BusinessSearchIF): void {
     this.business = business
     this.entity_type_cd = this.business?.legalType || null
     this.setCorpNum(business?.identifier || null)

--- a/src/enums/corp-num-requests.ts
+++ b/src/enums/corp-num-requests.ts
@@ -1,5 +1,0 @@
-/** Enum for Corp Num Requests. */
-export enum CorpNumRequests {
-  COLIN = 'colin',
-  MRAS = 'mras'
-}

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -1,7 +1,6 @@
 export * from './account-type'
 export * from './advanced-search-tabs'
 export * from './company-type'
-export * from './corp-num-requests'
 export * from './entity-type'
 export * from './furnished'
 export * from './jurisdictions'

--- a/src/interfaces/business.ts
+++ b/src/interfaces/business.ts
@@ -33,7 +33,8 @@ export interface CreateNRAffiliationRequestBody {
   email?: string
 }
 
-export interface BusinessFetchIF {
+/** Result object from business fetch/lookup. */
+export interface BusinessSearchIF {
   identifier: string
   legalName: string
   legalType: EntityType

--- a/src/list-data/request-action-mapping.ts
+++ b/src/list-data/request-action-mapping.ts
@@ -75,36 +75,27 @@ export const XproMapping: MappingI = {
   ]
 }
 
-// *** FUTURE: get rid of these when we remove getShowCorpNum()
-export const ColinRequestActions = [
-  NrRequestActionCodes.AMALGAMATE,
+/** Request actions that require business lookup. */
+export const BusinessLookupRequestActions = [
   NrRequestActionCodes.CHANGE_NAME,
   NrRequestActionCodes.CONVERSION,
   NrRequestActionCodes.RESTORE
 ]
 
-// list of entity types for which we show the corp num input
-// and allow the numbered company option
-export const NumberedRequestTypes = [
+/** Entity types that require business lookup. */
+export const BusinessLookupEntityTypes = [
   EntityType.BC,
   EntityType.CC,
   EntityType.CR,
-  EntityType.UL
-]
-
-// list of entity types for which we show the corp num input
-export const XproRequestTypes = [
+  EntityType.UL,
   EntityType.XCR,
   EntityType.XUL
 ]
 
-// MAY BE OBSOLETE
-export const MrasEntities = [
+/** Entity types that support the numbered company option. */
+export const NumberedEntityTypes = [
   EntityType.BC,
   EntityType.CC,
-  EntityType.CP,
   EntityType.CR,
-  EntityType.UL,
-  EntityType.XCR,
-  EntityType.XLP
+  EntityType.UL
 ]

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,7 +1,6 @@
 import querystring from 'qs'
 import axios from 'axios'
 import {
-  CorpNumRequests,
   EntityStates,
   EntityType,
   Location,
@@ -26,7 +25,7 @@ import { CanJurisdictions, Designations, IntlJurisdictions, RequestActions } fro
 
 // Interfaces
 import {
-  BusinessFetchIF,
+  BusinessSearchIF,
   CleanedNameIF,
   ConflictListItemI,
   ConversionTypesI,
@@ -295,24 +294,12 @@ export const setAddressSuggestions = ({ commit }, addressSuggestions: any[]): vo
 }
 
 /**
- * Makes API calls to verify that the Corp Num is valid.
+ * Searches Entities or COLIN to fetch a business' info.
+ * @param corpNum the business identifier to search for
  * @returns a resolved promise on success or a rejected promise on failure
  */
 // FUTURE: not an action - move it to another module?
-export const fetchCorpNum = async ({ getters }, corpNum: string): Promise<BusinessFetchIF> => {
-  // NB: MRAS search was done on first page
-  // if (getters.getShowCorpNum === CorpNumRequests.MRAS) {
-  //   return checkMRAS({ getters }, corpNum)
-  // }
-
-  // *** FUTURE: COLIN search (business lookup) should have been done on first page
-  if (getters.getShowCorpNum === CorpNumRequests.COLIN) {
-    return checkCOLIN({ getters }, corpNum)
-  }
-}
-
-// FUTURE: not an action - move it to another module?
-async function checkCOLIN ({ getters }, corpNum: string): Promise<BusinessFetchIF> {
+export async function searchBusiness ({ getters }, corpNum: string): Promise<BusinessSearchIF> {
   try {
     // first try to find business in Entities (Legal API)
     const data = await NamexServices.searchEntities(corpNum)
@@ -345,14 +332,6 @@ async function checkCOLIN ({ getters }, corpNum: string): Promise<BusinessFetchI
     return Promise.reject(error) // network error
   }
 }
-
-// FUTURE: not an action - move it to another module?
-// async function checkMRAS ({ getters }, corpNum: string): Promise<any> {
-//   let { xproJurisdiction } = getters.getNrData
-//   let { SHORT_DESC } = CanJurisdictions.find(jur => jur.text === xproJurisdiction)
-//   let url = `mras-profile/${SHORT_DESC}/${corpNum}`
-//   return axios.get(url)
-// }
 
 export const fetchMRASProfile = async ({ commit, getters }): Promise<any> => {
   if (getters.getCorpSearch) {
@@ -432,7 +411,7 @@ export const getNrTypeData = ({ getters }, type: NrType): any => {
 /** Submits an edited NR or a new name submission. */
 export const submit = async ({ commit, getters, dispatch }): Promise<any> => {
   if (getters.getEditMode) {
-    // TODO-CAM: Refactor the way these async requests are used to provide conditional booleans
+    // FUTURE: Refactor the way these async requests are used to provide conditional booleans
     const data = await NamexServices.patchNameRequests(getters.getNrId, getters.getRequestActionCd,
       getters.getEditNameReservation)
     if (data) {


### PR DESCRIPTION
*Issue #:* bcgov/entity#14789

*Description of changes:*
- app version = 5.0.32
- removed corp number input from Applicant Info 2 page + related getters, actions, etc
- removed corp number input from Applicant Info 3 page + related getters, actions, etc
- renamed BusinessFetchIF -> BusinessSearchIF
- renamed fetchCorpNum -> searchBusiness
- renamed misc getters
- deleted obsolete CorpNumRequests enum
- renamed ColinRequestActions -> BusinessLookupRequestActions
- renamed NumberedRequestTypes -> NumberedEntityTypes
- renamed XproRequestTypes -> BusinessLookupEntityTypes
- refactored getShowCorpNum
- refactored misc getters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).