### PR TITLE
18235 fixed more entity type / corp type mappings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.2.13",
+  "version": "5.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.2.13",
+      "version": "5.2.14",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.2.13",
+  "version": "5.2.14",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/new-request/search-components/business-lookup-fetch.vue
+++ b/src/components/new-request/search-components/business-lookup-fetch.vue
@@ -62,7 +62,7 @@ export default class BusinessLookupFetch extends Mixins(CommonMixin, SearchMixin
         if (this.isConversion) {
           return this.isAlterable || 'This business cannot alter their business type'
         } else if (this.isRestoration) {
-          return this.isRestorable || 'This business cannot be restored'
+          return this.isRestorable || 'This business cannot be reactivated'
         } else if (this.isChangeName) {
           return this.isNameChangeable || 'This business cannot change their business name'
         }

--- a/src/mixins/search-mixin.ts
+++ b/src/mixins/search-mixin.ts
@@ -158,7 +158,8 @@ export class SearchMixin extends Mixins(CommonMixin) {
   }
 
   get isChangeNameXpro (): boolean {
-    return XproMapping.CHG.includes(this.getSearchBusiness?.legalType)
+    const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd
+    return XproMapping.CHG.includes(this.corpTypeToEntityType(corpType))
   }
 
   /** Whether company can change name. */
@@ -172,7 +173,8 @@ export class SearchMixin extends Mixins(CommonMixin) {
 
   /** Whether the selected XPRO is restorable. */
   get isSelectedXproAndRestorable (): boolean {
-    return XproMapping.REH.includes(this.getSearchBusiness?.legalType)
+    const corpType = this.getSearchBusiness?.legalType as unknown as CorpTypeCd
+    return XproMapping.REH.includes(this.corpTypeToEntityType(corpType))
   }
 
   /** Whether the selected business' legal type is BC and restorable. */


### PR DESCRIPTION
*Issue #:* bcgov/entity#18235

*Description of changes:*
- app version = 5.2.14
- updated "not restorable" error text (per Janis)
- added missing mapping to isChangeNameXpro()
- added missing mapping to isSelectedXproAndRestorable()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).