### PR TITLE
17630 Reset request action on start over

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.1.4",
+      "version": "5.1.5",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/search-components/request-action.vue
+++ b/src/components/new-request/search-components/request-action.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop, Vue } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Vue, Watch } from 'vue-property-decorator'
 import NestedSelect from '@/components/common/nested-select.vue'
 import { SearchMixin } from '@/mixins'
 import { RequestActionsI } from '@/interfaces'
@@ -80,6 +80,14 @@ export default class RequestAction extends Mixins(SearchMixin) {
     const offsetWidth = el?.offsetWidth as number
     const scrollWidth = el?.scrollWidth as number
     this.showRequestActionTooltip = (offsetWidth < scrollWidth)
+  }
+
+  /** Resets fields when returned to the Tabs component */
+  @Watch('getDisplayedComponent')
+  watchDisplayedComponent (displayedComponent: string) {
+    if (displayedComponent === 'Tabs') {
+      this.onRequestActionChange(null as RequestActionsI)
+    }
   }
 }
 </script>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17630

*Description of changes:*
- Small bug fix based on Yui's comment. Resets the request action component when the "Start Over" button is pressed.

Note: To test on this branch you must use one of the completely refactored flows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
