### PR TITLE
Updated Restoration/Reinstatement Flow in response to Yui's comment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.0.37",
+  "version": "5.0.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.0.37",
+      "version": "5.0.38",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.0.37",
+  "version": "5.0.38",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16640

*Description of changes:*
- **Yui's comment**: When firm registration numbers are entered, the UI returns a result but the "This business cannot be restored" message does not appear until the field loses focus. The error message should appear right after the business name is retrieved.
- This PR also fixes this issue for alterations. It fixes the field focus and validation when we select a business that cannot be altered.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
