### PR TITLE
upgrade to Node.js 24

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
     uses: bcgov/bcregistry-sre/.github/workflows/frontend-cd.yaml@main
     with:
       target: ${{ inputs.environment }}
-      node_version: '20.5.1'
+      node_version: "24"
       app_name: 'namerequest'
       working_directory: 'app'
     secrets:

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,10 @@
 {
   "name": "name-request",
-  "version": "5.8.10",
+  "version": "5.9.0",
   "private": true,
+  "engines": {
+    "node": ">=24"
+  },
   "appName": "Name Request UI",
   "sbcName": "SBC Common Components",
   "scripts": {

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   sbc-common-components@3.0.15-c:
-    hash: dbxsbs7nnq5sxpyu75cpekwise
+    hash: 04ee617a4ac7ced8e6cfab349eeccdc740e5a5be3543ee92d05d0966a39046be
     path: patches/sbc-common-components@3.0.15-c.patch
 
 importers:
@@ -75,7 +75,7 @@ importers:
         version: 0.4.4
       sbc-common-components:
         specifier: 3.0.15-c
-        version: 3.0.15-c(patch_hash=dbxsbs7nnq5sxpyu75cpekwise)(@types/node@20.19.35)(postcss@8.5.8)(sass@1.59.3)
+        version: 3.0.15-c(patch_hash=04ee617a4ac7ced8e6cfab349eeccdc740e5a5be3543ee92d05d0966a39046be)(@types/node@20.19.35)(postcss@8.5.8)(sass@1.59.3)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -6762,7 +6762,7 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  sbc-common-components@3.0.15-c(patch_hash=dbxsbs7nnq5sxpyu75cpekwise)(@types/node@20.19.35)(postcss@8.5.8)(sass@1.59.3):
+  sbc-common-components@3.0.15-c(patch_hash=04ee617a4ac7ced8e6cfab349eeccdc740e5a5be3543ee92d05d0966a39046be)(@types/node@20.19.35)(postcss@8.5.8)(sass@1.59.3):
     dependencies:
       '@mdi/font': 4.9.95
       axios: 0.21.4

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   sbc-common-components@3.0.15-c:
-    hash: 04ee617a4ac7ced8e6cfab349eeccdc740e5a5be3543ee92d05d0966a39046be
+    hash: dbxsbs7nnq5sxpyu75cpekwise
     path: patches/sbc-common-components@3.0.15-c.patch
 
 importers:
@@ -75,7 +75,7 @@ importers:
         version: 0.4.4
       sbc-common-components:
         specifier: 3.0.15-c
-        version: 3.0.15-c(patch_hash=04ee617a4ac7ced8e6cfab349eeccdc740e5a5be3543ee92d05d0966a39046be)(@types/node@20.19.35)(postcss@8.5.8)(sass@1.59.3)
+        version: 3.0.15-c(patch_hash=dbxsbs7nnq5sxpyu75cpekwise)(@types/node@20.19.35)(postcss@8.5.8)(sass@1.59.3)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -6762,7 +6762,7 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  sbc-common-components@3.0.15-c(patch_hash=04ee617a4ac7ced8e6cfab349eeccdc740e5a5be3543ee92d05d0966a39046be)(@types/node@20.19.35)(postcss@8.5.8)(sass@1.59.3):
+  sbc-common-components@3.0.15-c(patch_hash=dbxsbs7nnq5sxpyu75cpekwise)(@types/node@20.19.35)(postcss@8.5.8)(sass@1.59.3):
     dependencies:
       '@mdi/font': 4.9.95
       axios: 0.21.4


### PR DESCRIPTION
Issue #: https://app.zenhub.com/workspaces/sre-team-board-654d163c6817d80016102d9a/issues/gh/bcgov/entity/32835

Description of changes:
Update engines field in package.json to require Node.js >= 24.
Update GitHub Actions CI/CD workflows to use Node 24.
Align with modern runtime standards and ensure pipeline stability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).