### PR TITLE
26502 calls to namex/legal/auth/reg-search apis include app-name header

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.33",
+  "version": "5.5.34",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/src/plugins/interceptors.ts
+++ b/app/src/plugins/interceptors.ts
@@ -1,6 +1,7 @@
 import { AxiosInstance } from 'axios'
 import ConfigHelper from 'sbc-common-components/src/util/config-helper'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
+import pkg from '../../package.json'
 
 export function AddAxiosInterceptors (axiosInstance: AxiosInstance): AxiosInstance {
   axiosInstance.interceptors.request.use(config => {
@@ -8,6 +9,7 @@ export function AddAxiosInterceptors (axiosInstance: AxiosInstance): AxiosInstan
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }
+    config.headers.common['App-Name'] = pkg.name
     return config
   },
   err => {

--- a/app/src/services/namex-services.ts
+++ b/app/src/services/namex-services.ts
@@ -15,6 +15,7 @@ import { RequestActions } from '@/list-data'
 import { NrAction, NrState, NrRequestActionCodes, RollbackActions } from '@/enums'
 import { NameRequestPayment } from '@/modules/payment/models'
 import { appBaseURL } from '../router/router'
+import pkg from '../../package.json'
 
 const ANALYSIS_TIMEOUT_MS = 3 * 60 * 1000 // 3 minutes
 const axiosNamex = Axios.create()
@@ -26,6 +27,7 @@ axiosNamex.interceptors.request.use(
     config.headers.common['BCREG-NRL'] = sessionStorage.getItem('BCREG-NRL')
     config.headers.common['BCREG-User-Phone'] = sessionStorage.getItem('BCREG-phoneNumber')
     config.headers.common['BCREG-User-Email'] = sessionStorage.getItem('BCREG-emailAddress')
+    config.headers.common['App-Name'] = pkg.name
     // eslint-disable-next-line no-console
     // console.log('in interceptor, common headers: ', config?.headers?.common)
     return config

--- a/app/src/store/actions.ts
+++ b/app/src/store/actions.ts
@@ -19,6 +19,7 @@ import { BAD_REQUEST, NOT_FOUND, OK, SERVICE_UNAVAILABLE } from 'http-status-cod
 import removeAccents from 'remove-accents'
 import { GetFeatureFlag, Sleep, sanitizeName } from '@/plugins'
 import NamexServices from '@/services/namex-services'
+import { appBaseURL } from '../router/router'
 import { DFLT_MIN_LENGTH, DFLT_MAX_LENGTH, MRAS_MIN_LENGTH, MRAS_MAX_LENGTH }
   from '@/components/new-request/constants'
 
@@ -345,8 +346,8 @@ export async function searchBusiness ({ getters }, corpNum: string): Promise<Bus
 export const fetchMRASProfile = async ({ commit, getters }): Promise<any> => {
   if (getters.getCorpSearch) {
     try {
-      const url = `mras-profile/${getters.getJurisdictionCd}/${getters.getCorpSearch}`
-      const response = await axios.get(url)
+      const url = `${appBaseURL}/mras-profile/${getters.getJurisdictionCd}/${getters.getCorpSearch}`
+      const response = await NamexServices.axios.get(url)
       if (response?.status === OK) {
         return response.data
       }
@@ -771,7 +772,7 @@ const getMatchesExact = async (
   token: string,
   cleanedName: string
 ): Promise<Array<ConflictListItemI>> => {
-  const exactResp = await axios.get('/exact-match?query=' + cleanedName, {
+  const exactResp = await NamexServices.axios.get(`${appBaseURL}/exact-match?query=` + cleanedName, {
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
   }).catch(() => {
     commit('mutateNameCheckErrorAdd', NameCheckErrorType.ERROR_EXACT)
@@ -786,7 +787,7 @@ const getMatchesSimilar = async (
   cleanedName: string,
   exactNames: Array<ConflictListItemI>
 ): Promise<Array<ConflictListItemI>> => {
-  const synonymResp = await axios.get('/requests/synonymbucket/' + cleanedName + '/*', {
+  const synonymResp = await NamexServices.axios.get(`${appBaseURL}/requests/synonymbucket/` + cleanedName + '/*', {
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
   }).catch(() => {
     commit('mutateNameCheckErrorAdd', NameCheckErrorType.ERROR_SIMILAR)
@@ -801,7 +802,7 @@ const getMatchesRestricted = async (
   token: string,
   cleanedName: string
 ): Promise<ParsedRestrictedResponseIF> => {
-  const restrictedResp = await axios.get(`/documents:restricted_words?content=${cleanedName}`, {
+  const restrictedResp = await NamexServices.axios.get(`${appBaseURL}/documents:restricted_words?content=${cleanedName}`, {
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
   }).catch(() => {
     commit('mutateNameCheckErrorAdd', NameCheckErrorType.ERROR_RESTRICTED)

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -11,6 +11,7 @@
     "experimentalDecorators": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
     "baseUrl": ".",
     "types": [


### PR DESCRIPTION
*Issue #:* 
https://github.com/bcgov/entity/issues/26502

*Description of changes:*
**Calls to NameX API**
- Go through `NamexServices` which now  adds the App-Name header via the interception
- In the actions file, the mras, exact-match, synonym-bucket, and restricted-words api calls now go through `NamexServices` as well meaning they also get this App-Name header. It also means they get a few other headers like `BCREG-NR` (Namex accepts these just fine)

**Calls to Legal, Registries-Search, and Auth APIs**
- These calls go through business-services, business-lookup-services, and auth-services respectively. And all of these get their headers from the `AddAxiosInterceptors` function. 
- The App-Name header was therefore added to this function so all of these calls include the App-Name header. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
