### PR TITLE
25899 remove supported restoration entities feature flag

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.24",
+  "version": "5.5.25",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/src/components/new-request/search.vue
+++ b/app/src/components/new-request/search.vue
@@ -577,8 +577,7 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin, Sear
     if (
       this.isRoleStaff &&
       this.isRestoration &&
-      this.isNumberedCompany &&
-      this.isSupportedRestoration(this.getEntityTypeCd)
+      this.isNumberedCompany
     ) return true
 
     return false
@@ -641,7 +640,6 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin, Sear
       !this.isRoleStaff &&
       this.isRestoration &&
       this.isNumberedCompany &&
-      this.isSupportedRestoration(this.getEntityTypeCd) &&
       this.getIsLearBusiness
     ) return true
 
@@ -650,7 +648,6 @@ export default class Search extends Mixins(CommonMixin, NrAffiliationMixin, Sear
       !this.isRoleStaff &&
       this.isRestoration &&
       this.isNumberedCompany &&
-      this.isSupportedRestoration(this.getEntityTypeCd) &&
       !this.getIsLearBusiness &&
       !this.isXproEntityType(this.getEntityTypeCd)
     ) return true

--- a/app/src/mixins/common-mixin.ts
+++ b/app/src/mixins/common-mixin.ts
@@ -217,12 +217,6 @@ export class CommonMixin extends Vue {
     return supportedContInEntites.includes(type)
   }
 
-  /** Returns true if the specified entity type is allowed for restoration/reinstatement. */
-  isSupportedRestoration (type: EntityTypes): boolean {
-    const supportedRestorationEntites = GetFeatureFlag('supported-restoration-entities')
-    return supportedRestorationEntites.includes(type)
-  }
-
   /** Returns true if the specified entity type is for an Extraprovincial Company. */
   isXproEntityType (type: EntityTypes): boolean {
     return [

--- a/app/src/plugins/featureFlags.ts
+++ b/app/src/plugins/featureFlags.ts
@@ -19,8 +19,7 @@ const defaultFlagSet: LDFlagSet = {
   'sentry-enable': false, // by default, no sentry logs
   'supported-amalgamation-entities': [],
   'supported-continuation-in-entities': [],
-  'supported-incorporation-registration-entities': [],
-  'supported-restoration-entities': []
+  'supported-incorporation-registration-entities': []
 }
 
 /**


### PR DESCRIPTION
*Issue #:* [Zenhub 25899](https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/25899)

*Description of changes:*
- The `supported-restoration-entities` feature flag is no longer needed in the new Restoration Flow. 
- This PR removes this feature flag and all references to it. 

### Restoration Flow
FOR STAFF (idir login)
  - Staff selects Restore NR and does not enter a historical company
      - "This business is not eligible for restoration name request" ------> BC0870655
  - Staff selects Restore NR and enters a XPRO company
      - NR progresses as normal ------> XCP0000771
  - Staff Selects Restore NR and enters a historical company
      - Staff selects a named company
         - NR progresses as normal
      - Staff selects a numbered company
         - "Restore Now" button with link to dashboard regardless if the company is in lear or not -----> Colin: BC0887562; Lear: BC0733495

FOR CLIENTS (non idir login)
  - Client selects Restore NR and does not enter a historical company
      - "This business is not eligible for restoration name request" ------> BC0870655
  - Client selects Restore NR and enters a XPRO company
      - NR progresses as normal ------> XCP0000771
  - Client Selects Restore NR and enters a historical company
      - Client selects a named company
         - NR progresses as normal
      - Client selects a numbered company
         - If the Company is in Lear
           - "Steps to Restore your Business" button with link to external instructions ------> BC0887562
         - If the Company is not in Lear
           - If the Company is not an XPro
             - "Steps to Restore your business" button with link to external instructions ------> BC0733495
           - If the Company is a XPro, would be in the second pipeline

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
