### PR TITLE
21033 Use different entity types for continuation in NRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.4.8",
+  "version": "5.4.9",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",
@@ -11,7 +11,8 @@
     "test:unit": "vue-cli-service test:unit --testPathPattern --coverage",
     "lint": "vue-cli-service lint",
     "lint:nofix": "vue-cli-service lint --no-fix",
-    "build-check": "node --max_old_space_size=8000 node_modules/@vue/cli-service/bin/vue-cli-service.js build"},
+    "build-check": "node --max_old_space_size=8000 node_modules/@vue/cli-service/bin/vue-cli-service.js build"
+  },
   "dependencies": {
     "@babel/compat-data": "^7.21.5",
     "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^0.4.2
         version: 0.4.4
       sbc-common-components:
-        specifier: 3.0.8
-        version: 3.0.8
+        specifier: 3.0.12
+        version: 3.0.12
       style-loader:
         specifier: ^1.3.0
         version: 1.3.0(webpack@5.78.0)
@@ -5453,8 +5453,8 @@ packages:
     resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
     engines: {node: '>=10'}
 
-  sbc-common-components@3.0.8:
-    resolution: {integrity: sha512-TjZA8xRxtwrynI/EXLbGKr68+NFBlFPXDs1n7Uc+EaGD+zwmi8flSi6FEQNbrfb01YfVmlZ8GNghU7f1YP41rw==}
+  sbc-common-components@3.0.12:
+    resolution: {integrity: sha512-xi+zRXCyhnlKQgqbDoPd64Mrs/peB3+TwBv8H3VoEAVkVVr+z6mxfn+ej4WIlGv8KPQkL30LGBQRuZ0TG/JwxQ==}
 
   schema-utils@2.7.0:
     resolution: {integrity: sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==}
@@ -12915,7 +12915,7 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  sbc-common-components@3.0.8:
+  sbc-common-components@3.0.12:
     dependencies:
       '@mdi/font': 4.9.95
       axios: 0.21.4

--- a/src/components/dialogs/pick-entity-or-conversion.vue
+++ b/src/components/dialogs/pick-entity-or-conversion.vue
@@ -338,7 +338,14 @@ export default class PickEntityOrConversionDialog extends CommonMixin {
 
   chooseType (entity: SelectOptionsI) {
     // special case for Society: if FF is not enabled then show society info panel and don't set the type
-    if (!this.isSocietyEnabled() && (entity.value === EntityTypes.SO || entity.value === EntityTypes.XSO)) {
+    if (
+      !this.isSocietyEnabled() &&
+      (
+        entity.value === EntityTypes.SO ||
+        entity.value === EntityTypes.XSO ||
+        entity.value === EntityTypes.CS
+      )
+    ) {
       this.showSocietiesInfo = true
       return
     }

--- a/src/components/existing-request/nr-approved-gray-box.vue
+++ b/src/components/existing-request/nr-approved-gray-box.vue
@@ -270,8 +270,13 @@ export default class NrApprovedGrayBox extends Mixins(CommonMixin) {
 
   /** True if the Go To Societies Online button should be shown. */
   get showGoToSocietiesButton (): boolean {
+    const isSociety = (
+      this.getNr.entity_type_cd === EntityTypes.SO ||
+      this.getNr.entity_type_cd === EntityTypes.XSO ||
+      this.getNr.entity_type_cd === EntityTypes.CS
+    )
     return (
-      this.getNr.entity_type_cd === EntityTypes.SO &&
+      isSociety &&
       this.getNr.request_action_cd === NrRequestActionCodes.NEW_BUSINESS &&
       (NrState.APPROVED === this.getNr.state || this.isConsentUnRequired)
     )

--- a/src/components/new-request/search.vue
+++ b/src/components/new-request/search.vue
@@ -454,7 +454,10 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin, Sear
   get isSocietyDisabled (): boolean {
     return (
       !this.isSocietyEnabled() &&
-      (this.getEntityTypeCd === EntityTypes.SO || this.getEntityTypeCd === EntityTypes.XSO)
+      (
+        this.getEntityTypeCd === EntityTypes.SO ||
+        this.getEntityTypeCd === EntityTypes.XSO ||
+        this.getEntityTypeCd === EntityTypes.CS)
     )
   }
 

--- a/src/enums/entity-types.ts
+++ b/src/enums/entity-types.ts
@@ -11,6 +11,7 @@ export enum EntityTypes {
   CCC = CorpTypeCd.CCC_CONTINUE_IN,
   CP = CorpTypeCd.COOP,
   CR = CorpTypeCd.CORPORATION,
+  CS = CorpTypeCd.CONT_IN_SOCIETY,
   CUL = CorpTypeCd.ULC_CONTINUE_IN,
   DBA = CorpTypeCd.DOING_BUSINESS_AS,
   FI = CorpTypeCd.FINANCIAL,

--- a/src/list-data/entity-type-data.ts
+++ b/src/list-data/entity-type-data.ts
@@ -281,6 +281,177 @@ export const EntityTypesBcData: EntityI[] = [
   }
 ]
 
+/** List of entity types for Continuation In NRs. */
+export const EntityTypesContInData: EntityI[] = [
+  {
+    text: 'Limited Company',
+    value: EntityTypes.C,
+    cat: 'Corporations',
+    blurbs: [
+      `A company that may have one or more people who own shares with some personal responsibility for debt and
+        liabilities.`,
+      `Has many of the same rights of an individual`,
+      `Reported separately as Corporate tax`,
+      `Has name protection in BC`
+    ],
+    mveBlurbs: [
+      `A company that may have one or more people who own shares with some personal responsibility for
+        debts and liabilities.`,
+      'Has many of the same rights of an individual',
+      'Reported separately as Corporate tax',
+      'Has name protection in BC'
+    ],
+    rehBlurbs: [
+      'Restore a limited company that is no longer active with BC Registries.'
+    ],
+    amlBlurbs: [
+      'An amalgamation of two or more corporations to form a new limited company.'
+    ],
+    chgBlurbs: [
+      'Change/Correct the name of an existing limited company.'
+    ],
+    shortlist: true,
+    rank: 1
+  },
+  {
+    text: 'Unlimited Liability Company',
+    value: EntityTypes.CUL,
+    cat: 'Corporations',
+    blurbs: [
+      `A type of corporation that is often used by American corporations as a Canadian subsidiary or to hold Canadian
+         assets.`,
+      'Shareholders liable for debts and liabilities',
+      'Reported separately as Canadian Corporate tax',
+      'Has name protection in BC'
+    ],
+    mveBlurbs: [
+      `A type of corporation that is often used by American corporations as a Canadian subsidiary or
+        to hold Canadian assets.`,
+      'Shareholders liable for debts and liabilities',
+      'Reported separately as Canadian Corporate tax',
+      'Has name protection in BC'
+    ],
+    rehBlurbs: [
+      'Restore an unlimited liability company (ULC) that is no longer active with BC Registries.'
+    ],
+    amlBlurbs: [
+      'An amalgamation of two or more corporations to form a new unlimited liability company.'
+    ],
+    chgBlurbs: [
+      'Change/Correct the name of an existing unlimited liability company.'
+    ]
+  },
+  {
+    text: 'Cooperative Association',
+    value: EntityTypes.CP, // FUTURE: update this? see also request-action-mapping.ts
+    cat: 'Social Enterprises',
+    blurbs: [
+      'Membership-based organization, owned and operated by the people who use its services.',
+      'Has independent legal status separate from its members',
+      'Members take on shares and have limited liability',
+      'Reported as Corporate tax',
+      'Has name protection in BC'
+    ],
+    mveBlurbs: [
+      'Membership-based organization, owned and operated by the people who use its services.',
+      'Has independent legal status separate from its members',
+      'Members take on shares and have limited liability',
+      'Reported as Corporate tax',
+      'Has name protection in BC'
+    ],
+    rehBlurbs: [
+      'Restore a cooperative association that is no longer active with BC Registries.'
+    ],
+    amlBlurbs: [
+      `An amalgamation of two or more cooperative associations to form a new cooperative
+        association.`
+    ],
+    chgBlurbs: [
+      'Change/correct the name of an existing cooperative association.'
+    ]
+  },
+  {
+    text: 'Benefit Company',
+    value: EntityTypes.CBEN,
+    cat: 'Corporations',
+    blurbs: [
+      `A type of corporation with special commitments to conduct business in a responsible and sustainable way.`,
+      'Must publish and post an audited annual benefit report',
+      'Reported as Corporate tax',
+      'Has name protection in BC'
+    ],
+    mveBlurbs: [
+      'A type of corporation with special commitments to conduct business in a responsible and sustainable way.',
+      'Must publish and post an audited annual benefit report',
+      'Reported as Corporate tax',
+      'Has name protection in BC'
+    ],
+    rehBlurbs: [
+      'Restore a benefit company that is no longer active with BC Registries.'
+    ],
+    amlBlurbs: [
+      'An amalgamation of two or more corporations to form a new benefit company.'
+    ],
+    chgBlurbs: [
+      'Change/Correct the name of an existing benefit company.'
+    ]
+  },
+  {
+    text: 'Community Contribution Company',
+    value: EntityTypes.CCC,
+    cat: 'Social Enterprises',
+    blurbs: [
+      `A type of corporation that has a benefit to the community. It is intended to bridge the gap between
+        for-profit and non-profit companies.`,
+      'Reported as Corporate tax',
+      'Has name protection in BC'
+    ],
+    mveBlurbs: [
+      'A type of corporation that has a benefit to the community. It is intended to bridge the gap between ' +
+      'for-profit and non-profit companies.',
+      'Reported as Corporate tax',
+      'Has name protection in BC'
+    ],
+    rehBlurbs: [
+      'Restore a community contribution company (CCC) that is no longer active with BC Registries.'
+    ],
+    amlBlurbs: [
+      `An amalgamation of two or more corporations to form a new community contribution
+        company.`
+    ],
+    chgBlurbs: [
+      'Change/correct the name of an existing community contribution company.'
+    ]
+  },
+  {
+    text: 'Society',
+    value: EntityTypes.CS,
+    cat: 'Social Enterprises',
+    blurbs: [
+      `A non-profit organization that is also known as a non-share corporation.`,
+      'Any funds or profits must be used only for social or community benefit',
+      'When incorporated, has independent legal status separate from its members',
+      'Members, staff and directors protected from personal liability',
+      'Has name protection in BC',
+      'Must use Societies Online to register a name and incorporate'
+    ],
+    mveBlurbs: [
+      `A non-profit organization that is also known as a non-share corporation.`,
+      'Any funds or profits must be used only for social or community benefit',
+      'When incorporated, has independent legal status separate from its members',
+      'Members, staff and directors protected from personal liability',
+      'Has name protection in BC',
+      'Must use Societies Online to register a name and incorporate'
+    ],
+    amlBlurbs: [
+      'Society amalgamation'
+    ],
+    chgBlurbs: [
+      'Societies must use Societies Online to get their name.'
+    ]
+  }
+]
+
 export const EntityTypesXproData: EntityI[] = [
   {
     text: 'Extraprovincial Limited Company',

--- a/src/list-data/request-action-mapping.ts
+++ b/src/list-data/request-action-mapping.ts
@@ -2,25 +2,31 @@ import { EntityTypes, NrRequestActionCodes } from '@/enums'
 import { RequestActionMappingI } from '@/interfaces'
 
 const EntityTypesBC = [
-  EntityTypes.FR,
-  EntityTypes.DBA,
-  EntityTypes.CR,
-  EntityTypes.UL,
-  EntityTypes.GP,
-  EntityTypes.LP,
-  EntityTypes.LL,
-  EntityTypes.CP,
   EntityTypes.BC,
+  EntityTypes.C,
+  EntityTypes.CBEN,
   EntityTypes.CC,
-  EntityTypes.SO,
-  EntityTypes.PA,
+  EntityTypes.CCC,
+  EntityTypes.CP,
+  EntityTypes.CR,
+  EntityTypes.CS,
+  EntityTypes.CUL,
+  EntityTypes.DBA,
   EntityTypes.FI,
-  EntityTypes.PAR
+  EntityTypes.FR,
+  EntityTypes.GP,
+  EntityTypes.LL,
+  EntityTypes.LP,
+  EntityTypes.PA,
+  EntityTypes.PAR,
+  EntityTypes.SO,
+  EntityTypes.UL
 ]
 
 // maps request_action_cd (key) to array of allowable entities (value)
 // { [request_action_cd]: entity_type_cd[] }
 export const BcMapping: RequestActionMappingI = {
+  // Amalgamate
   AML: [
     EntityTypes.CR,
     EntityTypes.UL,
@@ -29,6 +35,7 @@ export const BcMapping: RequestActionMappingI = {
     EntityTypes.BC,
     EntityTypes.SO
   ],
+  // Renew
   REN: [
     EntityTypes.CR,
     EntityTypes.CP,
@@ -38,6 +45,7 @@ export const BcMapping: RequestActionMappingI = {
     EntityTypes.BC,
     EntityTypes.SO
   ],
+  // Restore
   REH: [
     EntityTypes.CR,
     EntityTypes.CP,
@@ -47,17 +55,17 @@ export const BcMapping: RequestActionMappingI = {
     EntityTypes.BC,
     EntityTypes.SO
   ],
-  // every entity type except Parishes and Private Act
+  // Change Name
+  // (every entity type except Parishes and Private Act)
   CHG: EntityTypesBC.filter(ent => ent !== EntityTypes.PAR && ent !== EntityTypes.PA),
-  // when a MVE (continuation in) NR is created, the resultant company will have a
-  // different entity type in LEAR, as per comments below
+  // MVE = Continuation In
   MVE: [
-    EntityTypes.CR, // will become CorpTypeCd.CONTINUE_IN
-    EntityTypes.CC, // will become CorpTypeCd.CCC_CONTINUE_IN
-    EntityTypes.CP,
-    EntityTypes.UL, // will become CorpTypeCd.ULC_CONTINUE_IN
-    EntityTypes.SO,
-    EntityTypes.BC // will become CorpTypeCd.BEN_CONTINUE_IN
+    EntityTypes.C,
+    EntityTypes.CCC,
+    EntityTypes.CP, // FUTURE: update this? see also entity-type-data.ts
+    EntityTypes.CUL,
+    EntityTypes.CS,
+    EntityTypes.CBEN
   ]
 }
 

--- a/src/list-data/request-action-mapping.ts
+++ b/src/list-data/request-action-mapping.ts
@@ -139,5 +139,8 @@ export const NumberedEntityTypes = [
   EntityTypes.CC,
   EntityTypes.CR,
   EntityTypes.UL,
-  EntityTypes.C
+  EntityTypes.C,
+  EntityTypes.CBEN,
+  EntityTypes.CCC,
+  EntityTypes.CUL
 ]

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -506,7 +506,7 @@ export const getEntityTypesBC = (state: StateIF): EntityI[] => {
         }
         // "CR" type is shortlisted
         // if CR exists in filtered entity_types, preserve its rank and shortlist keys
-        if (entity === EntityTypes.CR) {
+        if (entity === EntityTypes.CR || entity === EntityTypes.C) {
           output.push(obj)
           continue
         }


### PR DESCRIPTION
*Issue #:* bcgov/entity#21033

*Description of changes:*
- app version = 5.4.9
- added missing entity type (CS) to enum
- added cont in entity type data
- added cont in types to list of BC types
- updated MVE request action mapping for cont in
- updated getters to return alternate entity type data for cont in vs BC
- added CS to society code checks
- added cont in codes to numbered entity types list

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).