### PR TITLE
22425-feat: Update jurisdiction list and truncate short descriptions

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/src/list-data/intl-jurisdictions.ts
+++ b/app/src/list-data/intl-jurisdictions.ts
@@ -17,13 +17,13 @@ const CanUsa: JurisdictionI[] = [
 const Other: JurisdictionI[] = [
   {
     value: 'CD',
-    SHORT_DESC: 'CONGO, THE DEMO',
-    text: 'CONGO, THE DEMOCRATIC REPUBLIC OF THE'
+    SHORT_DESC: 'Congo, The Demo',
+    text: 'Congo, The Democratic Republic of The'
   },
   {
     value: 'FX',
-    SHORT_DESC: 'FRANCE, METROPO',
-    text: 'FRANCE, METROPOLITAN'
+    SHORT_DESC: 'France, Metropo',
+    text: 'France, Metropolitan'
   },
   {
     value: 'TM',

--- a/app/src/list-data/intl-jurisdictions.ts
+++ b/app/src/list-data/intl-jurisdictions.ts
@@ -16,6 +16,16 @@ const CanUsa: JurisdictionI[] = [
 
 const Other: JurisdictionI[] = [
   {
+    value: 'CD',
+    SHORT_DESC: 'CONGO, THE DEMO',
+    text: 'CONGO, THE DEMOCRATIC REPUBLIC OF THE'
+  },
+  {
+    value: 'FX',
+    SHORT_DESC: 'FRANCE, METROPO',
+    text: 'FRANCE, METROPOLITAN',
+  },
+  {
     value: 'TM',
     SHORT_DESC: 'Turkmenistan',
     text: 'Turkmenistan'
@@ -153,12 +163,12 @@ const Other: JurisdictionI[] = [
   {
     value: 'VI',
     text: 'Virgin Islands, U.S.',
-    SHORT_DESC: 'Virgin Islands, U.S.'
+    SHORT_DESC: 'USVI'
   },
   {
     value: 'VG',
     text: 'Virgin Islands, British',
-    SHORT_DESC: 'Virgin Islands, British'
+    SHORT_DESC: 'BVI'
   },
   {
     value: 'WF',
@@ -1262,8 +1272,8 @@ const Other: JurisdictionI[] = [
   },
   {
     value: 'TR',
-    SHORT_DESC: 'Türkiye',
-    text: 'Türkiye, Republic Of'
+    SHORT_DESC: 'Turkiye',
+    text: 'Turkiye, Republic Of'
   }
 ]
 

--- a/app/src/list-data/intl-jurisdictions.ts
+++ b/app/src/list-data/intl-jurisdictions.ts
@@ -23,7 +23,7 @@ const Other: JurisdictionI[] = [
   {
     value: 'FX',
     SHORT_DESC: 'FRANCE, METROPO',
-    text: 'FRANCE, METROPOLITAN',
+    text: 'FRANCE, METROPOLITAN'
   },
   {
     value: 'TM',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22425

*Description of changes:*
- Added new jurisdictions:
  - `CD`: SHORT_DESC: "CONGO, THE DEMO", FULL_DESC: "CONGO, THE DEMOCRATIC REPUBLIC OF THE"
  - `FX`: SHORT_DESC: "FRANCE, METROPO", FULL_DESC: "FRANCE, METROPOLITAN"
- Truncated SHORT_DESC for:
  - `VI`: "Virgin Islands, U.S." to "USVI"
  - `VG`: "Virgin Islands, British" to "BVI"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
