### PR TITLE
fix: additional address use maxCharRules to prevent errors when empty

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.13",
+  "version": "5.5.14",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/src/components/common/applicant-info-1.vue
+++ b/app/src/components/common/applicant-info-1.vue
@@ -37,7 +37,7 @@
               <v-text-field
                 id="firstname"
                 :messages="messages['firstName']"
-                :rules="firstMiddleNameRules"
+                :rules="maxCharRules"
                 :value="applicant.firstName"
                 dense
                 filled
@@ -65,7 +65,7 @@
                 id="middlename"
                 :messages="messages['middleName']"
                 :value="applicant.middleName"
-                :rules="firstMiddleNameRules"
+                :rules="maxCharRules"
                 dense
                 filled
                 height="50"
@@ -594,14 +594,11 @@ export default class ApplicantInfo1 extends Mixins(ActionMixin) {
     v => !!v || 'Required field',
     v => (!v || v.length <= 50) || 'Cannot exceed 50 characters'
   ]
-  firstMiddleNameRules = [
+  maxCharRules = [
     v => (!v || v.length <= 50) || 'Cannot exceed 50 characters'
   ]
   requiredRules = [
     v => !!v || 'Required field',
-    v => (v.length <= 50) || 'Cannot exceed 50 characters'
-  ]
-  maxCharRules = [
     v => (v.length <= 50) || 'Cannot exceed 50 characters'
   ]
   showAddressMenu = false


### PR DESCRIPTION
*Issue #:* https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/24605

*Description of changes:*
The `maxCharRules` was causing problems when the additional address field was empty. This was because the check was attempting to get the length.
```
 maxCharRules = [
    v => (v.length <= 50) || 'Cannot exceed 50 characters'
  ]
```
This means for the `additionalAddressField` - which had this rule attached, would give the following error when there was nothing in this field preventing the user from moving on when editing an NR. 
![image](https://github.com/user-attachments/assets/205a4f46-1d87-491b-b70d-0b10ed95340c)

This PR changes this rule to be as follows:
```
  maxCharRules = [
    v => (!v || v.length <= 50) || 'Cannot exceed 50 characters'
  ]
```
This checks that the value is either falsy (when nothing is there) or that it has less than 50 characters. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
