### PR TITLE
26407 fixed URL not fetched in session storage

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -13,11 +13,11 @@ VUE_APP_SOCIETIES_ONLINE_HOME_URL="https://dev.bcregistry.ca/societies/"
 VUE_APP_STEPS_TO_RESTORE_URL="https://www2.gov.bc.ca/gov/content/employment-business/business/managing-a-business/permits-licences/businesses-incorporated-companies/incorporated-companies#restore"
 
 #vaults API
-VUE_APP_AUTH_API_URL="https://auth-api-dev.apps.silver.devops.gov.bc.ca"
+VUE_APP_AUTH_API_URL="https://auth-api-dev-142173140222.northamerica-northeast1.run.app"
 VUE_APP_AUTH_API_VERSION="/api/v1"
 VUE_APP_LEGAL_API_URL="https://legal-api-dev.apps.silver.devops.gov.bc.ca"
 VUE_APP_LEGAL_API_VERSION_2="/api/v2"
-VUE_APP_NAMEX_API_URL="https://namex-dev.apps.silver.devops.gov.bc.ca"
+VUE_APP_NAMEX_API_URL="https://namex-api-dev-475224072965.northamerica-northeast1.run.app"
 VUE_APP_NAMEX_API_VERSION="/api/v1"
 VUE_APP_STATUS_API_URL="https://status-api-dev.apps.gold.devops.gov.bc.ca"
 VUE_APP_STATUS_API_VERSION="/api/v1"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.27",
+  "version": "5.5.28",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/src/services/auth-services.ts
+++ b/app/src/services/auth-services.ts
@@ -6,7 +6,9 @@ const axios = AddAxiosInterceptors(Axios.create())
 
 export default class AuthServices {
   /** The Auth API URL. */
-  static authApiUrl = sessionStorage.getItem('AUTH_API_URL')
+  static get authApiUrl (): string {
+    return sessionStorage.getItem('AUTH_API_URL')
+  }
 
   /**
    * Creates an affiliation for the specified account and NR.


### PR DESCRIPTION
*Issue #:* bcgov/entity#26407

*Description of changes:*
- app version = 5.5.28
- updated Auth API URL and Namex API URL in example env file
- updated Auth Services to fetch URL when needed (not when class is used which is before session storage is populated)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).