### PR TITLE
25546 - Remove numbered option when restoration coop

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.26",
+  "version": "5.5.27",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/src/components/new-request/search.vue
+++ b/app/src/components/new-request/search.vue
@@ -248,7 +248,6 @@
           :type="'restore'"
           :showDialog="showSocietiesInfo"
         />
-        <CompanyType v-if="getSearchBusiness && isBcRestorable" />
         <Jurisdiction
           v-if="isSelectedXproAndRestorable"
           cols="12"

--- a/app/src/components/new-request/search.vue
+++ b/app/src/components/new-request/search.vue
@@ -248,6 +248,7 @@
           :type="'restore'"
           :showDialog="showSocietiesInfo"
         />
+        <CompanyType v-if="getSearchBusiness && isBcRestorable && isNumberedEntityType" />
         <Jurisdiction
           v-if="isSelectedXproAndRestorable"
           cols="12"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25546

*Description of changes:*
- When restore a Coop, remove the radio button for selecting company type (only allow named)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
