### PR TITLE
18299 fix xpro A -> XCR mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.2.14",
+  "version": "5.2.14a",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.2.14",
+      "version": "5.2.14a",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.2.14",
+  "version": "5.2.14a",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/list-data/request-action-mapping.ts
+++ b/src/list-data/request-action-mapping.ts
@@ -76,16 +76,16 @@ export const XproMapping: RequestActionMappingI = {
   REH: [
     EntityTypes.RLC, // maps to Corp Type "LLC"
     EntityTypes.XCP, // maps to Corp Type "XCP"
-    EntityTypes.XSO, // maps to Corp Type "XS"
-    EntityTypes.XUL // maps to Corp Type "A"
+    EntityTypes.XCR, // maps to Corp Type "EXTRA_PRO_A"
+    EntityTypes.XSO // maps to Corp Type "XS"
   ],
   CHG: [
     EntityTypes.RLC, // maps to Corp Type "LLC"
     EntityTypes.XCP, // maps to Corp Type "XCP"
+    EntityTypes.XCR, // maps to Corp Type "EXTRA_PRO_A"
     EntityTypes.XLL, // maps to Corp Type "XL"
     EntityTypes.XLP, // maps to Corp Type "XP"
-    EntityTypes.XSO, // maps to Corp Type "XS"
-    EntityTypes.XUL // maps to Corp Type "A"
+    EntityTypes.XSO // maps to Corp Type "XS"
   ]
 }
 

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -59,7 +59,6 @@ export class CommonMixin extends Vue {
    */
   entityTypeToCorpType (entityType: EntityTypes): CorpTypeCd {
     switch (entityType) {
-      case EntityTypes.A: return CorpTypeCd.EXTRA_PRO_A // same as XUL
       case EntityTypes.BC: return CorpTypeCd.BENEFIT_COMPANY
       case EntityTypes.CC: return CorpTypeCd.BC_CCC
       case EntityTypes.CP: return CorpTypeCd.COOP
@@ -77,13 +76,13 @@ export class CommonMixin extends Vue {
       case EntityTypes.SO: return CorpTypeCd.SOCIETY
       case EntityTypes.UL: return CorpTypeCd.BC_ULC_COMPANY
       case EntityTypes.XCP: return CorpTypeCd.XPRO_COOP
-      case EntityTypes.XCR: return CorpTypeCd.XPRO_CORPORATION
+      case EntityTypes.XCR: return CorpTypeCd.EXTRA_PRO_A
       case EntityTypes.XL: return CorpTypeCd.XPRO_LL_PARTNR // same as XLL
       case EntityTypes.XLL: return CorpTypeCd.XPRO_LL_PARTNR
       case EntityTypes.XLP: return CorpTypeCd.XPRO_LIM_PARTNR
       case EntityTypes.XP: return CorpTypeCd.XPRO_LIM_PARTNR // same as XLP
       case EntityTypes.XSO: return CorpTypeCd.XPRO_SOCIETY
-      case EntityTypes.XUL: return CorpTypeCd.EXTRA_PRO_A
+      case EntityTypes.XUL: return CorpTypeCd.XPRO_UNLIMITED_LIABILITY_COMPANY
       default: return null
     }
   }
@@ -99,7 +98,7 @@ export class CommonMixin extends Vue {
       case CorpTypeCd.BC_COMPANY: return EntityTypes.CR
       case CorpTypeCd.BC_ULC_COMPANY: return EntityTypes.UL
       case CorpTypeCd.COOP: return EntityTypes.CP
-      case CorpTypeCd.EXTRA_PRO_A: return EntityTypes.XUL
+      case CorpTypeCd.EXTRA_PRO_A: return EntityTypes.XCR
       case CorpTypeCd.FINANCIAL: return EntityTypes.FI
       case CorpTypeCd.PARTNERSHIP: return EntityTypes.GP
       case CorpTypeCd.LIMITED_CO: return EntityTypes.RLC
@@ -114,6 +113,7 @@ export class CommonMixin extends Vue {
       case CorpTypeCd.XPRO_LIM_PARTNR: return EntityTypes.XLP
       case CorpTypeCd.XPRO_LL_PARTNR: return EntityTypes.XLL
       case CorpTypeCd.XPRO_SOCIETY: return EntityTypes.XSO
+      case CorpTypeCd.XPRO_UNLIMITED_LIABILITY_COMPANY: return EntityTypes.XUL
       default: return null
     }
   }
@@ -212,13 +212,13 @@ export class CommonMixin extends Vue {
   /** Returns true if the specified entity type is for an Extraprovincial Company. */
   isXproEntityType (type: EntityTypes): boolean {
     return [
-      EntityTypes.XCR,
-      EntityTypes.XUL,
       EntityTypes.RLC,
-      EntityTypes.XLP,
-      EntityTypes.XLL,
       EntityTypes.XCP,
-      EntityTypes.XSO
+      EntityTypes.XCR,
+      EntityTypes.XLL,
+      EntityTypes.XLP,
+      EntityTypes.XSO,
+      EntityTypes.XUL
     ].includes(type)
   }
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#18299

**NOTE: this PR is being merged into release-5.2.14 branch so that I can deploy it to Test and Prod with no other commits in it since the last Prod version.**

*Description of changes:*
- app version = 5.2.14.a
- fixed Xpro REH and CHG mapping: XUL should be XCR
- fixed entity type to corp type mapping:
  - removed entity type A,
  - XCR should map to EXTRA_PRO_A and
  - XUL should map to XPRO_UNLIMITED_LIABILITY_COMPANY
- fixed corp type to entity type mapping:
  - EXTRA_PRO_A should map to XCR and
  - XPRO_UNLIMITED_LIABILITY_COMPANY should map to XUL

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).