### PR TITLE
18216 Updated default name length check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.2.11",
+  "version": "5.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.2.11",
+      "version": "5.2.12",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.2.11",
+  "version": "5.2.12",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/constants.ts
+++ b/src/components/new-request/constants.ts
@@ -1,2 +1,4 @@
+export const DFLT_MIN_LENGTH = 3
+export const DFLT_MAX_LENGTH = 150
 export const MRAS_MIN_LENGTH = 3
 export const MRAS_MAX_LENGTH = 40

--- a/src/components/new-request/name-input.vue
+++ b/src/components/new-request/name-input.vue
@@ -24,7 +24,8 @@ import { Component, Prop, Vue, Watch, Emit } from 'vue-property-decorator'
 import { Getter, Action } from 'vuex-class'
 import { ActionBindingIF } from '@/interfaces/store-interfaces'
 import { sanitizeName } from '@/plugins'
-import { MRAS_MAX_LENGTH } from '@/components/new-request/constants'
+import { DFLT_MIN_LENGTH, DFLT_MAX_LENGTH, MRAS_MIN_LENGTH, MRAS_MAX_LENGTH }
+  from '@/components/new-request/constants'
 
 @Component({})
 export default class NameInput extends Vue {
@@ -52,10 +53,9 @@ export default class NameInput extends Vue {
   @Action setMrasSearchInfoModalVisible!: ActionBindingIF
   @Action startAnalyzeName!: ActionBindingIF
 
-  readonly err_msg = 'Cannot exceed ' + MRAS_MAX_LENGTH + ' characters'
-
   readonly defaultRules = [
-    v => (!v || v.length <= MRAS_MAX_LENGTH) || this.err_msg
+    v => (!v || v.length >= DFLT_MIN_LENGTH) || `Must be at least ${DFLT_MIN_LENGTH} characters`,
+    v => (!v || v.length <= DFLT_MAX_LENGTH) || `Cannot exceed ${DFLT_MAX_LENGTH} characters`
   ]
 
   nameInputComponent = null
@@ -66,10 +66,11 @@ export default class NameInput extends Vue {
   }
 
   /** The array of validation rules for the MRAS corp num. */
-  get mrasRules (): Function[] {
+  get mrasRules (): any[] {
     return [
       v => (/^[0-9a-zA-Z-]+$/.test(v) || 'A corporate number is required'),
-      v => (!v || v.length <= 40) || 'Cannot exceed 40 characters' // maximum character count
+      v => (!v || v.length >= MRAS_MIN_LENGTH) || `Must be at least ${MRAS_MIN_LENGTH} characters`,
+      v => (!v || v.length <= MRAS_MAX_LENGTH) || `Cannot exceed ${MRAS_MAX_LENGTH} characters`
     ]
   }
 
@@ -107,12 +108,12 @@ export default class NameInput extends Vue {
       return ['Please enter a name for the business']
     }
 
-    if (this.getErrors.includes('length')) {
+    if (this.getErrors.includes('min_length')) {
       return ['Please enter a longer name']
     }
 
-    if (this.getErrors.includes('mras_length_exceeded')) {
-      return [this.err_msg]
+    if (this.getErrors.includes('max_length')) {
+      return ['Please enter a shorter name']
     }
 
     return null

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -19,7 +19,8 @@ import { BAD_REQUEST, NOT_FOUND, OK, SERVICE_UNAVAILABLE } from 'http-status-cod
 import removeAccents from 'remove-accents'
 import { GetFeatureFlag, Sleep, sanitizeName } from '@/plugins'
 import NamexServices from '@/services/namex-services'
-import { MRAS_MIN_LENGTH, MRAS_MAX_LENGTH } from '@/components/new-request/constants'
+import { DFLT_MIN_LENGTH, DFLT_MAX_LENGTH, MRAS_MIN_LENGTH, MRAS_MAX_LENGTH }
+  from '@/components/new-request/constants'
 
 // List Data
 import { CanJurisdictions, Designations, IntlJurisdictions, RequestActions } from '@/list-data'
@@ -1062,15 +1063,20 @@ export const startAnalyzeName = async ({ commit, getters }) => {
       commit('setErrors', 'name')
       return
     }
-    if (getters.getName.length < MRAS_MIN_LENGTH) {
-      commit('setErrors', 'length')
+
+    const min = getters.isXproFlow ? MRAS_MIN_LENGTH : DFLT_MIN_LENGTH
+    const max = getters.isXproFlow ? MRAS_MAX_LENGTH : DFLT_MAX_LENGTH
+
+    if (getters.getName.length < min) {
+      commit('setErrors', 'min_length')
       return
     }
-    if (getters.getName.length > MRAS_MAX_LENGTH) {
-      commit('setErrors', 'mras_length_exceeded')
+    if (getters.getName.length > max) {
+      commit('setErrors', 'max_length')
       return
     }
   }
+
   if (getters.getErrors.length > 0) {
     return
   }


### PR DESCRIPTION
*Issue #:* bcgov/entity#18216

*Description of changes:*
- app version = 5.2.12
- added constants for default name length
- used default constants for default rules (3 <= x <= 150)
- used MRAS constants for MRAS rules  (3 <= x <= 40)
- updated startAnalyzeName() to use either MRAS or default constants

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).