### PR TITLE
20133 Convert entity types in numbered Continuation In drafts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.4.8",
+  "version": "5.4.9",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",
@@ -11,7 +11,8 @@
     "test:unit": "vue-cli-service test:unit --testPathPattern --coverage",
     "lint": "vue-cli-service lint",
     "lint:nofix": "vue-cli-service lint --no-fix",
-    "build-check": "node --max_old_space_size=8000 node_modules/@vue/cli-service/bin/vue-cli-service.js build"},
+    "build-check": "node --max_old_space_size=8000 node_modules/@vue/cli-service/bin/vue-cli-service.js build"
+  },
   "dependencies": {
     "@babel/compat-data": "^7.21.5",
     "@bcrs-shared-components/breadcrumb": "2.1.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^0.4.2
         version: 0.4.4
       sbc-common-components:
-        specifier: 3.0.8
-        version: 3.0.8
+        specifier: 3.0.12
+        version: 3.0.12
       style-loader:
         specifier: ^1.3.0
         version: 1.3.0(webpack@5.78.0)
@@ -5453,8 +5453,8 @@ packages:
     resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
     engines: {node: '>=10'}
 
-  sbc-common-components@3.0.8:
-    resolution: {integrity: sha512-TjZA8xRxtwrynI/EXLbGKr68+NFBlFPXDs1n7Uc+EaGD+zwmi8flSi6FEQNbrfb01YfVmlZ8GNghU7f1YP41rw==}
+  sbc-common-components@3.0.12:
+    resolution: {integrity: sha512-xi+zRXCyhnlKQgqbDoPd64Mrs/peB3+TwBv8H3VoEAVkVVr+z6mxfn+ej4WIlGv8KPQkL30LGBQRuZ0TG/JwxQ==}
 
   schema-utils@2.7.0:
     resolution: {integrity: sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==}
@@ -12915,7 +12915,7 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  sbc-common-components@3.0.8:
+  sbc-common-components@3.0.12:
     dependencies:
       '@mdi/font': 4.9.95
       axios: 0.21.4

--- a/src/enums/entity-types.ts
+++ b/src/enums/entity-types.ts
@@ -11,6 +11,7 @@ export enum EntityTypes {
   CCC = CorpTypeCd.CCC_CONTINUE_IN,
   CP = CorpTypeCd.COOP,
   CR = CorpTypeCd.CORPORATION,
+  CS = CorpTypeCd.CONT_IN_SOCIETY,
   CUL = CorpTypeCd.ULC_CONTINUE_IN,
   DBA = CorpTypeCd.DOING_BUSINESS_AS,
   FI = CorpTypeCd.FINANCIAL,

--- a/src/list-data/request-action-mapping.ts
+++ b/src/list-data/request-action-mapping.ts
@@ -21,6 +21,7 @@ const EntityTypesBC = [
 // maps request_action_cd (key) to array of allowable entities (value)
 // { [request_action_cd]: entity_type_cd[] }
 export const BcMapping: RequestActionMappingI = {
+  // Amalgamate
   AML: [
     EntityTypes.CR,
     EntityTypes.UL,
@@ -29,6 +30,7 @@ export const BcMapping: RequestActionMappingI = {
     EntityTypes.BC,
     EntityTypes.SO
   ],
+  // Renew
   REN: [
     EntityTypes.CR,
     EntityTypes.CP,
@@ -38,6 +40,7 @@ export const BcMapping: RequestActionMappingI = {
     EntityTypes.BC,
     EntityTypes.SO
   ],
+  // Restore
   REH: [
     EntityTypes.CR,
     EntityTypes.CP,
@@ -47,16 +50,16 @@ export const BcMapping: RequestActionMappingI = {
     EntityTypes.BC,
     EntityTypes.SO
   ],
-  // every entity type except Parishes and Private Act
+  // Change Name
+  // (every entity type except Parishes and Private Act)
   CHG: EntityTypesBC.filter(ent => ent !== EntityTypes.PAR && ent !== EntityTypes.PA),
-  // when a MVE (continuation in) NR is created, the resultant company will have a
-  // different entity type in LEAR, as per comments below
+  // MVE = Continuation In
   MVE: [
     EntityTypes.CR, // will become CorpTypeCd.CONTINUE_IN
     EntityTypes.CC, // will become CorpTypeCd.CCC_CONTINUE_IN
     EntityTypes.CP,
     EntityTypes.UL, // will become CorpTypeCd.ULC_CONTINUE_IN
-    EntityTypes.SO,
+    EntityTypes.SO, // will becomes CorpTypeCd.CONT_IN_SOCIETY
     EntityTypes.BC // will become CorpTypeCd.BEN_CONTINUE_IN
   ]
 }

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -19,11 +19,11 @@ export class CommonMixin extends Vue {
       .join(' ')
   }
 
-  /** Returns entity type text for the the specified code. */
+  /** Returns the description for the given entity type code. */
   // FUTURE: use GetCorpFullDescription() instead
   entityTypeCdToText (cd: EntityTypes): string {
     switch (cd) {
-      // BC Entity Types:
+      // BC entity types:
       case EntityTypes.BC: return 'BC Benefit Company'
       case EntityTypes.CC: return 'BC Community Contribution Company'
       case EntityTypes.CP: return 'BC Cooperative Association'
@@ -40,13 +40,14 @@ export class CommonMixin extends Vue {
       case EntityTypes.SP: return 'BC Sole Proprietorship'
       case EntityTypes.UL: return 'BC Unlimited Liability Company'
 
-      // Continuation In Entity Types:
-      case EntityTypes.C: return 'Continuation In (BC Limited Company)'
-      case EntityTypes.CBEN: return 'Continuation In (Benefit Company)'
-      case EntityTypes.CCC: return 'Continuation In (BC Community Contribution Company)'
-      case EntityTypes.CUL: return 'Continuation In (BC Unlimited Liability Company)'
+      // Continuation In entity types:
+      case EntityTypes.C: return 'BC Limited Company (Continuation In)'
+      case EntityTypes.CBEN: return 'Benefit Company (Continuation In)'
+      case EntityTypes.CCC: return 'BC Community Contribution Company (Continuation In)'
+      case EntityTypes.CS: return 'BC Social Enterprise (Continuation In)'
+      case EntityTypes.CUL: return 'BC Unlimited Liability Company (Continuation In)'
 
-      // XPRO Entity Types:
+      // XPRO entity types:
       case EntityTypes.XCR: return 'Extraprovincial Limited Company'
       case EntityTypes.XUL: return 'Extraprovincial Unlimited Liability Company'
       case EntityTypes.RLC: return 'Extraprovincial Limited Liability Company'
@@ -60,8 +61,8 @@ export class CommonMixin extends Vue {
   }
 
   /**
-   * The alternate codes for entity types.
-   * Alternate codes are used in Entities UIs.
+   * Returns the Corp Type Code (used by LEAR) for the given Entity Type (used by Namex).
+   * @example UL --> ULC
    */
   entityTypeToCorpType (entityType: EntityTypes): CorpTypeCd {
     switch (entityType) {
@@ -72,6 +73,7 @@ export class CommonMixin extends Vue {
       case EntityTypes.CCC: return CorpTypeCd.CCC_CONTINUE_IN
       case EntityTypes.CP: return CorpTypeCd.COOP
       case EntityTypes.CR: return CorpTypeCd.BC_COMPANY
+      case EntityTypes.CS: return CorpTypeCd.CONT_IN_SOCIETY
       case EntityTypes.CUL: return CorpTypeCd.ULC_CONTINUE_IN
       case EntityTypes.DBA: return CorpTypeCd.SOLE_PROP // same as FR
       case EntityTypes.FI: return CorpTypeCd.FINANCIAL
@@ -98,7 +100,7 @@ export class CommonMixin extends Vue {
   }
 
   /**
-   * Entities UI codes to Name Request Code.
+   * Returns the Entity Type (used by Namex) for the given Corp Type Code (used by LEAR).
    * @example ULC --> UL
    */
   corpTypeToEntityType (entityType: CorpTypeCd): EntityTypes {
@@ -110,6 +112,7 @@ export class CommonMixin extends Vue {
       case CorpTypeCd.BC_ULC_COMPANY: return EntityTypes.UL
       case CorpTypeCd.CCC_CONTINUE_IN: return EntityTypes.CCC
       case CorpTypeCd.COOP: return EntityTypes.CP
+      case CorpTypeCd.CONT_IN_SOCIETY: return EntityTypes.CS
       case CorpTypeCd.CONTINUE_IN: return EntityTypes.C
       case CorpTypeCd.EXTRA_PRO_A: return EntityTypes.XCR
       case CorpTypeCd.FINANCIAL: return EntityTypes.FI

--- a/src/mixins/nr-affiliation-mixin.ts
+++ b/src/mixins/nr-affiliation-mixin.ts
@@ -27,7 +27,7 @@ export class NrAffiliationMixin extends Mixins(CommonMixin) {
   /**
    * Affiliates a NR to the current account, creates a temporary business, and then navigates
    * to the entity dashboard page.
-   * @param nr the NR to affiliate
+   * @param nr The NR to affiliate.
    */
   async createAffiliation (nr: NameRequestI): Promise<any> {
     try {
@@ -214,10 +214,10 @@ export class NrAffiliationMixin extends Mixins(CommonMixin) {
   }
 
   /**
-   * Handle the action buttons (numbered selection).
-   * Create draft business depending on business type.
-   * Redirect to Dashboard.
-   * @param legalType The legal type of the business
+   * 1. Handles the action buttons (numbered selection).
+   * 2. Creates draft business depending on legal type.
+   * 3. Redirects to entity dashboard.
+   * @param legalType The legal type of the business.
    */
   async actionNumberedEntity (legalType: CorpTypeCd): Promise<any> {
     // show spinner since this is a network call
@@ -244,19 +244,26 @@ export class NrAffiliationMixin extends Mixins(CommonMixin) {
   }
 
   /**
-   * Create a draft numbered business based on selected business type (If applicable).
+   * Creates a draft numbered business based on specified legal type.
    * @param accountId Account ID of logged in user.
    * @param legalType The legal type of the business that's being created.
    */
   async createNumberedBusiness (accountId: number, legalType: CorpTypeCd): Promise<string> {
+    if (this.isContinuationIn) {
+      // convert regular legal type to continuation in legal type
+      switch (legalType) {
+        case CorpTypeCd.BC_COMPANY: legalType = CorpTypeCd.CONTINUE_IN; break
+        case CorpTypeCd.BENEFIT_COMPANY: legalType = CorpTypeCd.BEN_CONTINUE_IN; break
+        case CorpTypeCd.BC_CCC: legalType = CorpTypeCd.CCC_CONTINUE_IN; break
+        case CorpTypeCd.BC_ULC_COMPANY: legalType = CorpTypeCd.ULC_CONTINUE_IN; break
+        case CorpTypeCd.SOCIETY: legalType = CorpTypeCd.CONT_IN_SOCIETY; break
+      }
+    }
+
     const businessRequest = {
       filing: {
-        header: {
-          accountId: accountId
-        },
-        business: {
-          legalType: legalType
-        }
+        header: { accountId },
+        business: { legalType }
       }
     } as BusinessRequest
 

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -531,7 +531,7 @@ export const getEntityTypesBC = (state: StateIF): EntityI[] => {
     return EntityTypesBcData
   } catch (err) {
     console.error('entityTypesBC() =', err) // eslint-disable-line no-console
-    return EntityTypesBcData
+    return []
   }
 }
 
@@ -606,11 +606,16 @@ export const getXproRequestTypeCd = (state: StateIF): XproNameType => {
 /** Get entity type options (short list only). */
 export const getEntityTypeOptions = (state: StateIF): Array<EntityI> => {
   const bcOptions: SelectOptionsI[] = getEntityTypesBC(state)?.filter(x => {
-    // Set shortlisted entity types for BC Move and Restoration requests.
-    if (
-      (isContinuationIn(state) || isRestoration(state)) &&
-      isLocationBC(state)
-    ) {
+    if (isContinuationIn(state) && isLocationBC(state)) {
+      // Shortlist order: Limited Company, Unlimited Liability Company
+      if (x.value === EntityTypes.UL) {
+        x.shortlist = true
+        x.rank = 2
+      } else if ([EntityTypes.FR, EntityTypes.GP, EntityTypes.UL].includes(x.value)) {
+        x.shortlist = null
+        x.rank = null
+      }
+    } else if (isRestoration(state) && isLocationBC(state)) {
       // Shortlist order: Limited Company, Cooperative Association
       if (x.value === EntityTypes.CP) {
         x.shortlist = true


### PR DESCRIPTION
*Issue #:* bcgov/entity#20133

(I abandoned my previous PR because that solution was fairly messy and still not working correctly 🙄)

*Description of changes:*
- app version = 5.4.9
- added missing entity type (CS) to enum
- added comments to mapping table
- adding missing entity type to common mixin methods
- updated createNumberedBusiness to convert "entity type" to "continuation in entity type"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).