### PR TITLE
24841 display error when create payment fails

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.16",
+  "version": "5.5.17",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/src/mixins/payment-mixin.ts
+++ b/app/src/mixins/payment-mixin.ts
@@ -424,6 +424,9 @@ export class PaymentMixin extends Mixins(ActionMixin) {
         if (err.errorResponse.response.data.businessInfo?.businessIdentifier) {
           sessionStorage.setItem('BCREG-nrNum', err.errorResponse.response.data.businessInfo.businessIdentifier)
         }
+        await errorModule.setAppError(
+          { id: 'payment-required-error', error: 'Payment Required' } as ErrorI
+        )
         throw err
       }
       // don't console.error - createPaymentRequest() already did that


### PR DESCRIPTION
*Issue #:* [bcgov/entity/24841](https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/24841)

*Description of changes:*
**Issue**
When creating a new NR, pressing the Continue to Payment button sends a Post request to create a payment in NameX API. NameX API calls the Pay-Api which handles creating the payment and continuing to the payment portal.

Rarely there is an issue with the account and the pay-api coughs an error when attempting to create the payment. Specifically:
```
Error when calling call_api post (https://pay-api-dev-142173140222.northamerica-northeast1.run.app/api/v1/payment-requests)

ERROR: An error occurred during the BC Online transaction. <br/>Please contact the help desk to resolve this issue. <br/><br/>SERVICE BC HELP DESK: <br/>Toll-free: 1-800-663-6102 (Canada and USA only)<br/>Fax: (250) 952-6115<br/>Email: bcolhelp@gov.bc.ca
```

When this happens the UI gets stuck and does not do anything looking like this:
![image](https://github.com/user-attachments/assets/eacdaaab-982a-4297-887f-54ad43b57625)

**Fix**
This PR triggers the UI to react to the error (Payment Required Error) and display the generic error dialog notifying the user to contact support. 
![image](https://github.com/user-attachments/assets/d6db4449-d93d-4299-8c5e-3b80b550806b)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
