### PR TITLE
Added Middle Name field when searching for NRs and after payment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/src/components/advanced-search/advanced-search-table.vue
+++ b/src/components/advanced-search/advanced-search-table.vue
@@ -28,7 +28,7 @@
             v-for="(applicant, index) in item.applicants"
             :key="`applicant-${index}`"
           >
-            {{ applicant.lastName }}, {{ applicant.firstName }}
+            {{ applicant.lastName }}, {{ applicant.firstName }} {{applicant.middleName}}
           </span>
         </td>
         <td>

--- a/src/components/existing-request/existing-request-display.vue
+++ b/src/components/existing-request/existing-request-display.vue
@@ -240,6 +240,7 @@
                   <span>Applicant Name:</span>
                   &nbsp;{{ nr && nr.applicants && nr.applicants.lastName }},
                   &nbsp;{{ nr && nr.applicants && nr.applicants.firstName }}
+                  &nbsp;{{ nr && nr.applicants && nr.applicants.middleName }}
                 </v-col>
 
                 <v-col


### PR DESCRIPTION
*Issue #:* /bcgov/entity###

*Description of changes:*
1. Added middle name displayed in existing-request after an applicant has paid for a name request.
2. Added middle name displayed in advanced-search-table when applicant searches for NRs.

Number 2 is dependent on NameX returning middleName field (another PR in NameX)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
