### PR TITLE
18201 Fix error after pressing Incorporate now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.3.10",
+  "version": "5.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.3.9",
+      "version": "5.3.11",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.3.9",
+  "version": "5.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.3.9",
+  "version": "5.3.10",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.3.10",
+  "version": "5.3.11",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -267,7 +267,7 @@ export default class App extends Mixins(
 
     // if there is stored legal type for an IA then incorporate/register it now
     const legaltype = sessionStorage.getItem('LEGAL_TYPE')
-    if (legaltype) {
+    if (legaltype && this.isAuthenticated) {
       try {
         await this.incorporateNow(legaltype as CorpTypeCd)
         // clear the legal type data

--- a/src/mixins/nr-affiliation-mixin.ts
+++ b/src/mixins/nr-affiliation-mixin.ts
@@ -188,8 +188,13 @@ export class NrAffiliationMixin extends Mixins(CommonMixin) {
       // show spinner since this is a network call
       this.$root.$emit('showSpinner', true)
       const accountId = +JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id || 0
-      const businessId = await this.createBusinessIA(accountId, legalType)
-      this.goToEntityDashboard(businessId)
+      // incorp requires user login, ignore if user is not logged in and return to NR page
+      if (accountId === 0) {
+        this.$root.$emit('showSpinner', false)
+      } else {
+        const businessId = await this.createBusinessIA(accountId, legalType)
+        this.goToEntityDashboard(businessId)
+      }
       return
     } catch (error) {
       this.$root.$emit('showSpinner', false)

--- a/src/mixins/nr-affiliation-mixin.ts
+++ b/src/mixins/nr-affiliation-mixin.ts
@@ -188,13 +188,8 @@ export class NrAffiliationMixin extends Mixins(CommonMixin) {
       // show spinner since this is a network call
       this.$root.$emit('showSpinner', true)
       const accountId = +JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id || 0
-      // incorp requires user login, ignore if user is not logged in and return to NR page
-      if (accountId === 0) {
-        this.$root.$emit('showSpinner', false)
-      } else {
-        const businessId = await this.createBusinessIA(accountId, legalType)
-        this.goToEntityDashboard(businessId)
-      }
+      const businessId = await this.createBusinessIA(accountId, legalType)
+      this.goToEntityDashboard(businessId)
       return
     } catch (error) {
       this.$root.$emit('showSpinner', false)


### PR DESCRIPTION
*Issue #:* bcgov/entity#18201

*Description of changes:*
An account id is required to go further incorp. If user back to NR page without logged in, the error occurred since no account id retrieved. If account id === 0, just simply go back to NR with out error. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
