### PR TITLE
29712 - Fixed the register your business button functionality of firms

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-request",
-  "version": "5.5.42",
+  "version": "5.5.43",
   "private": true,
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",

--- a/app/src/mixins/common-mixin.ts
+++ b/app/src/mixins/common-mixin.ts
@@ -256,7 +256,7 @@ export class CommonMixin extends Vue {
     let magic_link_route = ''
     switch (nr.request_action_cd) {
       case NrRequestActionCodes.NEW_BUSINESS:
-        magic_link_route = [EntityTypes.SP, EntityTypes.GP].includes(nr.entity_type_cd)
+        magic_link_route = [EntityTypes.FR, EntityTypes.GP].includes(nr.entity_type_cd)
           ? 'registerNow'
           : 'incorporateNow'
         break


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29712

*Description of changes:*
Fixed this:
<img width="711" height="846" alt="image" src="https://github.com/user-attachments/assets/dd3b765f-da64-42ae-80b8-c653b670970d" />

The URL was wrong. It was pointing towards incorporateNow although it's an SP. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namerequest license (Apache 2.0).
