### PR TITLE
Fixed corp num not being populated in CHG, REH, and CNV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.0.40",
+  "version": "5.0.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.0.40",
+      "version": "5.0.41",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.0.40",
+  "version": "5.0.41",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -164,7 +164,6 @@ export const resetAnalyzeName = ({ commit, getters }): void => {
   if (!getters.getUserCancelledAnalysis) {
     commit('mutateAnalysisJSON', null)
   }
-  commit('mutateCorpNum', '')
   commit('mutateEditMode', false)
   commit('mutateSubmissionType', 'normal')
   commit('mutateShowActualInput', false)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17633

*Description of changes:*
- The `corpNum` field is now being populated with the business identifier after submitting a CHG, REH, or CNV
- An example after submitting a Restoration:
![corp num now works](https://github.com/bcgov/namerequest/assets/122301442/3c6d06e7-14fc-443e-b981-6ff3c089cf58)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
