### PR TITLE
24107 Added designations for continued in business types

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.9",
+  "version": "5.5.10",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
     "@babel/compat-data": "^7.24.4",
     "@bcrs-shared-components/breadcrumb": "2.1.24",
     "@bcrs-shared-components/corp-type-module": "1.0.15",
-    "@bcrs-shared-components/enums": "1.1.7",
+    "@bcrs-shared-components/enums": "1.1.13",
     "@bcrs-shared-components/folio-number-input": "^1.1.44",
     "@bcrs-shared-components/genesys-web-message": "1.0.0",
     "@bcrs-shared-components/interfaces": "1.0.67",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 1.0.15
         version: 1.0.15
       '@bcrs-shared-components/enums':
-        specifier: 1.1.7
-        version: 1.1.7
+        specifier: 1.1.13
+        version: 1.1.13
       '@bcrs-shared-components/folio-number-input':
         specifier: ^1.1.44
         version: 1.1.44
@@ -925,11 +925,11 @@ packages:
   '@bcrs-shared-components/corp-type-module@1.0.15':
     resolution: {integrity: sha512-g/TcNSR7zJsG2lBjn/NnM+/+k7dJzhAiy5PiPj0ObN56bUV1PrUWVVlg5lz4/JZUEAZetWhwnyAzPVGsn7kr1w==}
 
-  '@bcrs-shared-components/enums@1.1.7':
-    resolution: {integrity: sha512-WORgcK1YS/AssOI6sbuSQv4f13wZTQR6td7+gcghgAl34WNyO5HT0Mu2VfVGbD2zXfIYDm5jXTj2Dg6dkxpouA==}
+  '@bcrs-shared-components/corp-type-module@1.0.16':
+    resolution: {integrity: sha512-3MumJZ/0Urfnp1AGJpnUifk5DMrLcjDD+8YiGXy1WXjvpVLwA0S4bNPuvFUf0w4My+0HyXWZ/XsZWiQydVGYHw==}
 
-  '@bcrs-shared-components/enums@1.1.9':
-    resolution: {integrity: sha512-rYmRG0QH9hMWXRJNrxzNQhM3tT/b6mubfLBREx2ICzUtSIDc9UvQ0VqmyX/q84xQdzAOYqh0Nth9vXYm7Ypdxg==}
+  '@bcrs-shared-components/enums@1.1.13':
+    resolution: {integrity: sha512-3kAFt9BvdSs1O8b0MIp4ysqt/QK1BzvkYEyju+0aI/fKeywFYOst8MOfmM47M3z4LKExOrmayj6M/S+5F+KkGw==}
 
   '@bcrs-shared-components/folio-number-input@1.1.44':
     resolution: {integrity: sha512-CWQmST9C5DplVu+ArHPeetRruZhAyHZ5wfR49XFZCi4y2AnQ+9LjTvTXmiK66OK6aRyn0bQ5DU8wSXV9W4dcaA==}
@@ -7541,13 +7541,11 @@ snapshots:
 
   '@bcrs-shared-components/corp-type-module@1.0.15': {}
 
-  '@bcrs-shared-components/enums@1.1.7':
-    dependencies:
-      '@bcrs-shared-components/corp-type-module': 1.0.15
+  '@bcrs-shared-components/corp-type-module@1.0.16': {}
 
-  '@bcrs-shared-components/enums@1.1.9':
+  '@bcrs-shared-components/enums@1.1.13':
     dependencies:
-      '@bcrs-shared-components/corp-type-module': 1.0.15
+      '@bcrs-shared-components/corp-type-module': 1.0.16
 
   '@bcrs-shared-components/folio-number-input@1.1.44':
     dependencies:
@@ -7563,18 +7561,18 @@ snapshots:
 
   '@bcrs-shared-components/interfaces@1.0.67':
     dependencies:
-      '@bcrs-shared-components/enums': 1.1.7
+      '@bcrs-shared-components/enums': 1.1.13
       vue: 2.7.16
 
   '@bcrs-shared-components/interfaces@1.1.10':
     dependencies:
       '@bcrs-shared-components/corp-type-module': 1.0.15
-      '@bcrs-shared-components/enums': 1.1.9
+      '@bcrs-shared-components/enums': 1.1.13
       vue: 2.7.16
 
   '@bcrs-shared-components/staff-payment@1.0.29(vue@2.7.10)':
     dependencies:
-      '@bcrs-shared-components/enums': 1.1.7
+      '@bcrs-shared-components/enums': 1.1.13
       '@bcrs-shared-components/folio-number-input': 1.1.44
       '@bcrs-shared-components/interfaces': 1.0.67
       vue-property-decorator: 8.5.1(vue@2.7.10)

--- a/app/src/list-data/designations.ts
+++ b/app/src/list-data/designations.ts
@@ -27,7 +27,17 @@ const CooperativeDesignations: DesignationI = {
 
 export const Designations = {
   BC: CorporateDesignations,
+  C: CorporateDesignations, // continued in BC Limited Company
+  CBEN: CorporateDesignations, // continued in Benefit Company
   CC: {
+    words: [
+      'CCC',
+      'COMMUNITY CONTRIBUTION COMPANY',
+      ...CorporateDesignations.words
+    ],
+    end: true
+  },
+  CCC: { // continued in Community Contribution Company
     words: [
       'CCC',
       'COMMUNITY CONTRIBUTION COMPANY',
@@ -37,6 +47,13 @@ export const Designations = {
   },
   CP: CooperativeDesignations,
   CR: CorporateDesignations,
+  CUL: { // continued in Unlimited Liability Company
+    words: [
+      'ULC',
+      'UNLIMITED LIABILITY COMPANY'
+    ],
+    end: true
+  },
   DBA: {
     words: [],
     end: false


### PR DESCRIPTION
*Issue #:* bcgov/entity#24107

*Description of changes:*
- app version = 5.5.10
- added designations for continued in business types (C, CBEN, CCC, CUL)
- imported latest shared enums

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).