### PR TITLE
22696: made street address fields have a maximum of 50 chars

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/src/components/common/applicant-info-1.vue
+++ b/app/src/components/common/applicant-info-1.vue
@@ -240,6 +240,7 @@
                 id="1ine2"
                 ref="Line2"
                 :messages="messages['Line2']"
+                :rules="maxCharRules"
                 :value="applicant.addrLine2"
                 dense
                 filled
@@ -272,6 +273,7 @@
                 id="line3"
                 ref="Line3"
                 :messages="messages['Line3']"
+                :rules="maxCharRules"
                 :value="applicant.addrLine3"
                 dense
                 filled
@@ -596,7 +598,11 @@ export default class ApplicantInfo1 extends Mixins(ActionMixin) {
     v => (!v || v.length <= 50) || 'Cannot exceed 50 characters'
   ]
   requiredRules = [
-    v => !!v || 'Required field'
+    v => !!v || 'Required field',
+    v => (v.length <= 50) || 'Cannot exceed 50 characters'
+  ]
+  maxCharRules = [
+    v => (v.length <= 50) || 'Cannot exceed 50 characters'
   ]
   showAddressMenu = false
 


### PR DESCRIPTION
*Issue #:* https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/22696

*Description of changes:*
Made the address fields have a maximum of 50 chars. 
 - Kept the first address (line 1) as mandatory and added the new rule of 50 chars max
 - Made a new rule set for lines 2 & 3 so they are not mandatory but still have a max of 50 chars

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
