### PR TITLE
24739 The new NR should be affiliated with the specified account ID, rather than the logged-in account ID

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.20",
+  "version": "5.5.21",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/src/components/dialogs/confirm-name-request.vue
+++ b/app/src/components/dialogs/confirm-name-request.vue
@@ -187,6 +187,7 @@ export default class ConfirmNrDialog extends Mixins(
   @Getter getName!: string
   @Getter getNameChoices!: NameChoicesIF
   @Getter getPriorityRequest!: boolean
+  @Getter getBusinessAccountId : string
   @Getter isMobile!: boolean
   @Getter isRoleStaff!: boolean
 
@@ -294,7 +295,8 @@ export default class ConfirmNrDialog extends Mixins(
         action: PaymentAction.CREATE,
         nrId: this.getNrId,
         filingType: FilingTypes.NM620,
-        priorityRequest: this.getPriorityRequest
+        priorityRequest: this.getPriorityRequest,
+        businessAccountId: this.getBusinessAccountId
       } as CreatePaymentParams, onSuccess)
     } catch (error) {
       this.isLoadingPayment = false

--- a/app/src/enums/routes.ts
+++ b/app/src/enums/routes.ts
@@ -3,5 +3,6 @@ export enum Routes {
   MANAGE = 'manage',
   EXISTING = 'existing',
   SIGNIN = 'signin',
-  SIGNOUT = 'signout'
+  SIGNOUT = 'signout',
+  BUSINESS_ACCOUNT = 'businessAccount',
 }

--- a/app/src/interfaces/new-request-interface.ts
+++ b/app/src/interfaces/new-request-interface.ts
@@ -77,4 +77,5 @@ export interface NewRequestIF {
   tabNumber: number
   userCancelledAnalysis: boolean
   waitingAddressSearch: WaitingAddressSearchI
+  businessAccountId: string
 }

--- a/app/src/mixins/payment-mixin.ts
+++ b/app/src/mixins/payment-mixin.ts
@@ -351,7 +351,7 @@ export class PaymentMixin extends Mixins(ActionMixin) {
   }
 
   async createPayment (params: CreatePaymentParams, onSuccess: (paymentResponse) => void): Promise<boolean> {
-    const { nrId, filingType, priorityRequest, action } = params
+    const { nrId, filingType, priorityRequest, action, businessAccountId } = params
     // Comment this out to use direct pay:
     // const methodOfPayment = 'CC' // We may need to handle more than one type at some point?
 
@@ -370,6 +370,7 @@ export class PaymentMixin extends Mixins(ActionMixin) {
       // paymentInfo: {
       //   methodOfPayment: methodOfPayment
       // },
+      businessAccountId: businessAccountId,
       filingInfo: {
         filingTypes: [
           {

--- a/app/src/modules/payment/models.ts
+++ b/app/src/modules/payment/models.ts
@@ -32,7 +32,8 @@ export interface CreatePaymentParams {
   action: string // FUTURE: use type 'NrAction' or 'NrRequestActionCodes' ?
   nrId: number
   filingType: string // FUTURE: use type 'FilingTypes' ?
-  priorityRequest: boolean
+  priorityRequest: boolean,
+  businessAccountId: string
 }
 
 export interface FetchFeesParams {

--- a/app/src/router/routes.ts
+++ b/app/src/router/routes.ts
@@ -8,6 +8,12 @@ export const routes = [
     component: Landing
   },
   {
+    path: '/:businessAccountId',
+    name: Routes.BUSINESS_ACCOUNT, // Add a corresponding name in your Routes enum
+    component: Landing,
+    props: true
+  },
+  {
     path: '/manage',
     name: Routes.MANAGE, // "Manage My Name Request" tab
     component: Landing

--- a/app/src/store/actions.ts
+++ b/app/src/store/actions.ts
@@ -1292,3 +1292,7 @@ export const setSearchJurisdiction = ({ commit }, val: any): void => {
 export const setSearchRequest = ({ commit }, val: RequestActionsI): void => {
   commit('mutateSearchRequest', val)
 }
+
+export const setBusinessAccountid = ({ commit }, val: any): void => {
+  commit('mutateBusinessAccountId', val)
+}

--- a/app/src/store/getters.ts
+++ b/app/src/store/getters.ts
@@ -1029,6 +1029,7 @@ export const getDraftNameReservation = (state: StateIF): DraftReqI => {
     nameFlag: getIsPersonsName(state),
     hotjarUserId: getHotjarUserId(state),
     submit_count: 0,
+    businessAccountId: getBusinessAccountId(state),
     ...getCorpNumForReservation(state) // must be last
   }
   if (getXproRequestTypeCd(state)) {
@@ -1300,4 +1301,8 @@ export const getSearchJurisdiction = (state: StateIF): any => {
 
 export const getSearchRequest = (state: StateIF): RequestActionsI => {
   return state.stateModel.newRequestModel.search.request
+}
+
+export const getBusinessAccountId = (state: StateIF): string => {
+  return state.stateModel.newRequestModel.businessAccountId
 }

--- a/app/src/store/mutations.ts
+++ b/app/src/store/mutations.ts
@@ -607,3 +607,7 @@ export const mutateSearchJurisdiction = (state: StateIF, val: any) => {
 export const mutateSearchRequest = (state: StateIF, val: RequestActionsI) => {
   state.stateModel.newRequestModel.search.request = val
 }
+
+export const mutateBusinessAccountId = (state: StateIF, businessAccountId: string) => {
+  state.stateModel.newRequestModel.businessAccountId = businessAccountId
+}

--- a/app/src/store/state.ts
+++ b/app/src/store/state.ts
@@ -158,7 +158,8 @@ export const stateModel: StateModelIF = {
     userCancelledAnalysis: false,
     waitingAddressSearch: null,
     isLoadingSubmission: false,
-    hotjarUserId: ''
+    hotjarUserId: '',
+    businessAccountId: ''
   },
   staffPayment: {
     option: StaffPaymentOptions.NONE,

--- a/app/src/views/landing.vue
+++ b/app/src/views/landing.vue
@@ -81,6 +81,7 @@ export default class Landing extends Vue {
   // Global actions
   @Action loadExistingNameRequest!: ActionBindingIF
   @Action setDisplayedComponent!: ActionBindingIF
+  @Action setBusinessAccountid!: ActionBindingIF
 
   /** ID parameter passed in on "/nr" route. */
   @Prop(String) readonly id!: string
@@ -88,11 +89,17 @@ export default class Landing extends Vue {
   async mounted () {
     const { id } = this
     const accountId = this.$route.query.accountid?.toString()
+    const businessAccountId = this.$route.params.businessAccountId?.toString()
 
     // if an id and accountid was specified then get and load the subject NR
     if (id && accountId) {
       const nrData = await NamexServices.getNameRequestByToken(true, id, accountId)
       if (nrData) await this.loadExistingNameRequest(nrData)
+    }
+
+    // Store businessAccountId in Vuex store
+    if (businessAccountId) {
+      this.setBusinessAccountid(businessAccountId)
     }
 
     // everything is rendered/loaded - hide spinner


### PR DESCRIPTION
*Issue #:* /bcgov/entity###
https://github.com/bcgov/entity/issues/24739

*Description of changes:*
Pass the business account id in the URL to the backend when creating a new NR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
