### PR TITLE
remove trailing spaces

### DIFF
--- a/app/src/list-data/intl-jurisdictions.ts
+++ b/app/src/list-data/intl-jurisdictions.ts
@@ -819,7 +819,7 @@ const Other: JurisdictionI[] = [
     value: 'MK',
     SHORT_DESC: 'THE Macedonia',
     text: 'Macedonia, The Former Yugoslav Republic'
-  },  
+  },
   {
     value: 'MG',
     SHORT_DESC: 'Madagascar',


### PR DESCRIPTION
*Description of changes:*
Building locally get linting error:

ERROR in [eslint] 
namerequest/app/src/list-data/intl-jurisdictions.ts
  822:5  error  Trailing spaces not allowed  no-trailing-spaces

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
