### PR TITLE
17692 Add additional corp types to entity type mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.1.15",
+      "version": "5.1.16",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/search-components/business-lookup-fetch.vue
+++ b/src/components/new-request/search-components/business-lookup-fetch.vue
@@ -96,7 +96,7 @@ export default class BusinessLookupFetch extends Mixins(CommonMixin, SearchMixin
     this.setSearchBusiness(business)
     this.entity_type_cd = this.getSearchBusiness?.legalType || null
     this.setCorpNum(business?.identifier || null)
-    this.setEntityTypeCd(this.getSearchBusiness?.legalType)
+    this.setEntityTypeCd(this.entity_type_cd)
     this.setName('')
     this.setSearchCompanyType('')
 
@@ -127,11 +127,11 @@ export default class BusinessLookupFetch extends Mixins(CommonMixin, SearchMixin
       // Check if not XPRO and BC restorable
       if (!this.isSelectedXproAndRestorable && this.isBcRestorable) {
         this.setLocation(Location.BC)
-        const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd
+        const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd || null
         this.setEntityTypeCd(this.corpTypeToEntityType(corpType))
       } else if (this.isSelectedXproAndRestorable) { // Check if XPRO and restorable
         this.setLocation(Location.CA)
-        const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd
+        const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd || null
         this.setEntityTypeCd(this.corpTypeToEntityType(corpType) || this.getSearchBusiness?.legalType || null)
       } else {
         this.setEntityTypeCd(null)

--- a/src/components/new-request/search-components/business-lookup-fetch.vue
+++ b/src/components/new-request/search-components/business-lookup-fetch.vue
@@ -127,12 +127,12 @@ export default class BusinessLookupFetch extends Mixins(CommonMixin, SearchMixin
       // Check if not XPRO and BC restorable
       if (!this.isSelectedXproAndRestorable && this.isBcRestorable) {
         this.setLocation(Location.BC)
-        const corpType = this.getSearchBusiness.legalType as unknown as CorpTypeCd
+        const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd
         this.setEntityTypeCd(this.corpTypeToEntityType(corpType))
       } else if (this.isSelectedXproAndRestorable) { // Check if XPRO and restorable
         this.setLocation(Location.CA)
-        const corpType = this.getSearchBusiness.legalType as unknown as CorpTypeCd
-        this.setEntityTypeCd(this.corpTypeToEntityType(corpType) || this.getSearchBusiness.legalType)
+        const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd
+        this.setEntityTypeCd(this.corpTypeToEntityType(corpType) || this.getSearchBusiness?.legalType || null)
       } else {
         this.setEntityTypeCd(null)
       }
@@ -142,19 +142,19 @@ export default class BusinessLookupFetch extends Mixins(CommonMixin, SearchMixin
       if (this.getSearchBusiness) {
         if (this.isBcBenCccUlc) {
           this.setLocation(Location.BC)
-          const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd
+          const corpType = this.getSearchBusiness.legalType as unknown as CorpTypeCd
           this.setEntityTypeCd(this.corpTypeToEntityType(corpType))
         } else {
           this.setSearchCompanyType(CompanyTypes.NAMED_COMPANY)
           this.setLocation(Location.BC)
-          const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd
-          this.setEntityTypeCd(this.corpTypeToEntityType(corpType) || this.getSearchBusiness?.legalType || null)
+          const corpType = this.getSearchBusiness.legalType as unknown as CorpTypeCd
+          this.setEntityTypeCd(this.corpTypeToEntityType(corpType) || this.getSearchBusiness.legalType)
         }
 
         if (this.isChangeNameXpro) {
           this.setLocation(Location.CA)
-          const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd
-          this.setEntityTypeCd(this.corpTypeToEntityType(corpType) || this.getSearchBusiness?.legalType || null)
+          const corpType = this.getSearchBusiness.legalType as unknown as CorpTypeCd
+          this.setEntityTypeCd(this.corpTypeToEntityType(corpType) || this.getSearchBusiness.legalType)
         }
       }
     }

--- a/src/components/new-request/search-components/business-lookup-fetch.vue
+++ b/src/components/new-request/search-components/business-lookup-fetch.vue
@@ -147,12 +147,14 @@ export default class BusinessLookupFetch extends Mixins(CommonMixin, SearchMixin
         } else {
           this.setSearchCompanyType(CompanyTypes.NAMED_COMPANY)
           this.setLocation(Location.BC)
-          this.setEntityTypeCd(this.getSearchBusiness?.legalType || null)
+          const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd
+          this.setEntityTypeCd(this.corpTypeToEntityType(corpType) || this.getSearchBusiness?.legalType || null)
         }
 
         if (this.isChangeNameXpro) {
           this.setLocation(Location.CA)
-          this.setEntityTypeCd(this.getSearchBusiness?.legalType || null)
+          const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd
+          this.setEntityTypeCd(this.corpTypeToEntityType(corpType) || this.getSearchBusiness?.legalType || null)
         }
       }
     }

--- a/src/components/new-request/search-components/business-lookup-fetch.vue
+++ b/src/components/new-request/search-components/business-lookup-fetch.vue
@@ -127,13 +127,15 @@ export default class BusinessLookupFetch extends Mixins(CommonMixin, SearchMixin
       // Check if not XPRO and BC restorable
       if (!this.isSelectedXproAndRestorable && this.isBcRestorable) {
         this.setLocation(Location.BC)
+        const corpType = this.getSearchBusiness.legalType as unknown as CorpTypeCd
+        this.setEntityTypeCd(this.corpTypeToEntityType(corpType))
       } else if (this.isSelectedXproAndRestorable) { // Check if XPRO and restorable
         this.setLocation(Location.CA)
+        const corpType = this.getSearchBusiness.legalType as unknown as CorpTypeCd
+        this.setEntityTypeCd(this.corpTypeToEntityType(corpType) || this.getSearchBusiness.legalType)
       } else {
         this.setEntityTypeCd(null)
       }
-      const corpType = this.getSearchBusiness.legalType as unknown as CorpTypeCd
-      this.setEntityTypeCd(this.corpTypeToEntityType(corpType))
     }
 
     if (this.isChangeName) {

--- a/src/components/new-request/search-components/business-lookup-fetch.vue
+++ b/src/components/new-request/search-components/business-lookup-fetch.vue
@@ -127,14 +127,13 @@ export default class BusinessLookupFetch extends Mixins(CommonMixin, SearchMixin
       // Check if not XPRO and BC restorable
       if (!this.isSelectedXproAndRestorable && this.isBcRestorable) {
         this.setLocation(Location.BC)
-        const corpType = this.getSearchBusiness.legalType as unknown as CorpTypeCd
-        this.setEntityTypeCd(this.corpTypeToEntityType(corpType))
       } else if (this.isSelectedXproAndRestorable) { // Check if XPRO and restorable
         this.setLocation(Location.CA)
-        this.setEntityTypeCd(this.getSearchBusiness.legalType)
       } else {
         this.setEntityTypeCd(null)
       }
+      const corpType = this.getSearchBusiness.legalType as unknown as CorpTypeCd
+      this.setEntityTypeCd(this.corpTypeToEntityType(corpType))
     }
 
     if (this.isChangeName) {

--- a/src/components/new-request/search-components/jurisdiction.vue
+++ b/src/components/new-request/search-components/jurisdiction.vue
@@ -13,7 +13,7 @@
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import NestedSelect from '@/components/common/nested-select.vue'
-import { Location } from '@/enums'
+import { CorpTypeCd, Location } from '@/enums'
 import { SearchMixin } from '@/mixins'
 import { CanJurisdictions, IntlJurisdictions } from '@/list-data'
 
@@ -60,7 +60,8 @@ export default class Jurisdiction extends Mixins(SearchMixin) {
 
     // if a business was previously selected, reset the entity type
     if (this.getSearchBusiness) {
-      this.setEntityTypeCd(this.getSearchBusiness.legalType)
+      const corpType = this.getSearchBusiness.legalType as unknown as CorpTypeCd
+      this.setEntityTypeCd(this.corpTypeToEntityType(corpType) || this.getSearchBusiness.legalType)
     }
   }
 }

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -324,6 +324,7 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin, Sear
   }
 
   get showDesignation (): boolean {
+    if (this.isRestoration && this.isSelectedXproAndRestorable) return false
     return (Designations[this.getEntityTypeCd]?.end || false)
   }
 

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -325,6 +325,7 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin, Sear
 
   get showDesignation (): boolean {
     if (this.isRestoration && this.isSelectedXproAndRestorable) return false
+    if (this.isChangeName && this.isChangeNameXpro) return false
     return (Designations[this.getEntityTypeCd]?.end || false)
   }
 

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -63,7 +63,15 @@ export class CommonMixin extends Vue {
       case EntityTypes.CC: return CorpTypeCd.BC_CCC
       case EntityTypes.CR: return CorpTypeCd.BC_COMPANY
       case EntityTypes.UL: return CorpTypeCd.BC_ULC_COMPANY
+      // case '': return CorpTypeCd.CONTINUE_IN           // CorpTypeCd.CONTINUE_IN = 'C'
       case EntityTypes.CP: return CorpTypeCd.COOP
+      case EntityTypes.XCR: return CorpTypeCd.EXTRA_PRO_A // CorpTypeCd.EXTRA_PRO_A = 'A'
+      // case '': return CorpTypeCd.LIMITED_CO            // CorpTypeCd.LIMITED_CO = 'LLC'
+      case EntityTypes.SO: return CorpTypeCd.SOCIETY
+      case EntityTypes.FR: return CorpTypeCd.SOLE_PROP
+      case EntityTypes.XLP: return CorpTypeCd.XPRO_LIM_PARTNR
+      case EntityTypes.XLL: return CorpTypeCd.XPRO_LL_PARTNR
+      case EntityTypes.XSO: return CorpTypeCd.XPRO_SOCIETY
       default: return null
     }
   }
@@ -78,7 +86,15 @@ export class CommonMixin extends Vue {
       case CorpTypeCd.BC_CCC: return EntityTypes.CC
       case CorpTypeCd.BC_COMPANY: return EntityTypes.CR
       case CorpTypeCd.BC_ULC_COMPANY: return EntityTypes.UL
+      // case CorpTypeCd.CONTINUE_IN: return ''           // CorpTypeCd.CONTINUE_IN = 'C'
       case CorpTypeCd.COOP: return EntityTypes.CP
+      case CorpTypeCd.EXTRA_PRO_A: return EntityTypes.XCR // CorpTypeCd.EXTRA_PRO_A = 'A'
+      // case CorpTypeCd.LIMITED_CO: return ''            // CorpTypeCd.LIMITED_CO = 'LLC'
+      case CorpTypeCd.SOCIETY: return EntityTypes.SO
+      case CorpTypeCd.SOLE_PROP: return EntityTypes.FR
+      case CorpTypeCd.XPRO_LIM_PARTNR: return EntityTypes.XLP
+      case CorpTypeCd.XPRO_LL_PARTNR: return EntityTypes.XLL
+      case CorpTypeCd.XPRO_SOCIETY: return EntityTypes.XSO
       default: return null
     }
   }

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -63,10 +63,9 @@ export class CommonMixin extends Vue {
       case EntityTypes.CC: return CorpTypeCd.BC_CCC
       case EntityTypes.CR: return CorpTypeCd.BC_COMPANY
       case EntityTypes.UL: return CorpTypeCd.BC_ULC_COMPANY
-      // case '': return CorpTypeCd.CONTINUE_IN           // CorpTypeCd.CONTINUE_IN = 'C'
       case EntityTypes.CP: return CorpTypeCd.COOP
-      case EntityTypes.XCR: return CorpTypeCd.EXTRA_PRO_A // CorpTypeCd.EXTRA_PRO_A = 'A'
-      // case '': return CorpTypeCd.LIMITED_CO            // CorpTypeCd.LIMITED_CO = 'LLC'
+      case EntityTypes.XUL: return CorpTypeCd.EXTRA_PRO_A
+      case EntityTypes.RLC: return CorpTypeCd.LIMITED_CO
       case EntityTypes.SO: return CorpTypeCd.SOCIETY
       case EntityTypes.FR: return CorpTypeCd.SOLE_PROP
       case EntityTypes.XLP: return CorpTypeCd.XPRO_LIM_PARTNR
@@ -86,10 +85,9 @@ export class CommonMixin extends Vue {
       case CorpTypeCd.BC_CCC: return EntityTypes.CC
       case CorpTypeCd.BC_COMPANY: return EntityTypes.CR
       case CorpTypeCd.BC_ULC_COMPANY: return EntityTypes.UL
-      // case CorpTypeCd.CONTINUE_IN: return ''           // CorpTypeCd.CONTINUE_IN = 'C'
       case CorpTypeCd.COOP: return EntityTypes.CP
-      case CorpTypeCd.EXTRA_PRO_A: return EntityTypes.XCR // CorpTypeCd.EXTRA_PRO_A = 'A'
-      // case CorpTypeCd.LIMITED_CO: return ''            // CorpTypeCd.LIMITED_CO = 'LLC'
+      case CorpTypeCd.EXTRA_PRO_A: return EntityTypes.XUL
+      case CorpTypeCd.LIMITED_CO: return EntityTypes.RLC
       case CorpTypeCd.SOCIETY: return EntityTypes.SO
       case CorpTypeCd.SOLE_PROP: return EntityTypes.FR
       case CorpTypeCd.XPRO_LIM_PARTNR: return EntityTypes.XLP

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -61,16 +61,16 @@ export class CommonMixin extends Vue {
     switch (entityType) {
       case EntityTypes.BC: return CorpTypeCd.BENEFIT_COMPANY
       case EntityTypes.CC: return CorpTypeCd.BC_CCC
-      case EntityTypes.CR: return CorpTypeCd.BC_COMPANY
-      case EntityTypes.UL: return CorpTypeCd.BC_ULC_COMPANY
       case EntityTypes.CP: return CorpTypeCd.COOP
-      case EntityTypes.XUL: return CorpTypeCd.EXTRA_PRO_A
+      case EntityTypes.CR: return CorpTypeCd.BC_COMPANY
+      case EntityTypes.FR: return CorpTypeCd.SOLE_PROP
       case EntityTypes.RLC: return CorpTypeCd.LIMITED_CO
       case EntityTypes.SO: return CorpTypeCd.SOCIETY
-      case EntityTypes.FR: return CorpTypeCd.SOLE_PROP
-      case EntityTypes.XLP: return CorpTypeCd.XPRO_LIM_PARTNR
+      case EntityTypes.UL: return CorpTypeCd.BC_ULC_COMPANY
       case EntityTypes.XLL: return CorpTypeCd.XPRO_LL_PARTNR
+      case EntityTypes.XLP: return CorpTypeCd.XPRO_LIM_PARTNR
       case EntityTypes.XSO: return CorpTypeCd.XPRO_SOCIETY
+      case EntityTypes.XUL: return CorpTypeCd.EXTRA_PRO_A
       default: return null
     }
   }

--- a/src/services/business-lookup-services.ts
+++ b/src/services/business-lookup-services.ts
@@ -37,7 +37,7 @@ export default class BusinessLookupServices {
    * @returns a promise to return the search results
    */
   static async search (query: string, status = ''): Promise<BusinessLookupResultIF[]> {
-    const legalType = 'A,BC,BEN,C,CC,CP,CUL,FI,GP,LL,LLC,LP,PA,S,SP,ULC,XCP,XL,XP,XS'
+    const legalType = 'A,BC,BEN,CC,CP,CUL,FI,GP,LL,LLC,LP,PA,S,SP,ULC,XCP,XL,XP,XS'
 
     let url = this.registriesSearchApiUrl + 'businesses/search/facets?start=0&rows=20'
     url += `&categories=legalType:${legalType}${status ? '::status:' + status : ''}`

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -555,6 +555,7 @@ export const setCorpSearch = ({ commit }, corpSearch: string): void => {
 }
 
 export const setEntityTypeCd = ({ commit }, entityTypeCd: EntityTypes): void => {
+  console.log(entityTypeCd)
   commit('mutateEntityType', entityTypeCd)
 }
 

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -555,7 +555,6 @@ export const setCorpSearch = ({ commit }, corpSearch: string): void => {
 }
 
 export const setEntityTypeCd = ({ commit }, entityTypeCd: EntityTypes): void => {
-  console.log(entityTypeCd)
   commit('mutateEntityType', entityTypeCd)
 }
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17692

*Description of changes:*

- Add additional corp types to entity type mapping, and convert to entity type as needed.
- Basically, every `legalType` passed in the entities search query string in[ `business-lookup-services.ts`](https://github.com/bcgov/namerequest/blob/main/src/services/business-lookup-services.ts#L40) needs to be a [valid entity type in namex](https://github.com/bcgov/namex/blob/main/api/namex/constants/__init__.py#L81). When it is not, we need to convert the corp type to a valid entity type before posting it to namex. This should also fix bcgov/entity#17780 and bcgov/entity#17791.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
