### PR TITLE
Update all jurisdictions that are different with COLIN

### DIFF
--- a/app/src/list-data/intl-jurisdictions.ts
+++ b/app/src/list-data/intl-jurisdictions.ts
@@ -98,7 +98,7 @@ const Other: JurisdictionI[] = [
   {
     value: 'BQ',
     SHORT_DESC: 'Bonaire',
-    text: 'Bonaire'
+    text: 'BONAIRE, ST EUSTATIUS AND SABA'
   },
   {
     value: 'CW',
@@ -747,13 +747,13 @@ const Other: JurisdictionI[] = [
   },
   {
     value: 'KP',
-    SHORT_DESC: 'Korea',
-    text: "Democratic People's Republic Of Korea"
+    SHORT_DESC: 'Korea, Democrat',
+    text: "Korea, Democratic People's Republic of"
   },
   {
     value: 'KR',
-    SHORT_DESC: 'Korea',
-    text: 'South Korea'
+    SHORT_DESC: 'Korea, Republic',
+    text: 'Korea, Republic of'
   },
   {
     value: 'KW',
@@ -817,9 +817,9 @@ const Other: JurisdictionI[] = [
   },
   {
     value: 'MK',
-    SHORT_DESC: 'Macedonia',
-    text: 'Macedonia'
-  },
+    SHORT_DESC: 'THE Macedonia',
+    text: 'Macedonia, The Former Yugoslav Republic'
+  },  
   {
     value: 'MG',
     SHORT_DESC: 'Madagascar',
@@ -882,13 +882,13 @@ const Other: JurisdictionI[] = [
   },
   {
     value: 'FM',
-    SHORT_DESC: 'Micronesia',
-    text: 'Micronesia'
+    SHORT_DESC: 'Micronesia, FED',
+    text: 'Micronesia, Federated States of'
   },
   {
     value: 'MD',
-    SHORT_DESC: 'Moldova',
-    text: 'Moldova'
+    SHORT_DESC: 'REPUBL Moldova',
+    text: 'Moldova, Republic of'
   },
   {
     value: 'MC',
@@ -1008,7 +1008,7 @@ const Other: JurisdictionI[] = [
   {
     value: 'PS',
     SHORT_DESC: 'Palestinian Ter',
-    text: 'Palestinian Territory'
+    text: 'Palestinian Territory, OCCUPIED'
   },
   {
     value: 'PA',
@@ -1232,7 +1232,7 @@ const Other: JurisdictionI[] = [
   },
   {
     value: 'TZ',
-    SHORT_DESC: 'Tanzania',
+    SHORT_DESC: 'Unite Tanzania',
     text: 'Tanzania, United Republic Of'
   },
   {
@@ -1272,8 +1272,8 @@ const Other: JurisdictionI[] = [
   },
   {
     value: 'TR',
-    SHORT_DESC: 'Turkiye',
-    text: 'Turkiye, Republic Of'
+    SHORT_DESC: 'Turkey',
+    text: 'Turkey, Republic Of'
   }
 ]
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22425

*Description of changes*:
  Updated various jurisdiction names and descriptions to match the latest standards and requirements:
  Bonaire updated text to "BONAIRE, ST EUSTATIUS AND SABA".
  Korea (North) updated short description to "Korea, Democrat" and text to "Korea, Democratic People's Republic of".
  Korea (South) updated short description to "Korea, Republic" and text to "Korea, Republic of".
  Macedonia updated short description to "THE Macedonia" and text to "Macedonia, The Former Yugoslav Republic".
  Micronesia updated short description to "Micronesia, FED" and text to "Micronesia, Federated States of".
  Moldova updated short description to "REPUBL Moldova" and text to "Moldova, Republic of".
  Palestinian Territory updated text to "Palestinian Territory, OCCUPIED".
  Tanzania updated short description to "Unite Tanzania".
  Turkey updated short description to "Turkey" and text to "Turkey, Republic Of".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
