### PR TITLE
9392 capture edit-lock-error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/dialogs/error.vue
+++ b/src/components/dialogs/error.vue
@@ -5,15 +5,25 @@
         <div>Name Request encountered an error</div>
       </v-card-title>
 
-      <v-card-text class="copy-normal pt-8">
-        If you have paid for a new NR, please do not try submitting your payment again.
-      </v-card-text>
+      <div v-if="isEditLockError">
+        <v-card-text class="copy-normal pt-8">
+          The Name Request is presently undergoing examination or editing by another user
+          and cannot be modified or canceled at this time.
+          <br>
+          <br>
+          For assistance, please contact BC Registries staff:
+        </v-card-text>
+      </div>
+      <div v-else>
+        <v-card-text class="copy-normal pt-8">
+          If you have paid for a new NR, please do not try submitting your payment again.
+        </v-card-text>
 
-      <v-card-text class="copy-normal pt-6">
-        If your payment was successful, you should receive a receipt by email within 1 hour.
-        If you do not receive the email, please contact BC Registries staff:
-      </v-card-text>
-
+        <v-card-text class="copy-normal pt-6">
+          If your payment was successful, you should receive a receipt by email within 1 hour.
+          If you do not receive the email, please contact BC Registries staff:
+        </v-card-text>
+      </div>
       <v-card-text class="copy-normal pt-6">
         <ContactInfo direction="col" />
       </v-card-text>
@@ -47,6 +57,11 @@ export default class ErrorDialog extends Vue {
 
   async hideModal () {
     await ErrorModule.clearAppErrors()
+  }
+
+  get isEditLockError () {
+    const errors = ErrorModule[ErrorTypes.GET_ERRORS]
+    return errors[0] && errors[0].id === 'edit-lock-error'
   }
 }
 </script>

--- a/src/services/namex-services.ts
+++ b/src/services/namex-services.ts
@@ -210,6 +210,8 @@ export default class NamexServices {
 
       let error_id = 'checkout-name-requests-error'
       if (err instanceof AxiosError && err.response.status === 423) {
+        // Editing is not allowed when the request is being edited by another user 
+        // or is in a state other than 'DRAFT'
         error_id = 'edit-lock-error'
       }
       await errorModule.setAppError({ id: error_id, error: msg } as ErrorI)

--- a/src/services/namex-services.ts
+++ b/src/services/namex-services.ts
@@ -207,7 +207,12 @@ export default class NamexServices {
     } catch (err) {
       const msg = await this.handleApiError(err, 'Could not checkout name request')
       console.error('checkoutNameRequest() =', msg) // eslint-disable-line no-console
-      await errorModule.setAppError({ id: 'checkout-name-requests-error', error: msg } as ErrorI)
+
+      let error_id = 'checkout-name-requests-error'
+      if (err instanceof AxiosError && err.response.status === 423) {
+        error_id = 'edit-lock-error'
+      }
+      await errorModule.setAppError({ id: error_id, error: msg } as ErrorI)
       return false
     }
   }
@@ -466,7 +471,13 @@ export default class NamexServices {
     } catch (err) {
       const msg = await this.handleApiError(err, 'Could not patch name requests by action')
       console.error('patchNameRequestsByAction() =', msg) // eslint-disable-line no-console
-      await errorModule.setAppError({ id: 'patch-name-requests-by-action-error', error: msg } as ErrorI)
+
+      let error_id = 'patch-name-requests-by-action-error'
+      if (err instanceof AxiosError && err.response.status === 423) {
+        // cannot be cancelled if the NR is not DRAFT state
+        error_id = 'edit-lock-error'
+      }
+      await errorModule.setAppError({ id: error_id, error: msg } as ErrorI)
       return null
     }
   }

--- a/src/services/namex-services.ts
+++ b/src/services/namex-services.ts
@@ -210,7 +210,7 @@ export default class NamexServices {
 
       let error_id = 'checkout-name-requests-error'
       if (err instanceof AxiosError && err.response.status === 423) {
-        // Editing is not allowed when the request is being edited by another user 
+        // Editing is not allowed when the request is being edited by another user
         // or is in a state other than 'DRAFT'
         error_id = 'edit-lock-error'
       }


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/9392
*Description of changes:*
capture error when edit/refund an NR with state other than 'DRAFT'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
