### PR TITLE
17672 changed misleading error messages to include 'eligible'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.1.15",
+      "version": "5.1.16",
       "dependencies": {
         "@babel/compat-data": "^7.12.13",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/business-lookup.vue
+++ b/src/components/new-request/business-lookup.vue
@@ -98,10 +98,10 @@ export default class BusinessLookup extends Vue {
   onStatuschanged (): void {
     if (this.searchStatus === EntityStates.HISTORICAL) {
       this.lookupLabel = 'Find a historical business'
-      this.lookupNoActiveText = 'No historical business found'
+      this.lookupNoActiveText = 'No eligible historical business found'
     } else {
       this.lookupLabel = 'Find an existing business'
-      this.lookupNoActiveText = 'No active B.C. business found'
+      this.lookupNoActiveText = 'No eligible active B.C. business found'
     }
   }
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17672

*Description of changes:*

- changed the business lookup status error message in change business name and in reactivate business name to:
                      "**No eligible historical business found**" and "**No eligible active business found**" 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
