### PR TITLE
Don't show any buttons when Federal Reinstatement is selected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.0.41",
+  "version": "5.0.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.0.41",
+      "version": "5.0.42",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.0.41",
+  "version": "5.0.42",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -622,6 +622,9 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin) {
   }
 
   get showActionButton (): boolean {
+    // Since Federal Reinstatement is a paper filing, we don't show any buttons.
+    // The same conditional is in showColinButton().
+    if (this.isFederal && this.isRestoration) return false
     if (this.isConversion && !this.isAlterOnline(this.getConversionType)) return false
     return true
   }
@@ -629,6 +632,7 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin) {
   /** Whether to show "Go to COLIN" button (otherwise will show `actionNowButtonText` button). */
   get showColinButton (): boolean {
     if (this.showContinueInButton) return true
+    if (this.isFederal && this.isRestoration) return false
     if (this.isFederal) return true
 
     // don't show COLIN button for supported alteration entities


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17685

*Description of changes:*
- See Janis' comment: https://github.com/bcgov/entity/issues/16640#issuecomment-1714414175
- No more showing button to go to Colin when a Federal Reinstatement is selected
![no more buttons in federal reinstatement](https://github.com/bcgov/namerequest/assets/122301442/078b7828-db81-4442-b8e6-487158082b56)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
