### PR TITLE
Added missing continuation in legal type for business lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "name-request",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "name-request",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/services/business-lookup-services.ts
+++ b/src/services/business-lookup-services.ts
@@ -37,7 +37,7 @@ export default class BusinessLookupServices {
    * @returns a promise to return the search results
    */
   static async search (query: string, status = ''): Promise<BusinessLookupResultIF[]> {
-    const legalType = 'A,BC,BEN,CC,CP,CUL,FI,GP,LL,LLC,LP,PA,S,SP,ULC,XCP,XL,XP,XS'
+    const legalType = 'A,BC,BEN,C,CC,CP,CUL,FI,GP,LL,LLC,LP,PA,S,SP,ULC,XCP,XL,XP,XS'
 
     let url = this.registriesSearchApiUrl + 'businesses/search/facets?start=0&rows=20'
     url += `&categories=legalType:${legalType}${status ? '::status:' + status : ''}`


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19694

*Description of changes:*
- The `C` legal type was missing from the business search query, added that

@ozamani9gh I made a scan, I think this was the only one missing. Please let me know if this is brought up again though.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
