### PR TITLE
Flipped CR and BC to fix colin/incorporate button for limited/benefit companies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.1.12",
+  "version": "5.1.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.1.12",
+      "version": "5.1.13",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.1.12",
+  "version": "5.1.13",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/list-data/entity-type-data.ts
+++ b/src/list-data/entity-type-data.ts
@@ -31,7 +31,7 @@ export const EntityTypesBcData: EntityI[] = [
   },
   {
     text: 'Limited Company',
-    value: EntityTypes.CR,
+    value: EntityTypes.BC,
     cat: 'Corporations',
     blurbs: [
       `A company that may have one or more people who own shares with some personal responsibility for debt and
@@ -164,7 +164,7 @@ export const EntityTypesBcData: EntityI[] = [
   },
   {
     text: 'Benefit Company',
-    value: EntityTypes.BC,
+    value: EntityTypes.CR,
     cat: 'Corporations',
     blurbs: [
       `A type of corporation with special commitments to conduct business in a responsible and sustainable way.`,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17811

*Description of changes:*
- Fixed the go to Colin button and Incorporate now button between Limited and Benefit Companies
- `CR` is now `BC` while `BC` is now `CR`

**Note:** I'm still investigating what caused this issue in the first place.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
