### PR TITLE
23332 - Fix request restoration nr for limited restored company

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.15",
+  "version": "5.5.16",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/src/store/actions.ts
+++ b/app/src/store/actions.ts
@@ -2,6 +2,7 @@ import querystring from 'qs'
 import axios from 'axios'
 import {
   CompanyTypes,
+  EntityStates,
   EntityTypes,
   Location,
   NameCheckAnalysisJurisdiction,
@@ -307,7 +308,7 @@ export async function searchBusiness ({ getters }, corpNum: string): Promise<Bus
     // first try to find business in Entities (Legal API)
     const data = await NamexServices.searchEntities(corpNum)
     // for restoration requests, verify business eligibility
-    if (getters.isRestoration) {
+    if (getters.isRestoration && data.state !== EntityStates.HISTORICAL) {
       // check if business is eligible for restoration by verifying restorationExpiryDate exists and not expired
       if (!data.restorationExpiryDate ||
         getters.getCurrentJsDate.toISOString().slice(0, 10) > data.restorationExpiryDate) {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23332

*Description of changes:*
* Found an issue when requesting restoration NRs for a [historical business ](https://dev.business-dashboard.bcregistry.gov.bc.ca/BC0884505/?accountid=3040&accountid=3040)
* Fix business logic to allow historical businesses to request the restoration NRs

Issue:
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/1d44afb8-959e-4737-99c9-a01b1b20ce5d" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
